### PR TITLE
Endringsbrev inntekt forbedringer

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/EndringRapportertInntektDto.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/EndringRapportertInntektDto.java
@@ -6,10 +6,7 @@ public record EndringRapportertInntektDto(
     PeriodeDto periode,
     long rapportertInntekt,
     long utbetalingBeløp,
-    int reduksjonssats,
-    long reduksjonBeløp,
-    long dagsats,
-    long redusertDagsats
+    int reduksjonssats
 
 ) implements TemplateInnholdDto  {
 }

--- a/formidling/src/main/resources/pdfgen/templates/felles/footer/footer.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/felles/footer/footer.hbs
@@ -1,5 +1,5 @@
 <h2>Trenger du mer informasjon? </h2>
-<p>Du finner mer informasjon på <a title="omsorgspenger" href="https://nav.no/ungdomsytelse">nav.no/ungdomsytelse</a>.
+<p>Du finner mer informasjon på <a title="ungdomsytelse" href="https://nav.no/ungdomsytelse">nav.no/ungdomsytelse</a>.
 </p>
 
 <p>På <a href="https://nav.no/kontakt">nav.no/kontakt</a> kan du chatte eller skrive til oss. </p>

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_høy_sats.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_høy_sats.hbs
@@ -1,7 +1,7 @@
 {{#> felles/base}}
 
     {{#> felles/seksjon/hoved }}
-        <h1>Nav har endret din ungdomsytelse</h1>
+        <h1>Vi har endret ungdomsytelsen din</h1>
         <p>
             Fra {{fom}} får du ny dagsats på {{> felles/beløp nyDagsats}} fordi du fyller {{aldersgrense}} år.
         </p>

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_høy_sats.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_høy_sats.hbs
@@ -6,7 +6,7 @@
             Fra {{fom}} får du ny dagsats på {{> felles/beløp nyDagsats}} fordi du fyller {{aldersgrense}} år.
         </p>
         <p>Nav utbetaler {{satsFaktor}} ganger grunnbeløp fra deltager er {{aldersgrense}} år. </p>
-        <p>Vedtaket er gjort etter folketrygdloven § X-Y.</p>
+        <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
     {{/felles/seksjon/hoved}}
 
     {{> felles/footer/footer-vedtak }}

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
@@ -4,14 +4,19 @@
     {{#> felles/seksjon/hoved }}
         <h1>Vi har endret ungdomsytelsen din</h1>
         <p>
-            Du har meldt inn inntekt på {{> felles/beløp rapportertInntekt}} {{> felles/periode-inline periode}}.
-            Nav har derfor redusert utbetalingen din for neste perioden
-            til {{> felles/beløp utbetalingBeløp}}.
+            Du får {{> felles/beløp utbetalingBeløp}} i ungdomsytelse for perioden {{> felles/periode-inline periode}}.
+            Det er fordi du har hatt en inntekt på {{> felles/beløp rapportertInntekt}} i denne perioden.
         </p>
-        <p>Nav reduserer utbetalt beløp med {{reduksjonssats}} prosent av innmeldt inntekt. Dette tilsvarer en
-            reduksjon på {{> felles/beløp reduksjonBeløp}}. Dagsatsen blir redusert fra {{> felles/beløp dagsats}}
-            til {{> felles/beløp redusertDagsats}}. </p>
-        <p></p>
+        <p>Pengene får du ubetalt før den 10. denne måneden. </p>
+        <p>
+            Når du har en inntekt, får du mindre penger i ungdomsytelse. Vi regner ut hva {{reduksjonssats}} prosent av inntekten din er hver måned, og så trekker vi dette beløpet fra pengene du får i ungdomsytelsen for den måneden.
+        </p>
+        <p>
+            Likevel får du til sammen <i>mer</i> penger når du både har en inntekt og får ungdomsytelse, enn hvis du bare hadde fått penger gjennom ungdomsytelsen.
+        </p>
+        <p>
+            Se <a title="utregningseksempler" href="https://nav.no/ungdomsportal/beregning">eksempel</a> på hvordan vi regner ut ungdomsytelsen basert på inntekt i Ungdomsportalen.
+        </p>
         <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
     {{/felles/seksjon/hoved}}
 

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
@@ -12,7 +12,7 @@
             reduksjon på {{> felles/beløp reduksjonBeløp}}. Dagsatsen blir redusert fra {{> felles/beløp dagsats}}
             til {{> felles/beløp redusertDagsats}}. </p>
         <p></p>
-        <p>Vedtaket er gjort etter folketrygdloven § X-Y.</p>
+        <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
     {{/felles/seksjon/hoved}}
 
     {{> felles/footer/footer-vedtak }}

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
@@ -2,7 +2,7 @@
 
 
     {{#> felles/seksjon/hoved }}
-        <h1>Nav har endret din ungdomsytelse</h1>
+        <h1>Vi har endret ungdomsytelsen din</h1>
         <p>
             Du har meldt inn inntekt på {{> felles/beløp rapportertInntekt}} {{> felles/periode-inline periode}}.
             Nav har derfor redusert utbetalingen din for neste perioden

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_inntekt.hbs
@@ -18,6 +18,7 @@
             Se <a title="utregningseksempler" href="https://nav.no/ungdomsportal/beregning">eksempel</a> på hvordan vi regner ut ungdomsytelsen basert på inntekt i Ungdomsportalen.
         </p>
         <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
+
     {{/felles/seksjon/hoved}}
 
     {{> felles/footer/footer-vedtak }}

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/innvilgelse.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/innvilgelse.hbs
@@ -76,7 +76,7 @@
             <a href="https://nav.no/ungdomsytelse">nav.no/ungdomsytelse</a>
         </p>
 
-        <p>Vedtaket er gjort etter folketrygdloven § X-Y.</p>
+        <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
 
     {{/felles/seksjon/hoved}}
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
@@ -132,7 +132,7 @@ class BrevGenerererTjenesteEndringHøySatsTest {
         var brevtekst = generertBrev.dokument().html();
 
         assertThatHtml(brevtekst).containsHtmlOnceInSequence(
-            "<h1>Nav har endret din ungdomsytelse</h1>"
+            "<h1>Vi har endret ungdomsytelsen din</h1>"
         ).containsSentencesOnceInSequence(
             "Fra 25. mars 2024 får du ny dagsats på 954 kroner fordi du fyller 25 år.",
             "Nav utbetaler 2 ganger grunnbeløp fra deltager er 25 år.",
@@ -164,7 +164,7 @@ class BrevGenerererTjenesteEndringHøySatsTest {
             assertThat(pdDocument.getNumberOfPages()).isEqualTo(1);
             String pdfTekst = new PDFTextStripper().getText(pdDocument);
             assertThat(pdfTekst).isNotEmpty();
-            assertThat(pdfTekst).contains("Nav har endret din ungdomsytelse");
+            assertThat(pdfTekst).contains("Vi har endret ungdomsytelsen din");
         }
 
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
@@ -136,7 +136,7 @@ class BrevGenerererTjenesteEndringHøySatsTest {
         ).containsSentencesOnceInSequence(
             "Fra 25. mars 2024 får du ny dagsats på 954 kroner fordi du fyller 25 år.",
             "Nav utbetaler 2 ganger grunnbeløp fra deltager er 25 år.",
-            "Vedtaket er gjort etter folketrygdloven § X-Y."
+            "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx."
         );
 
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
@@ -131,9 +131,9 @@ class BrevGenerererTjenesteEndringHøySatsTest {
 
         var brevtekst = generertBrev.dokument().html();
 
-        assertThatHtml(brevtekst).containsHtmlOnceInSequence(
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
             "<h1>Vi har endret ungdomsytelsen din</h1>"
-        ).containsSentencesOnceInSequence(
+        ).containsSentenceSubSequenceOnce(
             "Fra 25. mars 2024 får du ny dagsats på 954 kroner fordi du fyller 25 år.",
             "Nav utbetaler 2 ganger grunnbeløp fra deltager er 25 år.",
             "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx."

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
@@ -145,7 +145,7 @@ class BrevGenerererTjenesteEndringInntektTest {
         var brevtekst = generertBrev.dokument().html();
 
         assertThatHtml(brevtekst).containsHtmlOnceInSequence(
-            "<h1>Nav har endret din ungdomsytelse</h1>"
+            "<h1>Vi har endret ungdomsytelsen din</h1>"
         ).containsSentencesOnceInSequence(
             "Du har meldt inn inntekt på 10 000 kroner fra 1. desember 2024 til 31. desember 2024.",
             "Nav har derfor redusert utbetalingen din for neste perioden til 7 393 kroner.",
@@ -175,7 +175,7 @@ class BrevGenerererTjenesteEndringInntektTest {
             assertThat(pdDocument.getNumberOfPages()).isEqualTo(1);
             String pdfTekst = new PDFTextStripper().getText(pdDocument);
             assertThat(pdfTekst).isNotEmpty();
-            assertThat(pdfTekst).contains("Nav har endret din ungdomsytelse");
+            assertThat(pdfTekst).contains("Vi har endret ungdomsytelsen din");
         }
 
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
@@ -144,17 +144,22 @@ class BrevGenerererTjenesteEndringInntektTest {
 
         var brevtekst = generertBrev.dokument().html();
 
-        assertThatHtml(brevtekst).containsHtmlOnceInSequence(
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
             "<h1>Vi har endret ungdomsytelsen din</h1>"
-        ).containsSentencesOnceInSequence(
-            "Du har meldt inn inntekt på 10 000 kroner fra 1. desember 2024 til 31. desember 2024.",
-            "Nav har derfor redusert utbetalingen din for neste perioden til 7 393 kroner.",
-            "Nav reduserer utbetalt beløp med 66 prosent av innmeldt inntekt.",
-            "Dette tilsvarer en reduksjon på 6 600 kroner.",
-            "Dagsatsen blir redusert fra 636 kroner til 336 kroner.",
-            "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx."
+        ).containsTextAndSentenceSequenceOnce(
+            "Vi har endret ungdomsytelsen din ",
+            "Du får 7 393 kroner i ungdomsytelse for perioden fra 1. desember 2024 til 31. desember 2024.",
+            "Det er fordi du har hatt en inntekt på 10 000 kroner i denne perioden.",
+            "Pengene får du ubetalt før den 10. denne måneden.",
+            "Når du har en inntekt, får du mindre penger i ungdomsytelse.",
+            "Vi regner ut hva 66 prosent av inntekten din er hver måned, og så trekker vi dette beløpet fra pengene du får i ungdomsytelsen for den måneden.",
+            "Likevel får du til sammen mer penger når du både har en inntekt og får ungdomsytelse, enn hvis du bare hadde fått penger gjennom ungdomsytelsen.",
+            "Se eksempel på hvordan vi regner ut ungdomsytelsen basert på inntekt i Ungdomsportalen.",
+            "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.",
+            "Du har rett til å klage "
+        ).containsHtmlSubSequenceOnce(
+            "Se <a title=\"utregningseksempler\" href=\"https://nav.no/ungdomsportal/beregning\">eksempel</a> på hvordan vi regner ut ungdomsytelsen basert på inntekt i Ungdomsportalen."
         );
-
     }
 
     @Test

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
@@ -152,7 +152,7 @@ class BrevGenerererTjenesteEndringInntektTest {
             "Nav reduserer utbetalt beløp med 66 prosent av innmeldt inntekt.",
             "Dette tilsvarer en reduksjon på 6 600 kroner.",
             "Dagsatsen blir redusert fra 636 kroner til 336 kroner.",
-            "Vedtaket er gjort etter folketrygdloven § X-Y."
+            "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx."
         );
 
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
@@ -93,8 +93,8 @@ class BrevGenerererTjenesteEndringInntektTest {
 
         var endringInnholdBygger =
             new EndringRapportertInntektInnholdBygger(tilkjentYtelseRepository,
-                new RapportertInntektMapper(abakusInMemoryInntektArbeidYtelseTjeneste),
-                ungdomsytelseGrunnlagRepository);
+                new RapportertInntektMapper(abakusInMemoryInntektArbeidYtelseTjeneste)
+            );
 
         var detaljertResultatUtleder = new DetaljertResultatUtlederImpl(
             new ProsessTriggerPeriodeUtleder(prosessTriggereRepository, new UngdomsytelseSøknadsperiodeTjeneste(ungdomsytelseStartdatoRepository, ungdomsprogramPeriodeTjeneste, repositoryProvider.getBehandlingRepository())),

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteInnvilgelseTest.java
@@ -155,9 +155,9 @@ class BrevGenerererTjenesteInnvilgelseTest {
 
         var brevtekst = generertBrev.dokument().html();
 
-        assertThatHtml(brevtekst).containsHtmlOnceInSequence(
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
             "<h1>Nav har innvilget søknaden din om ungdomsytelse</h1>"
-        ).containsSentencesOnceInSequence(
+        ).containsSentenceSubSequenceOnce(
             "Du har rett til ungdomsytelse fra 1. desember 2024 i 260 dager.",
             "Du får utbetalt 636 kroner dagen, før skatt.",
             "Nav bruker grunnbeløpet på 124 028 kroner for å regne ut hvor mye du får.",
@@ -178,9 +178,9 @@ class BrevGenerererTjenesteInnvilgelseTest {
 
         var brevtekst = generertBrev.dokument().html();
 
-        assertThatHtml(brevtekst).containsHtmlOnceInSequence(
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
             "<h1>Nav har innvilget søknaden din om ungdomsytelse</h1>"
-        ).containsSentencesOnceInSequence(
+        ).containsSentenceSubSequenceOnce(
             "Du har rett til ungdomsytelse fra 1. desember 2024 i 260 dager.",
             "Du får utbetalt 954 kroner dagen, før skatt.",
             "Siden du er over 25 år så får du 2 ganger grunnbeløpet."
@@ -204,9 +204,9 @@ class BrevGenerererTjenesteInnvilgelseTest {
 
         var brevtekst = generertBrev.dokument().html();
 
-        assertThatHtml(brevtekst).containsHtmlOnceInSequence(
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
             "<h1>Nav har innvilget søknaden din om ungdomsytelse</h1>"
-        ).containsSentencesOnceInSequence(
+        ).containsSentenceSubSequenceOnce(
             "Du har rett til ungdomsytelse fra 1. desember 2024 i 130 dager.",
             "Du får utbetalt 954 kroner dagen, før skatt.",
             "Siden du er over 25 år så får du 2 ganger grunnbeløpet til måneden du fyller 29 år."
@@ -230,9 +230,9 @@ class BrevGenerererTjenesteInnvilgelseTest {
 
         var brevtekst = generertBrev.dokument().html();
 
-        assertThatHtml(brevtekst).containsHtmlOnceInSequence(
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
             "<h1>Nav har innvilget søknaden din om ungdomsytelse</h1>"
-        ).containsSentencesOnceInSequence(
+        ).containsSentenceSubSequenceOnce(
             "Du har rett til ungdomsytelse fra 1. desember 2024 i 260 dager.",
             "Fra 1. desember 2024 til 31. mai 2025 får du utbetalt 636 kroner dagen, før skatt.",
             "Fra 1. juni 2025 til 29. november 2025 får du utbetalt 954 kroner dagen, før skatt.",

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteInnvilgelseTest.java
@@ -162,7 +162,7 @@ class BrevGenerererTjenesteInnvilgelseTest {
             "Du får utbetalt 636 kroner dagen, før skatt.",
             "Nav bruker grunnbeløpet på 124 028 kroner for å regne ut hvor mye du får.",
             "Siden du er under 25 år så får du 1.33 ganger grunnbeløpet.",
-            "Vedtaket er gjort etter folketrygdloven § X-Y."
+            "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx."
         );
 
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/HtmlAssert.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/HtmlAssert.java
@@ -48,45 +48,86 @@ public class HtmlAssert extends AbstractAssert<HtmlAssert, String> {
         return this;
     }
 
-    public HtmlAssert containsTextsOnceInSequence(String... text) {
-        assertThatContainsOnceInSequence(actualTextTrimmed, text);
+
+    /**
+     * hvis setning slutter på punktum legges det på en space for å fange opp tegn etter punkt som ikke skal være der.
+     */
+    public HtmlAssert containsTextAndSentenceSequenceOnce(String... text) {
+        var transformed = addSpaceAfterSentenceStop(text);
+        assertThatContainsSequenceOnce(actualTextTrimmed, transformed.toArray(new String[0]));
         return this;
+    }
+
+    public HtmlAssert containsTextSubSequenceOnce(String... text) {
+        assertThatContainsSubSequenceOnce(actualTextTrimmed, text);
+        return this;
+    }
+
+    private static List<String> addSpaceAfterSentenceStop(String[] text) {
+        List<String> list = new ArrayList<>(text.length);
+        for (var linje : text) {
+            var trimmedLinje = linje.trim();
+            list.add(trimmedLinje.endsWith(".") ? trimmedLinje + " " : linje);
+
+        }
+        return list;
     }
 
     /**
      * Sjekker om alle text er setninger med punktum. Legger også på space etter siste punktum for å fange f.eks.
      * feilaktig dobbel punktum
      */
-    public HtmlAssert containsSentencesOnceInSequence(String... text) {
+    private static List<String> validateAndMakeSentencesWithSpace(String[] text) {
         List<String> list = new ArrayList<>();
         for (var linje : text) {
-            if (!linje.endsWith(".")) {
+            var trimmedLinje = linje.trim();
+            if (!trimmedLinje.endsWith(".")) {
                 throw new IllegalArgumentException("Alle setninger må slutte med punktum. Setningen: \"" + linje + "\" mangler punktum.");
             }
-            String medSpace = linje + " ";
-            list.add(medSpace);
+            list.add(trimmedLinje + " ");
         }
-        containsTextsOnceInSequence(list.toArray(new String[0]));
+        return list;
+    }
+
+
+    public HtmlAssert containsSentenceSubSequenceOnce(String... text) {
+        List<String> list = validateAndMakeSentencesWithSpace(text);
+        containsTextSubSequenceOnce(list.toArray(new String[0]));
         return this;
     }
 
-    public HtmlAssert containsHtmlOnceInSequence(CharSequence... html) {
-        assertThatContainsOnceInSequence(actualHtmlTrimmed, html);
+    public HtmlAssert containsHtmlSubSequenceOnce(String... html) {
+        assertThatContainsSubSequenceOnce(actualHtmlTrimmed, html);
         return this;
     }
 
-    public HtmlAssert doesNotContainText(CharSequence... texts) {
+    public HtmlAssert doesNotContainText(String... texts) {
         assertThat(actualTextTrimmed).doesNotContain(texts);
         return this;
     }
 
-    public HtmlAssert doesNotContainHtml(CharSequence... texts) {
+    public HtmlAssert doesNotContainHtml(String... texts) {
         assertThat(actualHtmlTrimmed).doesNotContain(texts);
         return this;
     }
 
-    private void assertThatContainsOnceInSequence(String actual, CharSequence... seq) {
+    /**
+     * Sjekker at teksten kommer etterhverandre i rekkefølge én gang uten noe annen tekst i mellom
+     */
+    private void assertThatContainsSequenceOnce(String actual, String... seq) {
+        assertThat(actual).containsSequence(seq);
+        assertThatOnlyOneOccurance(actual, seq);
+    }
+
+    /**
+     * Sjekker at teksten kommer etterhverandre i rekkefølge én gang. Kan ha annen tekst i mellom.
+     */
+    private void assertThatContainsSubSequenceOnce(String actual, String... seq) {
         assertThat(actual).containsSubsequence(seq);
+        assertThatOnlyOneOccurance(actual, seq);
+    }
+
+    private static void assertThatOnlyOneOccurance(String actual, String[] seq) {
         var soft = new SoftAssertions();
         Arrays.stream(seq).forEach(it ->
             soft.assertThat(actual).containsOnlyOnce(it)

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/HtmlAssert.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/HtmlAssert.java
@@ -50,6 +50,9 @@ public class HtmlAssert extends AbstractAssert<HtmlAssert, String> {
 
 
     /**
+     * Kan brukes til å sjekke at brevet henger sammen med riktig teksten uten noe i mellom.
+     * Husk å legge på punktum på setninger selv!
+     *
      * hvis setning slutter på punktum legges det på en space for å fange opp tegn etter punkt som ikke skal være der.
      */
     public HtmlAssert containsTextAndSentenceSequenceOnce(String... text) {

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/VedtaksbrevStandardTekstVerifiserer.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/VedtaksbrevStandardTekstVerifiserer.java
@@ -8,7 +8,7 @@ import no.nav.ung.sak.test.util.behandling.UngTestScenario;
 
 public class VedtaksbrevStandardTekstVerifiserer {
     static void verifiserStandardVedtaksbrevTekster(String brevHtml, String fnr, UngTestScenario ungTestscenario) {
-        assertThatHtml(brevHtml).containsTextsOnceInSequence(
+        assertThatHtml(brevHtml).containsTextSubSequenceOnce(
             BrevUtils.brevDatoString(LocalDate.now()), //vedtaksdato
             "Til: " + ungTestscenario.navn(),
             "Fødselsnummer: " + fnr,
@@ -19,7 +19,7 @@ public class VedtaksbrevStandardTekstVerifiserer {
             "Trenger du mer informasjon?",
             "Med vennlig hilsen",
             "Nav Arbeid og ytelser"
-        ).containsHtmlOnceInSequence(
+        ).containsHtmlSubSequenceOnce(
             "<h2>Du har rett til å klage</h2>",
             "<h2>Du har rett til innsyn</h2>",
             "<h2>Trenger du mer informasjon?</h2>"


### PR DESCRIPTION
### **Behov / Bakgrunn**
Endringer etter endelig tekst for brev om endring av inntekt. 

### **Løsning**
Lagt inn ny tekst, fjernet felter som ikke er i bruk og forenklet koden. 

### **Andre endringer**
Endret brev assertion til å sjekke at teksten ikke bare kommer i riktig rekkefølge men også etterfølges av hovedoverskrift. Og at etter hovedinnhold så kommer klage overskriften. Dette for å fange opp tilfeller der feil tekst kan komme før/etter at hovedinnholdet er ferdig. 

