### PR TITLE
TSFF-1194: Lagrer kontrollert inntektperioder i egen datastruktur og begrenser tilkjent ytelse til perioder som er ferdig kontrollert

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPeriode.java
@@ -1,0 +1,105 @@
+package no.nav.ung.sak.behandlingslager.tilkjentytelse;
+
+import jakarta.persistence.*;
+import no.nav.ung.sak.behandlingslager.BaseEntitet;
+import no.nav.ung.sak.behandlingslager.PostgreSQLRangeType;
+import no.nav.ung.sak.behandlingslager.Range;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import org.hibernate.annotations.Type;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity(name = "KontrollertInntektPeriode")
+@Table(name = "KONTROLLERT_INNTEKT_PERIODE")
+public class KontrollertInntektPeriode extends BaseEntitet {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_KONTROLLERT_INNTEKT_PERIODE")
+    private Long id;
+
+    @Type(PostgreSQLRangeType.class)
+    @Column(name = "periode", columnDefinition = "daterange")
+    private Range<LocalDate> periode;
+
+    @Column(name = "arbeidsinntekt", nullable = false)
+    private BigDecimal arbeidsinntekt;
+
+    @Column(name = "ytelse", nullable = false)
+    private BigDecimal ytelse;
+
+    protected KontrollertInntektPeriode() {
+    }
+
+    KontrollertInntektPeriode(KontrollertInntektPeriode eksisterende) {
+        this.periode = Range.closed(eksisterende.getPeriode().getFomDato(), eksisterende.getPeriode().getTomDato());
+        this.arbeidsinntekt = eksisterende.getArbeidsinntekt();
+        this.ytelse = eksisterende.getYtelse();
+    }
+
+    private KontrollertInntektPeriode(DatoIntervallEntitet periode,
+                                      BigDecimal arbeidsinntekt,
+                                      BigDecimal ytelse) {
+        this.periode = Range.closed(periode.getFomDato(), periode.getTomDato());
+        this.arbeidsinntekt = arbeidsinntekt;
+        this.ytelse = ytelse;
+    }
+
+    public DatoIntervallEntitet getPeriode() {
+        return DatoIntervallEntitet.fra(periode);
+    }
+
+    public BigDecimal getArbeidsinntekt() {
+        return arbeidsinntekt;
+    }
+
+    public BigDecimal getYtelse() {
+        return ytelse;
+    }
+
+    public static Builder ny() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private DatoIntervallEntitet periode;
+        private BigDecimal arbeidsinntekt;
+        private BigDecimal ytelse;
+
+        private Builder() {}
+
+        public Builder medPeriode(DatoIntervallEntitet periode) {
+            if (periode == null) {
+                throw new IllegalArgumentException("periode kan ikke være null");
+            }
+            this.periode = periode;
+            return this;
+        }
+
+        public Builder medArbeidsinntekt(BigDecimal arbeidsinntekt) {
+            if (arbeidsinntekt == null) {
+                throw new IllegalArgumentException("arbeidsinntekt kan ikke være null");
+            }
+            this.arbeidsinntekt = arbeidsinntekt;
+            return this;
+        }
+
+        public Builder medYtelse(BigDecimal ytelse) {
+            if (ytelse == null) {
+                throw new IllegalArgumentException("reduksjon kan ikke være null");
+            }
+            this.ytelse = ytelse;
+            return this;
+        }
+
+
+        public KontrollertInntektPeriode build() {
+            return new KontrollertInntektPeriode(periode, arbeidsinntekt, ytelse);
+        }
+
+
+    }
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPeriode.java
@@ -23,10 +23,10 @@ public class KontrollertInntektPeriode extends BaseEntitet {
     @Column(name = "periode", columnDefinition = "daterange")
     private Range<LocalDate> periode;
 
-    @Column(name = "arbeidsinntekt", nullable = false)
+    @Column(name = "arbeidsinntekt")
     private BigDecimal arbeidsinntekt;
 
-    @Column(name = "ytelse", nullable = false)
+    @Column(name = "ytelse")
     private BigDecimal ytelse;
 
     protected KontrollertInntektPeriode() {
@@ -79,17 +79,11 @@ public class KontrollertInntektPeriode extends BaseEntitet {
         }
 
         public Builder medArbeidsinntekt(BigDecimal arbeidsinntekt) {
-            if (arbeidsinntekt == null) {
-                throw new IllegalArgumentException("arbeidsinntekt kan ikke være null");
-            }
             this.arbeidsinntekt = arbeidsinntekt;
             return this;
         }
 
         public Builder medYtelse(BigDecimal ytelse) {
-            if (ytelse == null) {
-                throw new IllegalArgumentException("reduksjon kan ikke være null");
-            }
             this.ytelse = ytelse;
             return this;
         }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPerioder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPerioder.java
@@ -1,0 +1,86 @@
+package no.nav.ung.sak.behandlingslager.tilkjentytelse;
+
+import jakarta.persistence.*;
+import no.nav.ung.sak.behandlingslager.BaseEntitet;
+import org.hibernate.annotations.Immutable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holder på perioder der det er utført kontroll av inntekt mot opplysninger i a-ordningen.
+ */
+@Entity(name = "KontrollertInntektPerioder")
+@Table(name = "KONTROLLERT_INNTEKT_PERIODER")
+public class KontrollertInntektPerioder extends BaseEntitet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_KONTROLLERT_INNTEKT_PERIODER")
+    private Long id;
+
+    @Column(name = "behandling_id", nullable = false, updatable = false)
+    private Long behandlingId;
+
+    @Column(name = "aktiv", nullable = false, updatable = true)
+    private boolean aktiv = true;
+
+    @Immutable
+    @JoinColumn(name = "kontrollert_perioder_id", nullable = false, updatable = false)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REFRESH})
+    private List<KontrollertInntektPeriode> perioder = new ArrayList<>();
+
+
+    public Long getBehandlingId() {
+        return behandlingId;
+    }
+
+    public boolean isAktiv() {
+        return aktiv;
+    }
+
+    void setIkkeAktiv() {
+        this.aktiv = false;
+    }
+
+    public List<KontrollertInntektPeriode> getPerioder() {
+        return perioder;
+    }
+
+    public static Builder ny(Long behandlingId) {
+        if (behandlingId == null) {
+            throw new IllegalArgumentException("behandlingId kan ikke være null");
+        }
+        return new Builder(behandlingId);
+    }
+
+    public static class Builder {
+        private Long behandlingId;
+        private List<KontrollertInntektPeriode> perioder = new ArrayList<>();
+        private String input;
+        private String sporing;
+
+
+        public Builder(Long behandlingId) {
+            this.behandlingId = behandlingId;
+        }
+
+        public Builder medPerioder(List<KontrollertInntektPeriode> perioder) {
+            if (perioder == null) {
+                throw new IllegalArgumentException("perioder kan ikke være null");
+            }
+            this.perioder.addAll(perioder);
+            return this;
+        }
+
+
+        public KontrollertInntektPerioder build() {
+            KontrollertInntektPerioder tilkjentYtelse = new KontrollertInntektPerioder();
+            tilkjentYtelse.behandlingId = this.behandlingId;
+            tilkjentYtelse.perioder = this.perioder;
+            return tilkjentYtelse;
+        }
+
+    }
+
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPerioder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPerioder.java
@@ -25,7 +25,7 @@ public class KontrollertInntektPerioder extends BaseEntitet {
     private boolean aktiv = true;
 
     @Immutable
-    @JoinColumn(name = "kontrollert_perioder_id", nullable = false, updatable = false)
+    @JoinColumn(name = "kontrollert_inntekt_perioder_id", nullable = false, updatable = false)
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REFRESH})
     private List<KontrollertInntektPeriode> perioder = new ArrayList<>();
 

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/TilkjentYtelseRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/TilkjentYtelseRepository.java
@@ -8,6 +8,7 @@ import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,6 +23,28 @@ public class TilkjentYtelseRepository {
         this.entityManager = entityManager;
     }
 
