### PR TITLE
Legg til Vary: X-Json-Serializer-Option header på alle responser.

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>no.nav.openapi.spec.utils</groupId>
             <artifactId>openapi-spec-utils</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
 
         <!-- CDI -->

--- a/web/src/main/java/no/nav/ung/sak/web/app/ApplicationConfig.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/ApplicationConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.ws.rs.ApplicationPath;
+import no.nav.openapi.spec.utils.http.DynamicObjectMapperResolverVaryFilter;
 import no.nav.openapi.spec.utils.jackson.DynamicJacksonJsonProvider;
 import no.nav.openapi.spec.utils.openapi.OpenApiSetupHelper;
 import no.nav.ung.sak.web.app.exceptions.KnownExceptionMappers;
@@ -49,6 +50,7 @@ public class ApplicationConfig extends ResourceConfig {
         registerClasses(new LinkedHashSet<>(new RestImplementationClasses().getImplementationClasses()));
 
         register(ObjectMapperResolver.class);
+        register(DynamicObjectMapperResolverVaryFilter.class);
 
         registerInstances(new LinkedHashSet<>(new KnownExceptionMappers().getExceptionMappers()));
         register(CacheControlFeature.class);


### PR DESCRIPTION
### **Behov / Bakgrunn**
Uten slik Vary header kunne respons bli cacha av klient og brukt opp igjen ved ny request til samme url, sjølv om X-Json-Serializer-Option vart endra mellom requests.

Dette ville føre til feil resultat for klient.

### **Løsning**
Legger til Vary header på alle responser frå serveren.
