### PR TITLE
Fikser dødshendelse og revurdering av sak ved barns død

### DIFF
--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/beregning/barnetillegg/LagBarnetilleggTidslinje.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/beregning/barnetillegg/LagBarnetilleggTidslinje.java
@@ -63,7 +63,10 @@ public class LagBarnetilleggTidslinje {
 
     static BarnetilleggVurdering beregnBarnetillegg(LocalDateTimeline<Boolean> perioder, List<FødselOgDødInfo> relevantPersonInfoBarn) {
         var antallBarnGrunnlagTidslinje = relevantPersonInfoBarn.stream()
-            .map(info -> new LocalDateTimeline<>(info.fødselsdato().plusMonths(1).withDayOfMonth(1), getTilDato(info), 1))
+            .map(info -> {
+                boolean barnILive = info.dødsdato() == null;
+                return new LocalDateTimeline<>(info.fødselsdato().plusDays(1), getTilDato(info), barnILive ? 1 : 0);
+            })
             .reduce((t1, t2) -> t1.crossJoin(t2, StandardCombinators::sum))
             .orElse(LocalDateTimeline.empty());
 
@@ -79,7 +82,7 @@ public class LagBarnetilleggTidslinje {
 
 
     private static LocalDate getTilDato(FødselOgDødInfo info) {
-        return info.dødsdato() != null ? info.dødsdato().plusMonths(1).with(TemporalAdjusters.lastDayOfMonth()) : TIDENES_ENDE;
+        return info.dødsdato() != null ? info.dødsdato().plusDays(1) : TIDENES_ENDE;
     }
 
     private FødselOgDødInfo finnRelevantPersonInfo(AktørId barnAktørId) {

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/hendelsemottak/FinnFagsakerForAktørTjeneste.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/hendelsemottak/FinnFagsakerForAktørTjeneste.java
@@ -34,8 +34,8 @@ public class FinnFagsakerForAktørTjeneste {
                     "inner join BEHANDLING b on gr.behandling_id = b.id " +
                     "inner join FAGSAK f on b.fagsak_id = f.id " +
                     "WHERE f.ytelse_type != 'OBSOLETE'" +
-                    "and relasjonsrolle = :relasjonsrolle " +
-                    "and til_aktoer_id = :aktoer_id " +
+                    "and relasjon.relasjonsrolle = :relasjonsrolle " +
+                    "and relasjon.til_aktoer_id = :aktoer_id " +
                     "and f.periode && daterange(cast(:dato as date), cast(:dato as date), '[]') = true", //$NON-NLS-1$
                 Fagsak.class)
             .setParameter("relasjonsrolle", RelasjonsRolleType.BARN.getKode())

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/hendelsemottak/FinnFagsakerForAktørTjeneste.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/hendelsemottak/FinnFagsakerForAktørTjeneste.java
@@ -28,15 +28,18 @@ public class FinnFagsakerForAktørTjeneste {
 
     public List<Fagsak> hentRelevantFagsakForAktørSomBarnAvSøker(AktørId aktørId, LocalDate relevantDato) {
         Query query = entityManager.createNativeQuery(
-                "SELECT f FROM GR_PERSONOPPLYSNING gr " +
+                "SELECT f.* FROM GR_PERSONOPPLYSNING gr " +
                     "inner join PO_INFORMASJON informasjon on informasjon.id = gr.registrert_informasjon_id " +
                     "inner join PO_RELASJON relasjon on relasjon.po_informasjon_id = informasjon.id " +
                     "inner join BEHANDLING b on gr.behandling_id = b.id " +
                     "inner join FAGSAK f on b.fagsak_id = f.id " +
-                    "WHERE relasjonsrolle = :relasjonsrolle and til_aktoer_id = :aktoer_id and f.periode && daterange(cast(:dato as date), cast(:dato as date), '[]') = true", //$NON-NLS-1$
+                    "WHERE f.ytelse_type != 'OBSOLETE'" +
+                    "and relasjonsrolle = :relasjonsrolle " +
+                    "and til_aktoer_id = :aktoer_id " +
+                    "and f.periode && daterange(cast(:dato as date), cast(:dato as date), '[]') = true", //$NON-NLS-1$
                 Fagsak.class)
             .setParameter("relasjonsrolle", RelasjonsRolleType.BARN.getKode())
-            .setParameter("til_aktoer_id", aktørId.getId())
+            .setParameter("aktoer_id", aktørId.getId())
             .setParameter("dato", relevantDato); // NOSONAR //$NON-NLS-1$
         return query.getResultList();
     }

--- a/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/hendelsemottak/PdlDødsfallFagsakTilVurderingUtleder.java
+++ b/ytelse-ung/src/main/java/no/nav/ung/sak/ytelse/ung/hendelsemottak/PdlDødsfallFagsakTilVurderingUtleder.java
@@ -87,8 +87,8 @@ public class PdlDødsfallFagsakTilVurderingUtleder implements FagsakerTilVurderi
             finnFagsakerForAktørTjeneste.hentRelevantFagsakForAktørSomBarnAvSøker(aktør, aktuellDato)
                 .stream()
                 .filter(f -> deltarIProgramPåHendelsedato(f, aktuellDato, hendelseId))
-                .filter(f -> erNyInformasjonIHendelsen(fagsakForAktør.get(), aktør, aktuellDato, hendelseId))
-                .forEach(f -> fagsakÅrsakMap.put(f, BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER));
+                .filter(f -> erNyInformasjonIHendelsen(f, aktør, aktuellDato, hendelseId))
+                .forEach(f -> fagsakÅrsakMap.put(f, BehandlingÅrsakType.RE_HENDELSE_DØD_BARN));
         }
 
         return fagsakÅrsakMap;

--- a/ytelse-ung/src/test/java/no/nav/ung/sak/ytelse/ung/beregning/barnetillegg/LagBarnetilleggTidslinjeTest.java
+++ b/ytelse-ung/src/test/java/no/nav/ung/sak/ytelse/ung/beregning/barnetillegg/LagBarnetilleggTidslinjeTest.java
@@ -36,14 +36,16 @@ class LagBarnetilleggTidslinjeTest {
         var resultat = LagBarnetilleggTidslinje.beregnBarnetillegg(relevantTidslinje, fødselOgDødInfos);
 
         var forventetResultat = new LocalDateTimeline<>(List.of(
-            new LocalDateSegment<>(LocalDate.of(2020, 2, 1), LocalDate.of(2020, 2, 29), new Barnetillegg(108, 3)),
-            new LocalDateSegment<>(LocalDate.of(2020, 3, 1), LocalDate.of(2020, 3, 15), new Barnetillegg(36, 1))));
+            new LocalDateSegment<>(LocalDate.of(2020, 1, 2), LocalDate.of(2020, 1, 15), new Barnetillegg(0, 0)),
+            new LocalDateSegment<>(LocalDate.of(2020, 1, 16), LocalDate.of(2020, 1, 16), new Barnetillegg(0, 0)),
+            new LocalDateSegment<>(LocalDate.of(2020, 1, 18), LocalDate.of(2020, 3, 15), new Barnetillegg(36, 1))
+        ));
 
         assertThat(resultat.barnetilleggTidslinje()).isEqualTo(forventetResultat);
     }
 
     @Test
-    void skal_få_barnetillegg_for_barn_som_er_født_og_dør_samme_dag() {
+    void skal_ikke_få_barnetillegg_for_barn_som_er_født_og_dør_samme_dag() {
         var fødselsdato1 = LocalDate.of(2020,1,1);
         var dødsdato1 = LocalDate.of(2020,1,1);
 
@@ -60,13 +62,13 @@ class LagBarnetilleggTidslinjeTest {
         var resultat = LagBarnetilleggTidslinje.beregnBarnetillegg(relevantTidslinje, fødselOgDødInfos);
 
         var forventetResultat = new LocalDateTimeline<>(List.of(
-            new LocalDateSegment<>(LocalDate.of(2020, 2, 1), LocalDate.of(2020, 2, 29), new Barnetillegg(36, 1))));
+            new LocalDateSegment<>(LocalDate.of(2020, 1, 2), LocalDate.of(2020, 1, 2), new Barnetillegg(0, 0))));
 
         assertThat(resultat.barnetilleggTidslinje()).isEqualTo(forventetResultat);
     }
 
     @Test
-    void skal_få_barnetillegg_for_barn_som_er_født_og_dør_siste_dag_i_måneden() {
+    void skal_ikke_få_barnetillegg_for_barn_som_er_født_og_dør_siste_dag_i_måneden() {
         var fødselsdato1 = LocalDate.of(2020,2,29);
         var dødsdato1 = LocalDate.of(2020,2,29);
 
@@ -83,7 +85,7 @@ class LagBarnetilleggTidslinjeTest {
         var resultat = LagBarnetilleggTidslinje.beregnBarnetillegg(relevantTidslinje, fødselOgDødInfos);
 
         var forventetResultat = new LocalDateTimeline<>(List.of(
-            new LocalDateSegment<>(LocalDate.of(2020, 3, 1), LocalDate.of(2020, 3, 15), new Barnetillegg(36, 1))));
+            new LocalDateSegment<>(LocalDate.of(2020, 3, 1), LocalDate.of(2020, 3, 1), new Barnetillegg(0, 0))));
 
         assertThat(resultat.barnetilleggTidslinje()).isEqualTo(forventetResultat);
     }


### PR DESCRIPTION
Ved mottatt dødshendelse gjøres det en revurdering av saken, og reduserer barnetillegget ned fra neste dag etter dødsdato.

- Fikser sql spørring for `hentRelevantFagsakForAktørSomBarnAvSøker`.