### PR TITLE
Støtte ungdomsytelse i simulering, bruker FRISINN isdf UNG i dev mot oppdrag

### DIFF
--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/ProsessModell.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/ProsessModell.java
@@ -29,6 +29,7 @@ public class ProsessModell {
             .medSteg(BehandlingStegType.UNGDOMSYTELSE_BEREGNING, StartpunktType.BEREGNING)
             .medSteg(BehandlingStegType.VURDER_UTTAK)
             .medSteg(BehandlingStegType.BEREGN_YTELSE)
+            .medSteg(BehandlingStegType.SIMULER_OPPDRAG)
             .medSteg(BehandlingStegType.FORESLÅ_VEDTAK)
             .medSteg(BehandlingStegType.FATTE_VEDTAK)
             .medSteg(BehandlingStegType.IVERKSETT_VEDTAK);
@@ -53,6 +54,7 @@ public class ProsessModell {
             .medSteg(BehandlingStegType.UNGDOMSYTELSE_BEREGNING, StartpunktType.BEREGNING)
             .medSteg(BehandlingStegType.VURDER_UTTAK)
             .medSteg(BehandlingStegType.BEREGN_YTELSE)
+            .medSteg(BehandlingStegType.SIMULER_OPPDRAG)
             .medSteg(BehandlingStegType.FORESLÅ_VEDTAK)
             .medSteg(BehandlingStegType.FATTE_VEDTAK)
             .medSteg(BehandlingStegType.IVERKSETT_VEDTAK);

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/tilkjentytelse/MapperForTilkjentYtelse.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/tilkjentytelse/MapperForTilkjentYtelse.java
@@ -1,20 +1,20 @@
 package no.nav.ung.sak.økonomi.tilkjentytelse;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.konfigurasjon.env.Environment;
 import no.nav.k9.oppdrag.kontrakt.kodeverk.Inntektskategori;
 import no.nav.k9.oppdrag.kontrakt.kodeverk.SatsType;
 import no.nav.k9.oppdrag.kontrakt.tilkjentytelse.TilkjentYtelseAndelV1;
 import no.nav.k9.oppdrag.kontrakt.tilkjentytelse.TilkjentYtelsePeriodeV1;
 import no.nav.ung.sak.ytelse.DagsatsOgUtbetalingsgrad;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class MapperForTilkjentYtelse {
 
@@ -36,8 +36,15 @@ public class MapperForTilkjentYtelse {
             logger.info("Periode {}-{} hadde ingen beløp over 0 og ble ignorert", periode.getFom(), periode.getTom());
             return null;
         }
+        Inntektskategori inntektskategori = Inntektskategori.ARBEIDSTAKER_UTEN_FERIEPENGER;
+        if (Environment.current().isDev()){
+            //midlertidig mapping i dev for å kunne teste simulering
+            //FIXME fjern
+            inntektskategori = Inntektskategori.FRILANSER;
+        }
+
         return new TilkjentYtelsePeriodeV1(periode.getFom(), periode.getTom(), List.of(
-            new TilkjentYtelseAndelV1(true, Inntektskategori.ARBEIDSTAKER_UTEN_FERIEPENGER, periode.getValue().dagsats(), SatsType.DAG, periode.getValue().utbetalingsgrad())));
+            new TilkjentYtelseAndelV1(true, inntektskategori, periode.getValue().dagsats(), SatsType.DAG, periode.getValue().utbetalingsgrad())));
     }
 
 }

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/tilkjentytelse/MapperForYtelseType.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/tilkjentytelse/MapperForYtelseType.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import no.nav.k9.felles.konfigurasjon.env.Environment;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.k9.oppdrag.kontrakt.kodeverk.YtelseType;
 
@@ -33,6 +34,12 @@ class MapperForYtelseType {
                 throw new IllegalStateException("Kan ikke opprette mapping fra " + FagsakYtelseType.class.getName() + "." + egenKode.name() + " til " + YtelseType.class.getName()
                     + " siden det ikke finnes tilsvarende i " + YtelseType.class.getName());
             }
+        }
+
+        if (Environment.current().isDev()){
+            //FIXME fjern
+            //midlertidig mapping i dev for å kunne teste simulering
+            map.put(FagsakYtelseType.UNGDOMSYTELSE, YtelseType.FRISINN);
         }
         return map;
     }


### PR DESCRIPTION
### **Behov / Bakgrunn**

Simulering mot oppdrag skal være del av løsningen, men kan ikke skrus på 100% i dev/prod p.t. siden bakenforliggende system ikke er klart. 

### **Løsning**

Legge til simulering-steg

Bytter til å bruke koder for FRISINN mot oppdrag isdf egne koder for UNG, for å kunne teste simulering i dev

### **Andre endringer**

En konsekvens er at månedlig oversending ikke kan testes, siden FRISINN oversendes med alle perioder fra k9-oppdrag

### **Skjermbilder** (hvis relevant)
