### PR TITLE
Fiks ObjectMapperResolver caching, swagger X-Json-Serializer-Option select

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>no.nav.openapi.spec.utils</groupId>
             <artifactId>openapi-spec-utils</artifactId>
-            <version>1.0.0-beta</version>
+            <version>1.2.0</version>
         </dependency>
 
         <!-- CDI -->

--- a/web/src/main/java/no/nav/ung/sak/web/app/ApplicationConfig.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/ApplicationConfig.java
@@ -40,6 +40,7 @@ public class ApplicationConfig extends ResourceConfig {
     }
 
     public ApplicationConfig() {
+        register(DynamicJacksonJsonProvider.class); // Denne må registrerast før anna OpenAPI oppsett for å fungere.
         final var resolvedOpenAPI = resolveOpenAPI();
         register(new no.nav.openapi.spec.utils.openapi.OpenApiResource(resolvedOpenAPI));
 
@@ -48,7 +49,6 @@ public class ApplicationConfig extends ResourceConfig {
         registerClasses(new LinkedHashSet<>(new RestImplementationClasses().getImplementationClasses()));
 
         register(ObjectMapperResolver.class);
-        register(DynamicJacksonJsonProvider.class);
 
         registerInstances(new LinkedHashSet<>(new KnownExceptionMappers().getExceptionMappers()));
         register(CacheControlFeature.class);

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -6657,7 +6657,7 @@
     },
     "/api/formidling/vedtaksbrev/forhaandsvis" : {
       "post" : {
-        "description" : "Forhåndsvise vedtaksbrev for en behandling",
+        "description" : "Forhåndsvise vedtaksbrev for en behandling. Bruk application/octet-stream fra swagger for å laste ned pdf ",
         "operationId" : "forhåndsvisVedtaksbrev",
         "requestBody" : {
           "content" : {

--- a/web/src/main/resources/web/swagger/local-swagger.js
+++ b/web/src/main/resources/web/swagger/local-swagger.js
@@ -1,3 +1,49 @@
+const defaultValue = "default";
+const optionValues = [defaultValue, "openapi-compat", "kodeverdi-string", "kodeverdi-kalkulus-string"]
+
+// JsonSerializerOptionPlugin adds a select input for choosing a value for the X-Json-Serializer-Option header value to be used for subsequent requests
+// from the swagger ui, and state to keep the selected value.
+const JsonSerializerOptionPlugin = () => {
+    return {
+        statePlugins: {
+            jsonSerializerOption: {
+                actions: {
+                    updateJsonSerializerOption: (option) => {
+                        return {
+                            type: "UPDATE_JSON_SERIALIZER_OPTION",
+                            payload: option,
+                        }
+                    }
+                },
+                reducers: {
+                    "UPDATE_JSON_SERIALIZER_OPTION": (state, action) => {
+                        return state.set("xJsonSerializerOption", action.payload)
+                    }
+                },
+                selectors: {
+                    xJsonSerializerOption: (state) => state.get("xJsonSerializerOption")
+                },
+            }
+        },
+        wrapComponents: {
+            ServersContainer: (Original, system) => props => {
+                const React = system.React;
+                const options = optionValues.map(opt => React.createElement("option", {value: opt}, `${opt}`))
+                const selectId = "JsonSerializerOptionSelect"
+                const onChange = (ev) => {
+                    system.jsonSerializerOptionActions.updateJsonSerializerOption(ev.target.value);
+                }
+                const select = React.createElement("select", {id: selectId, onChange}, ...options)
+                const label = React.createElement("label", {for: selectId, style: {display: "block", marginBottom: "0", paddingTop: "4px"}}, "X-Json-Serializer-Option")
+                const original = React.createElement(Original, props)
+                const div = React.createElement("div", null, label, select)
+                return [original, div]
+            }
+        }
+    }
+}
+
+
 window.onload = function() {
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
@@ -9,9 +55,22 @@ window.onload = function() {
       SwaggerUIStandalonePreset
     ],
     plugins: [
+      JsonSerializerOptionPlugin,
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    // requestInterceptor adds chosen X-Json-Serializer-Option header value to all requests, if it has been changed from default (undefined).
+    requestInterceptor: (req) => {
+        // On first request after load (to get openapi.yaml), this.ui is null.
+        // serializerOptionVal would always be undefined (default value) anyway at that point, so doesn't matter.
+        if(this.ui != null) {
+            const serializerOptionVal = this.ui.jsonSerializerOptionSelectors.xJsonSerializerOption()
+            if(serializerOptionVal != null && serializerOptionVal !== defaultValue) {
+                req.headers["X-Json-Serializer-Option"] = serializerOptionVal
+            }
+        }
+        return req
+    }
   });
   // End Swagger UI call region
 


### PR DESCRIPTION
**Bakgrunn**
- Tidlegare fiksa ObjectMapper caching bug hadde gjenoppstått.
- Ønske om å kunne velge kva ObjectMapper som brukast frå swagger. Slik at ein enklare kan kopiere ut testdata etc kompatibelt med openapi genererte typer.

**Endring**
- Fikser caching bug ved å flytte registrering av konfigurasjonsklasse til tidleg nok i applikasjonsoppsett.
- Legger til select input for X-Json-Serializer-Option header i swagger-ui.
<img width="442" alt="Skjermbilde 2025-02-24 kl  10 51 26" src="https://github.com/user-attachments/assets/81ebccd6-76bc-4fdc-9968-0b044bccda4b" />
