### PR TITLE
Hindre out of memory ved brevgenerering ved å begrense antallet samtidige genereringer

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/BrevGenereringSemafor.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/BrevGenereringSemafor.java
@@ -1,0 +1,40 @@
+package no.nav.ung.sak.formidling;
+
+import no.nav.k9.felles.konfigurasjon.env.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
+
+public class BrevGenereringSemafor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BrevGenereringSemafor.class);
+
+    private static final Integer MAX_SAMTIDIGE = Environment.current().getProperty("BREVGENERERING_MAX_ANTALL_SAMTIDIGE", Integer.class, 2);
+    private static final Semaphore SEMAFOR = new Semaphore(MAX_SAMTIDIGE);
+
+    private BrevGenereringSemafor() {
+    }
+
+    public static <T> T begrensetParallellitet(Supplier<T> supplier) {
+        try {
+            long t0 = System.nanoTime();
+            SEMAFOR.acquire();
+            long t1 = System.nanoTime();
+            long ventetidMillis = (t1 - t0) / 1_000_000;
+            if (ventetidMillis > 2000) {
+                LOG.warn("Ventet i {} ms på å få semafor for brevbestilling, skjer dette ofte bør semaforens antall og nodens minne økes for bedre ytelse", ventetidMillis);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            return supplier.get();
+        } finally {
+            SEMAFOR.release();
+        }
+
+    }
+
+}

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/formidling/FormidlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/formidling/FormidlingRestTjeneste.java
@@ -4,9 +4,7 @@ import static no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionAttributt.RE
 import static no.nav.ung.abac.BeskyttetRessursKoder.FAGSAK;
 
 import java.util.Objects;
-import java.util.concurrent.Semaphore;
 
-import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +53,6 @@ public class FormidlingRestTjeneste {
     private static final Logger LOG = LoggerFactory.getLogger(FormidlingRestTjeneste.class);
     private static final String PDF_MEDIA_STRING = "application/pdf";
     private static final MediaType PDF_MEDIA_TYPE = MediaType.valueOf(PDF_MEDIA_STRING);
-
-    private static final int MAX_ANTALL_SAMTIDIGE_FORHÅNDSVISNINGER = 2; //kan justeres sammen med minne for applikasjonen
-    private static final Semaphore SEMAFOR_SAMTIDIGE_FORHÅNDSVISNINGER = new Semaphore(MAX_ANTALL_SAMTIDIGE_FORHÅNDSVISNINGER);
 
     @Inject
     public FormidlingRestTjeneste(
@@ -114,20 +109,8 @@ public class FormidlingRestTjeneste {
     public Response forhåndsvisVedtaksbrev(
         @NotNull @Parameter(description = "") @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) VedtaksbrevForhåndsvisDto dto,
         @Context HttpServletRequest request
-    ) throws InterruptedException {
-        // Semafor her for å begrense hvor mange samtidige forhåndsvisninger som kjøres for å unngå OutOfMemoryError.
-        // Operasjonen både bruker noe tid, og mye minne, så uten begrensning er det er fullt mulig å knele applikasjonen
-        // ved å forhåndsvise flere ganger på kort tid.
-        SEMAFOR_SAMTIDIGE_FORHÅNDSVISNINGER.acquire();
-        try {
-            return doForhåndsvisVedtaksbrev(dto, request);
-        } finally {
-            SEMAFOR_SAMTIDIGE_FORHÅNDSVISNINGER.release();
-        }
-    }
+    ) {
 
-    @WithSpan //span her for å kunne skille venting på semafor fra resten
-    private Response doForhåndsvisVedtaksbrev(VedtaksbrevForhåndsvisDto dto, HttpServletRequest request) {
         GenerertBrev generertBrev = brevGenerererTjeneste.genererVedtaksbrev(dto.behandlingId());
 
         var mediaTypeReq = Objects.requireNonNullElse(request.getHeader(HttpHeaders.ACCEPT), MediaType.APPLICATION_OCTET_STREAM);
@@ -141,7 +124,6 @@ public class FormidlingRestTjeneste {
 
         };
     }
-
 
 }
 


### PR DESCRIPTION
Endring: 
* Flytter semafor til mer sentralt sted for å også plukke med brevgenerering fra prosesstasker.
* konfigurerbar grense
