### PR TITLE
Utvidet mapping for aksjonspunkttyper mot sif-abac-pdp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
             <dependency>
                 <groupId>no.nav.sif.abac</groupId>
                 <artifactId>kontrakt</artifactId>
-                <version>1.0.4</version>
+                <version>1.0.5</version>
             </dependency>
 
             <dependency>

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/PdpRequestMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/PdpRequestMapper.java
@@ -9,6 +9,9 @@ import no.nav.sif.abac.kontrakt.person.AktørId;
 import no.nav.sif.abac.kontrakt.person.PersonIdent;
 
 import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
 public class PdpRequestMapper {
 
@@ -35,7 +38,17 @@ public class PdpRequestMapper {
             Arrays.stream(AbacFagsakStatus.values())
                 .filter(v -> v.getEksternKode().equals(pdpRequest.getString(AbacAttributter.RESOURCE_SAKSSTATUS)))
                 .findFirst().orElse(null),
-            aksjonspunktTypeFraKode(pdpRequest.getString(AbacAttributter.RESOURCE_AKSJONSPUNKT_TYPE)));
+            null,
+            aksjonspunktTyperFraKoder(pdpRequest.getListOfString(AbacAttributter.RESOURCE_AKSJONSPUNKT_TYPE)));
+    }
+
+    private static Set<AksjonspunktType> aksjonspunktTyperFraKoder(List<String> koder) {
+        Set<AksjonspunktType> resultat = EnumSet.noneOf(AksjonspunktType.class);
+        for (String kode : koder) {
+            resultat.add(aksjonspunktTypeFraKode(kode));
+        }
+        return resultat;
+
     }
 
     private static AksjonspunktType aksjonspunktTypeFraKode(String kode) {


### PR DESCRIPTION
### **Behov / Bakgrunn**

Det er teknisk mulig å løse flere aksjonspunkter i samme REST-kall mot ung-sak og k9-sak. Denne endringen understøtter denne muligheten.

### **Løsning**

Utvidet kontrakt fra sif-abac-pdp og tar i bruk denne

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
