### PR TITLE
Fjerner vilkårtype argument frå VilkårsPerioderTilVurderingTjeneste utled metode.

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/inngangsvilkår/InngangsvilkårFellesTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/inngangsvilkår/InngangsvilkårFellesTjeneste.java
@@ -49,7 +49,7 @@ public class InngangsvilkårFellesTjeneste {
     public NavigableSet<DatoIntervallEntitet> utledPerioderTilVurdering(Long behandlingId, VilkårType vilkårType) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         var tjeneste = getPerioderTilVurderingTjeneste(behandling);
-        var perioderTilVurdering = tjeneste.utled(behandlingId, vilkårType);
+        var perioderTilVurdering = tjeneste.utled(behandlingId);
 
         if (behandling.getOriginalBehandlingId().isPresent()) {
             // Trekk fra periodene som er forlengelse
@@ -68,7 +68,7 @@ public class InngangsvilkårFellesTjeneste {
     public NavigableSet<DatoIntervallEntitet> utledForlengelserTilVurdering(Long behandlingId, VilkårType vilkårType) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         var tjeneste = getPerioderTilVurderingTjeneste(behandling);
-        var perioderTilVurdering = tjeneste.utled(behandlingId, vilkårType);
+        var perioderTilVurdering = tjeneste.utled(behandlingId);
         var forlengelseTjeneste = ForlengelseTjeneste.finnTjeneste(this.forlengelseTjeneste, behandling.getFagsakYtelseType(), behandling.getType());
 
         return forlengelseTjeneste.utledPerioderSomSkalBehandlesSomForlengelse(BehandlingReferanse.fra(behandling), perioderTilVurdering, vilkårType);

--- a/domenetjenester/behandling/src/main/java/no/nav/ung/sak/perioder/FullVilkårsperiodeUtleder.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/ung/sak/perioder/FullVilkårsperiodeUtleder.java
@@ -9,7 +9,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandling.BehandlingReferanse;
 import no.nav.ung.sak.behandlingskontroll.BehandlingTypeRef;
 import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
@@ -39,7 +38,7 @@ public class FullVilkårsperiodeUtleder implements EndretUtbetalingPeriodeutlede
     @Override
     public NavigableSet<DatoIntervallEntitet> utledPerioder(BehandlingReferanse behandlingReferanse) {
         var periodeTjeneste = VilkårsPerioderTilVurderingTjeneste.finnTjeneste(vilkårsPerioderTilVurderingTjenester, behandlingReferanse.getFagsakYtelseType(), behandlingReferanse.getBehandlingType());
-        return periodeTjeneste.utled(behandlingReferanse.getBehandlingId(), VilkårType.BEREGNINGSGRUNNLAGVILKÅR).stream()
+        return periodeTjeneste.utled(behandlingReferanse.getBehandlingId()).stream()
             .flatMap(p -> utledPerioder(behandlingReferanse, p).stream())
             .collect(Collectors.toCollection(TreeSet::new));
     }

--- a/domenetjenester/behandling/src/main/java/no/nav/ung/sak/perioder/VilkårsPerioderTilVurderingTjeneste.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/ung/sak/perioder/VilkårsPerioderTilVurderingTjeneste.java
@@ -34,15 +34,13 @@ public interface VilkårsPerioderTilVurderingTjeneste {
         return null;
     }
 
-    NavigableSet<DatoIntervallEntitet> utled(Long behandlingId, VilkårType vilkårType);
+    NavigableSet<DatoIntervallEntitet> utled(Long behandlingId);
 
     default NavigableSet<DatoIntervallEntitet> utledFraDefinerendeVilkår(Long behandlingId) {
         LocalDateTimeline<Boolean> tidslinje = LocalDateTimeline.empty();
-        for (VilkårType vilkårType : this.definerendeVilkår()) {
-            NavigableSet<DatoIntervallEntitet> perioderForVilkår = this.utled(behandlingId, vilkårType);
-            var perioderSomTidslinje = TidslinjeUtil.tilTidslinjeKomprimert(perioderForVilkår);
-            tidslinje = tidslinje.crossJoin(perioderSomTidslinje, StandardCombinators::alwaysTrueForMatch);
-        }
+        NavigableSet<DatoIntervallEntitet> perioderForVilkår = this.utled(behandlingId);
+        var perioderSomTidslinje = TidslinjeUtil.tilTidslinjeKomprimert(perioderForVilkår);
+        tidslinje = tidslinje.crossJoin(perioderSomTidslinje, StandardCombinators::alwaysTrueForMatch);
         return TidslinjeUtil.tilDatoIntervallEntiteter(tidslinje.compress());
     }
     Map<VilkårType, NavigableSet<DatoIntervallEntitet>> utledRådataTilUtledningAvVilkårsperioder(Long behandlingId);

--- a/domenetjenester/behandling/src/main/java/no/nav/ung/sak/vilkår/VilkårTjeneste.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/ung/sak/vilkår/VilkårTjeneste.java
@@ -289,8 +289,8 @@ public class VilkårTjeneste {
     }
 
     @WithSpan
-    public NavigableSet<DatoIntervallEntitet> utledPerioderTilVurdering(BehandlingReferanse ref, @SpanAttribute("vilkarType") VilkårType vilkårType) {
-        return utledPerioderTilVurderingUfiltrert(ref, vilkårType);
+    public NavigableSet<DatoIntervallEntitet> utledPerioderTilVurdering(BehandlingReferanse ref) {
+        return utledPerioderTilVurderingUfiltrert(ref);
     }
 
     public TreeSet<DatoIntervallEntitet> utledPerioderSomIkkeVurderes(BehandlingReferanse ref, VilkårType vilkårType, Collection<DatoIntervallEntitet> perioderTilVurdering) {
@@ -303,9 +303,9 @@ public class VilkårTjeneste {
                 .noneMatch(tilVurdering -> tilVurdering.inkluderer(vilkårsperiode.getFomDato()))).collect(Collectors.toCollection(TreeSet::new));
     }
 
-    public TreeSet<DatoIntervallEntitet> utledPerioderTilVurderingUfiltrert(BehandlingReferanse ref, VilkårType vilkårType) {
+    public TreeSet<DatoIntervallEntitet> utledPerioderTilVurderingUfiltrert(BehandlingReferanse ref) {
         var perioderTilVurderingTjeneste = getVilkårsPerioderTilVurderingTjeneste(ref.getFagsakYtelseType(), ref.getBehandlingType());
-        var perioder = new TreeSet<>(perioderTilVurderingTjeneste.utled(ref.getBehandlingId(), vilkårType));
+        var perioder = new TreeSet<>(perioderTilVurderingTjeneste.utled(ref.getBehandlingId()));
         var utvidetTilVUrdering = perioderTilVurderingTjeneste.utledUtvidetRevurderingPerioder(ref);
         if (!utvidetTilVUrdering.isEmpty()) {
             perioder.addAll(utvidetTilVUrdering);

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektArbeidYtelse.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektArbeidYtelse.java
@@ -104,7 +104,7 @@ class StartpunktUtlederInntektArbeidYtelse implements EndringStartpunktUtleder {
             diffForFrisinn(ref, grunnlagId1, grunnlagId2, startpunkter, diff, saksnummer);
         } else {
             var perioderTilVurderingTjeneste = VilkårsPerioderTilVurderingTjeneste.finnTjeneste(perioderTilVurderingTjenester, ref.getFagsakYtelseType(), ref.getBehandlingType());
-            var perioderTilVurdering = perioderTilVurderingTjeneste.utled(ref.getBehandlingId(), VilkårType.OPPTJENINGSVILKÅRET);
+            var perioderTilVurdering = perioderTilVurderingTjeneste.utled(ref.getBehandlingId());
 
             for (DatoIntervallEntitet periode : perioderTilVurdering) {
                 var opptjeningsperiode = DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFomDato().minusDays(30), periode.getFomDato());

--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/ekstern/OverlappendeYtelserTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/ekstern/OverlappendeYtelserTjeneste.java
@@ -95,7 +95,7 @@ public class OverlappendeYtelserTjeneste {
 
     private LocalDateTimeline<Boolean> hentBeregningsgrunnlagPerioderTilVurderingTidslinje(BehandlingReferanse ref) {
         var perioderTilVurderingTjeneste = VilkårsPerioderTilVurderingTjeneste.finnTjeneste(perioderTilVurderingTjenester, ref.getFagsakYtelseType(), ref.getBehandlingType());
-        var perioderTilVurdering = perioderTilVurderingTjeneste.utled(ref.getBehandlingId(), VilkårType.BEREGNINGSGRUNNLAGVILKÅR);
+        var perioderTilVurdering = perioderTilVurderingTjeneste.utled(ref.getBehandlingId());
         var periodeSegmenter = perioderTilVurdering.stream().map(it -> new LocalDateSegment<>(it.getFomDato(), it.getTomDato(), true)).toList();
 
         return new LocalDateTimeline<>(periodeSegmenter);

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårRestTjeneste.java
@@ -122,7 +122,7 @@ public class VilkårRestTjeneste {
         Set<VilkårType> aktuelleVilkårTyper = finnAktuelleVilkårTyper(behandling, vilkårene);
         Map<VilkårType, Set<DatoIntervallEntitet>> resultat = new EnumMap<>(VilkårType.class);
         for (VilkårType vilkårType : aktuelleVilkårTyper) {
-            resultat.put(vilkårType, utledPeriodeTilVurdering(behandling, vilkårType));
+            resultat.put(vilkårType, utledPeriodeTilVurdering(behandling));
         }
         return resultat;
     }
@@ -146,8 +146,8 @@ public class VilkårRestTjeneste {
         return vilkårene.getVilkårene().stream().map(Vilkår::getVilkårType).collect(Collectors.toSet());
     }
 
-    private NavigableSet<DatoIntervallEntitet> utledPeriodeTilVurdering(Behandling behandling, VilkårType vilkårType) {
-        return getPerioderTilVurderingTjeneste(behandling).utled(behandling.getId(), vilkårType);
+    private NavigableSet<DatoIntervallEntitet> utledPeriodeTilVurdering(Behandling behandling) {
+        return getPerioderTilVurderingTjeneste(behandling).utled(behandling.getId());
     }
 
     private VilkårsPerioderTilVurderingTjeneste getPerioderTilVurderingTjeneste(Behandling behandling) {

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/vilkår/VilkårForlengelseDump.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/vilkår/VilkårForlengelseDump.java
@@ -73,7 +73,7 @@ public class VilkårForlengelseDump implements DebugDumpBehandling {
         var perioderTilVurderingTjeneste = VilkårsPerioderTilVurderingTjeneste.finnTjeneste(vilkårsPerioderTilVurderingTjeneste, ref.getFagsakYtelseType(), ref.getBehandlingType());
         return vilkårene.getVilkårene().stream().flatMap(v -> {
             var perioder = v.getPerioder().stream().map(VilkårPeriode::getPeriode).collect(Collectors.toCollection(TreeSet::new));
-            var perioderTilVurdering = perioderTilVurderingTjeneste.utled(ref.getBehandlingId(), v.getVilkårType());
+            var perioderTilVurdering = perioderTilVurderingTjeneste.utled(ref.getBehandlingId());
 
             try {
                 var forlengelseperioder = forlengelseTjeneste.utledPerioderSomSkalBehandlesSomForlengelse(ref,

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/kravperioder/PerioderTilBehandlingMedKildeRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/kravperioder/PerioderTilBehandlingMedKildeRestTjeneste.java
@@ -122,13 +122,10 @@ public class PerioderTilBehandlingMedKildeRestTjeneste {
     }
 
     private LocalDateTimeline<Utfall> utledTidslinjeTilVurdering(Behandling behandling, VilkårsPerioderTilVurderingTjeneste perioderTilVurderingTjeneste) {
-        var definerendeVilkår = perioderTilVurderingTjeneste.definerendeVilkår();
-
-        return new LocalDateTimeline<>(definerendeVilkår.stream()
-            .map(it -> perioderTilVurderingTjeneste.utled(behandling.getId(), it))
-            .flatMap(Collection::stream)
-            .map(it -> new LocalDateSegment<>(it.toLocalDateInterval(), Utfall.IKKE_VURDERT))
-            .collect(Collectors.toSet()));
+        final var segmenter = perioderTilVurderingTjeneste.utled(behandling.getId())
+            .stream().map(intervall -> new LocalDateSegment<>(intervall.toLocalDateInterval(), Utfall.IKKE_VURDERT))
+            .collect(Collectors.toSet());
+        return new LocalDateTimeline<>(segmenter);
     }
 
     private List<PeriodeMedUtfall> mapVilkårMedUtfall(Behandling behandling, LocalDateTimeline<Utfall> timelineTilVurdering) {
@@ -154,10 +151,7 @@ public class PerioderTilBehandlingMedKildeRestTjeneste {
         var kravdokumenterMedPeriode = søknadsfristTjeneste.hentPerioderTilVurdering(ref);
         var definerendeVilkår = perioderTilVurderingTjeneste.definerendeVilkår();
 
-        var perioderTilVurdering = definerendeVilkår.stream()
-            .map(it -> perioderTilVurderingTjeneste.utled(ref.getBehandlingId(), it))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toCollection(TreeSet::new));
+        final var perioderTilVurdering = new TreeSet<>(perioderTilVurderingTjeneste.utled(ref.getBehandlingId()));
 
         perioderTilVurdering.addAll(perioderTilVurderingTjeneste.utledUtvidetRevurderingPerioder(ref));
 

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/behandlingsresultat/UngdomsytelseForeslåBehandlingsresultatTjeneste.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/behandlingsresultat/UngdomsytelseForeslåBehandlingsresultatTjeneste.java
@@ -48,7 +48,7 @@ public class UngdomsytelseForeslåBehandlingsresultatTjeneste extends ForeslåBe
         var timeline = new LocalDateTimeline<Boolean>(List.of());
 
         for (VilkårType vilkårType : definerendeVilkår) {
-            timeline = timeline.combine(new LocalDateTimeline<>(vilkårsPerioderTilVurderingTjeneste.utled(behandlingId, vilkårType)
+            timeline = timeline.combine(new LocalDateTimeline<>(vilkårsPerioderTilVurderingTjeneste.utled(behandlingId)
                 .stream()
                 .map(it -> new LocalDateSegment<>(it.getFomDato(), it.getTomDato(), true))
                 .toList()), StandardCombinators::coalesceRightHandSide, LocalDateTimeline.JoinStyle.CROSS_JOIN);

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/beregning/UngdomsytelseBeregningSteg.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/beregning/UngdomsytelseBeregningSteg.java
@@ -57,7 +57,7 @@ public class UngdomsytelseBeregningSteg implements BehandlingSteg {
 
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
-        var perioder = vilkårsPerioderTilVurderingTjeneste.utled(kontekst.getBehandlingId(), VilkårType.UNGDOMSPROGRAMVILKÅRET);
+        var perioder = vilkårsPerioderTilVurderingTjeneste.utled(kontekst.getBehandlingId());
         var samletResultat = vilkårTjeneste.samletVilkårsresultat(kontekst.getBehandlingId());
         var perioderTilVurderingTidslinje = TidslinjeUtil.tilTidslinjeKomprimert(perioder);
         var oppfyltVilkårTidslinje = samletResultat.filterValue(v -> v.getSamletUtfall().equals(Utfall.OPPFYLT));

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/inngangsvilkår/alder/VurderAldersvilkåretSteg.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/inngangsvilkår/alder/VurderAldersvilkåretSteg.java
@@ -58,7 +58,7 @@ public class VurderAldersvilkåretSteg implements BehandlingSteg {
 
         var perioderTilVurderingTjeneste = getPerioderTilVurderingTjeneste(behandling);
 
-        var perioderTilVurdering = perioderTilVurderingTjeneste.utled(behandling.getId(), VilkårType.ALDERSVILKÅR);
+        var perioderTilVurdering = perioderTilVurderingTjeneste.utled(behandling.getId());
         var personopplysningerAggregat = personopplysningTjeneste.hentGjeldendePersoninformasjonPåTidspunkt(behandling.getId(), behandling.getAktørId(), behandling.getFagsak().getPeriode().getFomDato());
         var fødselsdato = personopplysningerAggregat.getSøker().getFødselsdato();
         vurderAldersVilkårTjeneste.vurderPerioder(vilkårBuilder, perioderTilVurdering, fødselsdato);

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/inngangsvilkår/ungdomsprogram/VurderUngdomsprogramVilkårSteg.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/inngangsvilkår/ungdomsprogram/VurderUngdomsprogramVilkårSteg.java
@@ -64,7 +64,7 @@ public class VurderUngdomsprogramVilkårSteg implements BehandlingSteg {
         var vilkårene = vilkårResultatRepository.hent(kontekst.getBehandlingId());
         var resultatBuilder = Vilkårene.builderFraEksisterende(vilkårene);
         var vilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.UNGDOMSPROGRAMVILKÅRET);
-        var perioderTilVurdering = vilkårsPerioderTilVurderingTjeneste.utled(behandling.getId(), VilkårType.UNGDOMSPROGRAMVILKÅRET);
+        var perioderTilVurdering = vilkårsPerioderTilVurderingTjeneste.utled(behandling.getId());
         var ungdomsprogramTidslinje = ungdomsprogramPeriodeTjeneste.finnPeriodeTidslinje(behandling.getId());
         var builders = vurderPerioder(ungdomsprogramTidslinje, perioderTilVurdering, vilkårBuilder);
         builders.forEach(vilkårBuilder::leggTil);

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/periode/UngdomsytelseVilkårsperioderTilVurderingTjeneste.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/periode/UngdomsytelseVilkårsperioderTilVurderingTjeneste.java
@@ -56,7 +56,7 @@ public class UngdomsytelseVilkårsperioderTilVurderingTjeneste implements Vilkå
     }
 
     @Override
-    public NavigableSet<DatoIntervallEntitet> utled(Long behandlingId, VilkårType vilkårType) {
+    public NavigableSet<DatoIntervallEntitet> utled(Long behandlingId) {
         return utledPeriode(behandlingId);
     }
 


### PR DESCRIPTION
**Bakgrunn**: i UngdomsytelseVilkårsperioderTilVurderingTjeneste som er einaste implementasjon av VilkårsPerioderTilVurderingTjeneste (pr no), er vilkårtype argument ikkje brukt.

**Resultat**:
Forenkler kodebasen litt ved å fjerne argumentet frå interface, og all kode som kaller metoden.