+
+    public void lagre(long behandlingId, List<KontrollertInntektPeriode> perioder) {
+        final var eksisterende = hentKontrollertInntektPerioder(behandlingId);
+        if (eksisterende.isPresent()) {
+            eksisterende.get().setIkkeAktiv();
+            entityManager.persist(eksisterende.get());
+        }
+        final var eksisterendePerioderSomSkalBeholdes = eksisterende.stream().flatMap(it -> it.getPerioder().stream())
+            .filter(p -> perioder.stream().map(KontrollertInntektPeriode::getPeriode).noneMatch(p2 -> p.getPeriode().overlapper(p2)))
+            .map(KontrollertInntektPeriode::new).toList();
+        final var allePerioder = new ArrayList<KontrollertInntektPeriode>();
+        allePerioder.addAll(eksisterendePerioderSomSkalBeholdes);
+        allePerioder.addAll(perioder);
+
+        allePerioder.forEach(entityManager::persist);
+
+        final var ny = KontrollertInntektPerioder.ny(behandlingId)
+            .medPerioder(allePerioder)
+            .build();
+        entityManager.persist(ny);
+        entityManager.flush();
+    }
 
     public void lagre(long behandlingId, List<TilkjentYtelsePeriode> perioder, String input, String sporing) {
         final var eksisterende = hentTilkjentYtelse(behandlingId);
@@ -45,6 +68,14 @@ public class TilkjentYtelseRepository {
         return HibernateVerktøy.hentUniktResultat(query);
     }
 
+    public Optional<KontrollertInntektPerioder> hentKontrollertInntektPerioder(Long behandlingId) {
+        var query = entityManager.createQuery("SELECT t FROM KontrollertInntektPerioder t WHERE t.behandlingId=:id AND t.aktiv = true", KontrollertInntektPerioder.class)
+            .setParameter("id", behandlingId);
+
+        return HibernateVerktøy.hentUniktResultat(query);
+    }
+
+
     public LocalDateTimeline<TilkjentYtelseVerdi> hentTidslinje(Long behandlingId) {
         var query = entityManager.createQuery(
                 "SELECT p FROM TilkjentYtelse t JOIN t.perioder p " +
@@ -66,6 +97,7 @@ public class TilkjentYtelseRepository {
 
         return new LocalDateTimeline<>(segments);
     }
+
 
     public void lagre(Long behandlingId, LocalDateTimeline<TilkjentYtelseVerdi> tilkjentYtelseTidslinje, String input, String sporing) {
         final var tilkjentYtelsePerioder = tilkjentYtelseTidslinje.toSegments().stream()

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/TilkjentYtelseRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/TilkjentYtelseRepository.java
@@ -37,8 +37,6 @@ public class TilkjentYtelseRepository {
         allePerioder.addAll(eksisterendePerioderSomSkalBeholdes);
         allePerioder.addAll(perioder);
 
-        allePerioder.forEach(entityManager::persist);
-
         final var ny = KontrollertInntektPerioder.ny(behandlingId)
             .medPerioder(allePerioder)
             .build();

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.tilkjentytelse.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.tilkjentytelse.orm.xml
@@ -6,8 +6,14 @@
 
     <sequence-generator name="SEQ_TILKJENT_YTELSE" allocation-size="50" sequence-name="SEQ_TILKJENT_YTELSE"/>
     <sequence-generator name="SEQ_TILKJENT_YTELSE_PERIODE" allocation-size="50" sequence-name="SEQ_TILKJENT_YTELSE_PERIODE"/>
+    <sequence-generator name="SEQ_KONTROLLERT_INNTEKT_PERIODER" allocation-size="50" sequence-name="SEQ_KONTROLLERT_INNTEKT_PERIODER"/>
+    <sequence-generator name="SEQ_KONTROLLERT_INNTEKT_PERIODE" allocation-size="50" sequence-name="SEQ_KONTROLLERT_INNTEKT_PERIODE"/>
 
     <entity class="no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelse"/>
     <entity class="no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelsePeriode"/>
+
+    <entity class="no.nav.ung.sak.behandlingslager.tilkjentytelse.KontrollertInntektPerioder"/>
+    <entity class="no.nav.ung.sak.behandlingslager.tilkjentytelse.KontrollertInntektPeriode"/>
+
 
 </entity-mappings>

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelse.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelse.java
@@ -31,7 +31,10 @@ public class LagTilkjentYtelse {
         final var førstePeriode = new LocalDateTimeline<>(godkjentTidslinje.getMinLocalDate(), godkjentTidslinje.getMinLocalDate().with(TemporalAdjusters.lastDayOfMonth()), true).intersection(godkjentTidslinje);
         tidslinjeSomSkalHaTilkjentYtelse = tidslinjeSomSkalHaTilkjentYtelse.crossJoin(førstePeriode);
         final var sistePeriode = new LocalDateTimeline<>(godkjentTidslinje.getMaxLocalDate().withDayOfMonth(1), godkjentTidslinje.getMaxLocalDate(), true).intersection(godkjentTidslinje);
-        tidslinjeSomSkalHaTilkjentYtelse = tidslinjeSomSkalHaTilkjentYtelse.crossJoin(sistePeriode);
+        // Legger til siste periode kun om vi har gjort kontroll av perioden før
+        if (tidslinjeSomSkalHaTilkjentYtelse.getMaxLocalDate().plusDays(1).isEqual(sistePeriode.getMinLocalDate())) {
+            tidslinjeSomSkalHaTilkjentYtelse = tidslinjeSomSkalHaTilkjentYtelse.crossJoin(sistePeriode);
+        }
 
 
         return totalsatsTidslinje.combine(rapportertInntektTidslinje, (di, sats, rapportertInntekt) -> {

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelse.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelse.java
@@ -1,7 +1,10 @@
 package no.nav.ung.sak.domene.behandling.steg.beregnytelse;
 
 import java.math.BigDecimal;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Set;
 
+import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.sak.ytelse.BeregnetSats;
@@ -12,19 +15,33 @@ import no.nav.ung.sak.ytelse.TilkjentYtelsePeriodeResultat;
 
 /**
  * `LagTilkjentYtelse` er en hjelpeklasse som brukes til å generere en tidslinje for tilkjent ytelse basert på godkjente perioder,
- * totale satser og rapportert inntekt.
+ * totale satser og perioder med kontrollert inntekt.
+ * <p>
+ * Det er i utgangspukntet kun perioder der det utført kontroll av rapportert inntekt som vil bli med i tilkjent ytelse. Unntaket er første og siste periode. I disse periodene utføres det ingen kontroll og vi sender disse til oppdrag med en gang.
  */
 public class LagTilkjentYtelse {
 
-    static LocalDateTimeline<TilkjentYtelsePeriodeResultat> lagTidslinje(LocalDateTimeline<Boolean> godkjentTidslinje, LocalDateTimeline<BeregnetSats> totalsatsTidslinje, LocalDateTimeline<RapporterteInntekter> rapportertInntektTidslinje) {
+    static LocalDateTimeline<TilkjentYtelsePeriodeResultat> lagTidslinje(LocalDateTimeline<Boolean> godkjentTidslinje, LocalDateTimeline<BeregnetSats> totalsatsTidslinje, LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje) {
+        if (godkjentTidslinje.isEmpty()) {
+            return LocalDateTimeline.empty();
+        }
+
+        // Begrenser tilkjent ytelse til periode med kontrollert inntekt eller første/siste periode
+        var tidslinjeSomSkalHaTilkjentYtelse = rapportertInntektTidslinje.intersection(godkjentTidslinje).mapValue(it -> true);
+        final var førstePeriode = new LocalDateTimeline<>(godkjentTidslinje.getMinLocalDate(), godkjentTidslinje.getMinLocalDate().with(TemporalAdjusters.lastDayOfMonth()), true).intersection(godkjentTidslinje);
+        tidslinjeSomSkalHaTilkjentYtelse = tidslinjeSomSkalHaTilkjentYtelse.crossJoin(førstePeriode);
+        final var sistePeriode = new LocalDateTimeline<>(godkjentTidslinje.getMaxLocalDate().withDayOfMonth(1), godkjentTidslinje.getMaxLocalDate(), true).intersection(godkjentTidslinje);
+        tidslinjeSomSkalHaTilkjentYtelse = tidslinjeSomSkalHaTilkjentYtelse.crossJoin(sistePeriode);
+
+
         return totalsatsTidslinje.combine(rapportertInntektTidslinje, (di, sats, rapportertInntekt) -> {
                 // Dersom det ikke er rapportert inntekt settes denne til 0, ellers summeres alle inntektene
-                final var rapporertinntekt = rapportertInntekt == null ? BigDecimal.ZERO : rapportertInntekt.getValue().getBrukerRapporterteInntekter().stream().map(RapportertInntekt::beløp).reduce(BigDecimal.ZERO, BigDecimal::add);
+                final var rapporertinntekt = rapportertInntekt == null ? BigDecimal.ZERO : rapportertInntekt.getValue().stream().map(RapportertInntekt::beløp).reduce(BigDecimal.ZERO, BigDecimal::add);
                 // Mapper verdier til TilkjentYtelsePeriodeResultat
                 final var periodeResultat = TikjentYtelseBeregner.beregn(di, sats.getValue(), rapporertinntekt);
                 return new LocalDateSegment<>(di.getFomDato(), di.getTomDato(), periodeResultat);
             }, LocalDateTimeline.JoinStyle.LEFT_JOIN)
-            .intersection(godkjentTidslinje);
+            .intersection(tidslinjeSomSkalHaTilkjentYtelse);
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/BeregnYtelseStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/BeregnYtelseStegTest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.ung.sak.ytelse.KontrollerteInntektperioderTjeneste;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,8 +67,8 @@ class BeregnYtelseStegTest {
             behandlingRepository);
         beregnYtelseSteg = new BeregnYtelseSteg(ungdomsytelseGrunnlagRepository,
             tilkjentYtelseRepository,
-            new RapportertInntektMapper(inntektArbeidYtelseTjeneste, ytelseperiodeUtleder),
-            ytelseperiodeUtleder);
+            ytelseperiodeUtleder,
+            new KontrollerteInntektperioderTjeneste(tilkjentYtelseRepository));
 
         fagsakRepository = new FagsakRepository(entityManager);
 

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelseTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelseTest.java
@@ -140,6 +140,108 @@ class LagTilkjentYtelseTest {
             76);
     }
 
+    @Test
+    void skal_lage_tilkjent_ytelse_for_første_periode_når_andre_periode_ikke_er_kontrollert() {
+        // Arrange
+        final var fom1 = LocalDate.of(2023, 1, 1);
+        final var tom1 = LocalDate.of(2023, 1, 31);
+        final var fom2 = LocalDate.of(2023, 2, 1);
+        final var tom2 = LocalDate.of(2023, 2, 28);
+        final var fom3 = LocalDate.of(2023, 3, 1);
+        final var tom3 = LocalDate.of(2023, 3, 15);
+
+
+        LocalDateTimeline<Boolean> godkjentTidslinje = new LocalDateTimeline<>(List.of(
+            new LocalDateSegment<>(fom1, tom1, true),
+            new LocalDateSegment<>(fom2, tom2, true),
+            new LocalDateSegment<>(fom3, tom3, true)
+
+        ));
+
+        final var grunnsats1 = BigDecimal.valueOf(100);
+        final var grunnsats2 = BigDecimal.valueOf(150);
+        final var barnetilleggSats1 = 200;
+        final var barnetilleggSats2 = 250;
+        LocalDateTimeline<BeregnetSats> totalsatsTidslinje = new LocalDateTimeline<>(List.of(
+            lagSatsperiode(grunnsats1, barnetilleggSats1, fom1, tom1),
+            lagSatsperiode(grunnsats2, barnetilleggSats2, fom2, tom2),
+            lagSatsperiode(grunnsats2, barnetilleggSats2, fom3, tom3)
+        ));
+
+        LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje = TOM_TIDSLINJE;
+
+        // Act
+        LocalDateTimeline<TilkjentYtelseVerdi> resultat = getResultat(godkjentTidslinje, totalsatsTidslinje, rapportertInntektTidslinje);
+
+        // Assert
+        // Forventer ingen reduksjon og tilkjent ytelse for første periode
+        assertNotNull(resultat);
+        assertEquals(1, resultat.getLocalDateIntervals().size());
+
+        final var iterator = resultat.toSegments().iterator();
+        final var forventetDagsats1 = BigDecimal.valueOf(14);
+        final var forventetUredusertBeløp1 = grunnsats1.add(BigDecimal.valueOf(barnetilleggSats1));
+        LocalDateSegment<TilkjentYtelseVerdi> segment1 = iterator.next();
+        assertSegment(segment1, fom1, tom1, forventetUredusertBeløp1, forventetDagsats1, BigDecimal.ZERO, forventetUredusertBeløp1, 100);
+    }
+
+
+    @Test
+    void skal_lage_tilkjent_ytelse_for_siste_periode_når_nest_siste_periode_er_kontrollert() {
+        // Arrange
+        final var fom1 = LocalDate.of(2023, 1, 1);
+        final var tom1 = LocalDate.of(2023, 1, 31);
+        final var fom2 = LocalDate.of(2023, 2, 1);
+        final var tom2 = LocalDate.of(2023, 2, 28);
+        final var fom3 = LocalDate.of(2023, 3, 1);
+        final var tom3 = LocalDate.of(2023, 3, 15);
+
+
+        LocalDateTimeline<Boolean> godkjentTidslinje = new LocalDateTimeline<>(List.of(
+            new LocalDateSegment<>(fom1, tom1, true),
+            new LocalDateSegment<>(fom2, tom2, true),
+            new LocalDateSegment<>(fom3, tom3, true)
+
+        ));
+
+        final var grunnsats1 = BigDecimal.valueOf(100);
+        final var grunnsats2 = BigDecimal.valueOf(150);
+        final var barnetilleggSats1 = 200;
+        final var barnetilleggSats2 = 250;
+        LocalDateTimeline<BeregnetSats> totalsatsTidslinje = new LocalDateTimeline<>(List.of(
+            lagSatsperiode(grunnsats1, barnetilleggSats1, fom1, tom1),
+            lagSatsperiode(grunnsats2, barnetilleggSats2, fom2, tom2),
+            lagSatsperiode(grunnsats2, barnetilleggSats2, fom3, tom3)
+        ));
+
+        LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje = new LocalDateTimeline<>(fom2, tom2, Set.of());
+
+        // Act
+        LocalDateTimeline<TilkjentYtelseVerdi> resultat = getResultat(godkjentTidslinje, totalsatsTidslinje, rapportertInntektTidslinje);
+
+        // Assert
+        // Forventer ingen reduksjon og tilkjent ytelse for første periode
+        assertNotNull(resultat);
+        assertEquals(3, resultat.getLocalDateIntervals().size());
+
+        final var iterator = resultat.toSegments().iterator();
+        final var forventetDagsats1 = BigDecimal.valueOf(14);
+        final var forventetUredusertBeløp1 = grunnsats1.add(BigDecimal.valueOf(barnetilleggSats1));
+        LocalDateSegment<TilkjentYtelseVerdi> segment1 = iterator.next();
+        assertSegment(segment1, fom1, tom1, forventetUredusertBeløp1, forventetDagsats1, BigDecimal.ZERO, forventetUredusertBeløp1, 100);
+
+        LocalDateSegment<TilkjentYtelseVerdi> segment2 = iterator.next();
+        final var forventetUredusertBeløp2 = grunnsats2.add(BigDecimal.valueOf(barnetilleggSats2));
+        final var forventetDagsats2 = BigDecimal.valueOf(20);
+        assertSegment(segment2, fom2, tom2, forventetUredusertBeløp2, forventetDagsats2, BigDecimal.ZERO, forventetUredusertBeløp2, 100);
+
+        LocalDateSegment<TilkjentYtelseVerdi> segment3 = iterator.next();
+        final var forventetUredusertBeløp3 = grunnsats2.add(BigDecimal.valueOf(barnetilleggSats2));
+        final var forventetDagsats3 = BigDecimal.valueOf(36);
+        assertSegment(segment3, fom3, tom3, forventetUredusertBeløp3, forventetDagsats3, BigDecimal.ZERO, forventetUredusertBeløp3, 100);
+    }
+
+
 
 
     private static void assertSegment(LocalDateSegment<TilkjentYtelseVerdi> segment2,

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelseTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/LagTilkjentYtelseTest.java
@@ -23,7 +23,7 @@ import no.nav.ung.sak.ytelse.TilkjentYtelsePeriodeResultat;
 
 class LagTilkjentYtelseTest {
 
-    public static final LocalDateTimeline<RapporterteInntekter> TOM_TIDSLINJE = LocalDateTimeline.empty();
+    public static final LocalDateTimeline<Set<RapportertInntekt>> TOM_TIDSLINJE = LocalDateTimeline.empty();
 
     @Test
     void testLagTidslinjeMedTomGodkjentTidslinje() {
@@ -35,11 +35,9 @@ class LagTilkjentYtelseTest {
             lagSatsperiode(BigDecimal.valueOf(150), 250, LocalDate.of(2023, 2, 1), LocalDate.of(2023, 2, 28))
         ));
 
-        LocalDateTimeline<RapporterteInntekter> rapportertInntektTidslinje = new LocalDateTimeline<>(List.of(
+        LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje = new LocalDateTimeline<>(List.of(
             new LocalDateSegment<>(LocalDate.of(2023, 1, 15), LocalDate.of(2023, 2, 15),
-                new RapporterteInntekter(
-                    Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, BigDecimal.valueOf(50000))),
-                        Set.of()))
+                    Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, BigDecimal.valueOf(50000))))
         ));
 
         // Call the method under test
@@ -50,7 +48,7 @@ class LagTilkjentYtelseTest {
         assertTrue(resultat.isEmpty());
     }
 
-    private static LocalDateTimeline<TilkjentYtelseVerdi> getResultat(LocalDateTimeline<Boolean> godkjentTidslinje, LocalDateTimeline<BeregnetSats> totalsatsTidslinje, LocalDateTimeline<RapporterteInntekter> rapportertInntektTidslinje) {
+    private static LocalDateTimeline<TilkjentYtelseVerdi> getResultat(LocalDateTimeline<Boolean> godkjentTidslinje, LocalDateTimeline<BeregnetSats> totalsatsTidslinje, LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje) {
         return LagTilkjentYtelse.lagTidslinje(godkjentTidslinje, totalsatsTidslinje, rapportertInntektTidslinje).mapValue(TilkjentYtelsePeriodeResultat::verdi);
     }
 
@@ -76,7 +74,7 @@ class LagTilkjentYtelseTest {
             lagSatsperiode(grunnsats2, barnetilleggSats2, fom2, tom2)
         ));
 
-        LocalDateTimeline<RapporterteInntekter> rapportertInntektTidslinje = TOM_TIDSLINJE;
+        LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje = TOM_TIDSLINJE;
 
         // Act
         LocalDateTimeline<TilkjentYtelseVerdi> resultat = getResultat(godkjentTidslinje, totalsatsTidslinje, rapportertInntektTidslinje);
@@ -115,11 +113,9 @@ class LagTilkjentYtelseTest {
         ));
 
         final var rapportertInntekt = BigDecimal.valueOf(150);
-        LocalDateTimeline<RapporterteInntekter> rapportertInntektTidslinje = new LocalDateTimeline<>(List.of(
-            new LocalDateSegment<>(fom, tom, new RapporterteInntekter(
-                Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, rapportertInntekt)),
-                Set.of()))
-        ));
+        LocalDateTimeline<Set<RapportertInntekt>> rapportertInntektTidslinje = new LocalDateTimeline<>(List.of(
+            new LocalDateSegment<>(fom, tom, Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, rapportertInntekt))))
+        );
 
         // Act
         LocalDateTimeline<TilkjentYtelseVerdi> resultat = getResultat(godkjentTidslinje, totalsatsTidslinje, rapportertInntektTidslinje);

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/KontrollerteInntektperioderTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/KontrollerteInntektperioderTjeneste.java
@@ -11,6 +11,7 @@ import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseRepository;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -39,10 +40,16 @@ public class KontrollerteInntektperioderTjeneste {
         return tilkjentYtelseRepository.hentKontrollertInntektPerioder(behandlingId)
             .stream()
             .flatMap(it -> it.getPerioder().stream())
-            .map(p -> new LocalDateTimeline<>(p.getPeriode().getFomDato(), p.getPeriode().getTomDato(), Set.of(
-                new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, p.getArbeidsinntekt()),
-                new RapportertInntekt(InntektType.YTELSE, p.getYtelse())
-            ))).reduce(LocalDateTimeline::crossJoin)
+            .map(p -> {
+                Set<RapportertInntekt> rapportertInntekter = new HashSet<>();
+                if (p.getArbeidsinntekt() != null)  {
+                    rapportertInntekter.add(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, p.getArbeidsinntekt()));
+                }
+                if (p.getYtelse() != null) {
+                    rapportertInntekter.add(new RapportertInntekt(InntektType.YTELSE, p.getYtelse()));
+                }
+                return new LocalDateTimeline<>(p.getPeriode().getFomDato(), p.getPeriode().getTomDato(), rapportertInntekter);
+            }).reduce(LocalDateTimeline::crossJoin)
             .orElse(LocalDateTimeline.empty());
     }
 

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/KontrollerteInntektperioderTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/KontrollerteInntektperioderTjeneste.java
@@ -1,0 +1,73 @@
+package no.nav.ung.sak.ytelse;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateSegmentCombinator;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.sak.behandlingslager.tilkjentytelse.KontrollertInntektPeriode;
+import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseRepository;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+/**
+ * Tjeneste for oppretting og uthenting av kontrollerte perioder for rapportert inntekt
+ * <p>
+ * Perioder med kontrollert inntekt styrer hvilke perioder som det lages tilkjent ytelse perioder for og hvilke perioder som sendes over til økonomi.
+ */
+@Dependent
+public class KontrollerteInntektperioderTjeneste {
+
+    private TilkjentYtelseRepository tilkjentYtelseRepository;
+
+
+    @Inject
+    public KontrollerteInntektperioderTjeneste(TilkjentYtelseRepository tilkjentYtelseRepository) {
+        this.tilkjentYtelseRepository = tilkjentYtelseRepository;
+    }
+
+    public void opprettKontrollerteInntekterPerioder(Long behandlingId, LocalDateTimeline<Set<RapportertInntekt>> inntektTidslinje, LocalDateTimeline<Set<BehandlingÅrsakType>> prosesstriggerTidslinje) {
+        final var relevantePerioderForKontroll = prosesstriggerTidslinje.filterValue(it -> it.contains(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT));
+        final var kontrollertePerioder = relevantePerioderForKontroll.combine(inntektTidslinje, lagTomListeForIngenInntekter(), LocalDateTimeline.JoinStyle.LEFT_JOIN)
+            .toSegments().stream().map(
+                s -> KontrollertInntektPeriode.ny()
+                    .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(s.getFom(), s.getTom()))
+                    .medArbeidsinntekt(finnInntektAvType(s, InntektType.ARBEIDSTAKER_ELLER_FRILANSER))
+                    .medYtelse(finnInntektAvType(s, InntektType.YTELSE))
+                    .build()
+            ).toList();
+
+
+        tilkjentYtelseRepository.lagre(behandlingId, kontrollertePerioder);
+
+
+    }
+
+
+    public LocalDateTimeline<Set<RapportertInntekt>> hentTidslinje(Long behandlingId) {
+        return tilkjentYtelseRepository.hentKontrollertInntektPerioder(behandlingId)
+            .stream()
+            .flatMap(it -> it.getPerioder().stream())
+            .map(p -> new LocalDateTimeline<>(p.getPeriode().getFomDato(), p.getPeriode().getTomDato(), Set.of(
+                new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, p.getArbeidsinntekt()),
+                new RapportertInntekt(InntektType.YTELSE, p.getYtelse())
+            ))).reduce(LocalDateTimeline::crossJoin)
+            .orElse(LocalDateTimeline.empty());
+    }
+
+    private static LocalDateSegmentCombinator<Set<BehandlingÅrsakType>, Set<RapportertInntekt>, Set<RapportertInntekt>> lagTomListeForIngenInntekter() {
+        return (di, lhs, rhs) -> rhs != null ? new LocalDateSegment<>(di, Set.of()) : rhs;
+    }
+
+    private static BigDecimal finnInntektAvType(LocalDateSegment<Set<RapportertInntekt>> s, InntektType inntektType) {
+        return s.getValue().stream()
+            .filter(it -> it.inntektType().equals(inntektType))
+            .map(RapportertInntekt::beløp)
+            .reduce(BigDecimal::add)
+            .orElse(null);
+    }
+
+}

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_018__kontrollert_inntekt_tabeller.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_018__kontrollert_inntekt_tabeller.sql
@@ -1,0 +1,58 @@
+create table kontrollert_inntekt_perioder
+(
+    id                bigint not null primary key,
+    behandling_id     bigint not null references behandling(id),
+    aktiv             boolean not null,
+    opprettet_tid     timestamp default CURRENT_TIMESTAMP not null,
+    opprettet_av         varchar(20) not null default 'VL',
+    endret_av         varchar(20),
+    endret_tid        timestamp
+);
+
+create index idx_kontrollert_inntekt_perioder_behandling_id
+    on kontrollert_inntekt_perioder (behandling_id);
+
+create unique index idx_kontrollert_inntekt_perioder_aktiv_behandling_id
+    on kontrollert_inntekt_perioder (behandling_id)
+    where aktiv = true;
+
+create sequence if not exists seq_kontrollert_inntekt_perioder increment by 50 minvalue 1000000;
+
+
+comment on table kontrollert_inntekt_perioder is 'Inneholder kontrollerte perioder for inntekt.';
+comment on column kontrollert_inntekt_perioder.id is 'Primary Key. Unik identifikator for kontroll av inntekt.';
+comment on column kontrollert_inntekt_perioder.behandling_id is 'Referanse til behandling.';
+comment on column kontrollert_inntekt_perioder.aktiv is 'Angir om aggregatet er aktivt.';
+comment on column kontrollert_inntekt_perioder.opprettet_tid is 'Tidspunkt for når ytelsen ble opprettet.';
+comment on column kontrollert_inntekt_perioder.endret_tid is 'Tidspunkt for når ytelsen sist ble endret.';
+
+
+create table kontrollert_inntekt_periode
+(
+    id                bigint not null primary key,
+    kontrollert_inntekt_perioder_id bigint not null references kontrollert_inntekt_perioder(id),
+    periode           daterange not null,
+    arbeidsinntekt   numeric,
+    ytelse   numeric,
+    opprettet_tid     timestamp default CURRENT_TIMESTAMP not null,
+    opprettet_av         varchar(20) not null default 'VL',
+    endret_av         varchar(20),
+    endret_tid        timestamp
+);
+
+create index idx_kontrollert_inntekt_periode_kontrollert_inntekt_perioder_id on kontrollert_inntekt_periode (kontrollert_inntekt_perioder_id);
+
+alter table kontrollert_inntekt_periode
+    add constraint no_overlapping_kontrollerte_perioder
+    exclude using gist (kontrollert_inntekt_perioder_id with =, periode with &&);
+
+create sequence if not exists seq_kontrollert_inntekt_periode increment by 50 minvalue 1000000;
+
+comment on table kontrollert_inntekt_periode is 'Inneholder perioder for kontroll av inntekt.';
+comment on column kontrollert_inntekt_periode.id is 'Primary Key. Unik identifikator for perioden.';
+comment on column kontrollert_inntekt_periode.kontrollert_inntekt_perioder_id is 'Referanse til kontrollerte inntekt perioder.';
+comment on column kontrollert_inntekt_periode.periode is 'Periode for ytelsen som daterange.';
+comment on column kontrollert_inntekt_periode.arbeidsinntekt is 'Arbeidsinntekt for perioden.';
+comment on column kontrollert_inntekt_periode.ytelse is 'Ytelse for perioden.';
+comment on column kontrollert_inntekt_periode.opprettet_tid is 'Tidspunkt for når perioden ble opprettet.';
+comment on column kontrollert_inntekt_periode.endret_tid is 'Tidspunkt for når perioden sist ble endret.';


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er kun perioder som har passert kontroll av rapportert inntekt som skal sendes til økonomi.

### **Løsning**
Ny datastruktur som lagrer perioder som er ferdig kontrollert og hvilken inntekt som ble brukt.
