### PR TITLE
Tsff 1204 lagre uttalelse

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/Etterlysning.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/Etterlysning.java
@@ -18,10 +18,6 @@ import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
 import no.nav.ung.sak.behandlingslager.BaseEntitet;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
-import org.hibernate.annotations.Immutable;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 import no.nav.ung.sak.typer.JournalpostId;
 
 @Entity(name = "Etterlysning")

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/Etterlysning.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/Etterlysning.java
@@ -26,7 +26,7 @@ import no.nav.ung.sak.typer.JournalpostId;
 
 @Entity(name = "Etterlysning")
 @Table(name = "ETTERLYSNING")
-public class EtterlysningEntitet extends BaseEntitet {
+public class Etterlysning extends BaseEntitet {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_ETTERLYSNING")
@@ -64,17 +64,17 @@ public class EtterlysningEntitet extends BaseEntitet {
     @JoinColumn(name = "id", referencedColumnName = "etterlysning_id")
     private UttalelseEntitet uttalelse;
 
-    private EtterlysningEntitet() {
+    private Etterlysning() {
         // Hibernate
     }
 
-    public static EtterlysningEntitet forInntektKontrollUttalelse(
+    public static Etterlysning forInntektKontrollUttalelse(
         Long behandlingId,
         UUID grunnlagsreferanse,
         UUID eksternReferanse,
         DatoIntervallEntitet periode) {
 
-        return new EtterlysningEntitet(
+        return new Etterlysning(
             behandlingId,
             grunnlagsreferanse,
             eksternReferanse,
@@ -83,12 +83,12 @@ public class EtterlysningEntitet extends BaseEntitet {
             EtterlysningStatus.OPPRETTET);
     }
 
-    public EtterlysningEntitet(Long behandlingId,
-                               UUID grunnlagsreferanse,
-                               UUID eksternReferanse,
-                               DatoIntervallEntitet periode,
-                               EtterlysningType type,
-                               EtterlysningStatus status) {
+    public Etterlysning(Long behandlingId,
+                        UUID grunnlagsreferanse,
+                        UUID eksternReferanse,
+                        DatoIntervallEntitet periode,
+                        EtterlysningType type,
+                        EtterlysningStatus status) {
         this.behandlingId = behandlingId;
         this.grunnlagsreferanse = grunnlagsreferanse;
         this.eksternReferanse = eksternReferanse;

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningEntitet.java
@@ -1,6 +1,19 @@
 package no.nav.ung.sak.behandlingslager.etterlysning;
 
-import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
 import no.nav.ung.sak.behandlingslager.BaseEntitet;
@@ -13,7 +26,6 @@ import no.nav.ung.sak.typer.JournalpostId;
 
 @Entity(name = "Etterlysning")
 @Table(name = "ETTERLYSNING")
-@Immutable
 public class EtterlysningEntitet extends BaseEntitet {
 
     @Id

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningEntitet.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Entity(name = "Etterlysning")
 @Table(name = "ETTERLYSNING")
 @Immutable
-public class Etterlysning extends BaseEntitet {
+public class EtterlysningEntitet extends BaseEntitet {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_ETTERLYSNING")
@@ -25,6 +25,9 @@ public class Etterlysning extends BaseEntitet {
     @Column(name = "grunnlag_ref", nullable = false)
     private UUID grunnlagsreferanse;
 
+    /**
+     * Referanse mot deltager-app oppgave styrt av ung-sak
+     */
     @Column(name = "ekstern_ref", nullable = false)
     private UUID eksternReferanse;
 
@@ -40,17 +43,17 @@ public class Etterlysning extends BaseEntitet {
     @Column(name = "frist")
     private LocalDateTime frist;
 
-    private Etterlysning() {
+    private EtterlysningEntitet() {
         // Hibernate
     }
 
-    public static Etterlysning forInntektKontrollUttalelse(
+    public static EtterlysningEntitet forInntektKontrollUttalelse(
         Long behandlingId,
         UUID grunnlagsreferanse,
         UUID eksternReferanse,
         DatoIntervallEntitet periode) {
 
-        return new Etterlysning(
+        return new EtterlysningEntitet(
             behandlingId,
             grunnlagsreferanse,
             eksternReferanse,
@@ -59,12 +62,12 @@ public class Etterlysning extends BaseEntitet {
             EtterlysningStatus.OPPRETTET);
     }
 
-    public Etterlysning(Long behandlingId,
-                        UUID grunnlagsreferanse,
-                        UUID eksternReferanse,
-                        DatoIntervallEntitet periode,
-                        EtterlysningType type,
-                        EtterlysningStatus status) {
+    public EtterlysningEntitet(Long behandlingId,
+                               UUID grunnlagsreferanse,
+                               UUID eksternReferanse,
+                               DatoIntervallEntitet periode,
+                               EtterlysningType type,
+                               EtterlysningStatus status) {
         this.behandlingId = behandlingId;
         this.grunnlagsreferanse = grunnlagsreferanse;
         this.eksternReferanse = eksternReferanse;
@@ -136,4 +139,10 @@ public class Etterlysning extends BaseEntitet {
     }
 
 
+    public void mottattSvar() {
+        if (status != EtterlysningStatus.VENTER) {
+            throw new IllegalStateException("Kan ikke motta svar på etterlysning som ikke er satt til VENTER. Status er " + status);
+        }
+        this.status = EtterlysningStatus.MOTTATT_SVAR;
+    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningEntitet.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.Immutable;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import no.nav.ung.sak.typer.JournalpostId;
 
 @Entity(name = "Etterlysning")
 @Table(name = "ETTERLYSNING")
@@ -42,6 +43,14 @@ public class EtterlysningEntitet extends BaseEntitet {
 
     @Column(name = "frist")
     private LocalDateTime frist;
+
+    @Embedded
+    @AttributeOverrides(@AttributeOverride(name = "journalpostId", column = @Column(name = "svar_journalpost_id")))
+    private JournalpostId svarJournalpostId;
+
+    @OneToOne
+    @JoinColumn(name = "id", referencedColumnName = "etterlysning_id")
+    private UttalelseEntitet uttalelse;
 
     private EtterlysningEntitet() {
         // Hibernate
@@ -139,10 +148,24 @@ public class EtterlysningEntitet extends BaseEntitet {
     }
 
 
-    public void mottattSvar() {
+    public void mottattSvar(JournalpostId svarJournalpostId) {
         if (status != EtterlysningStatus.VENTER) {
             throw new IllegalStateException("Kan ikke motta svar på etterlysning som ikke er satt til VENTER. Status er " + status);
         }
+        this.svarJournalpostId = svarJournalpostId;
         this.status = EtterlysningStatus.MOTTATT_SVAR;
+    }
+
+    public void mottattUttalelse(String uttalelse, JournalpostId svarJournalpostId) {
+        mottattSvar(svarJournalpostId);
+        this.uttalelse = new UttalelseEntitet(uttalelse, this.id);
+    }
+
+    public JournalpostId getSvarJournalpostId() {
+        return svarJournalpostId;
+    }
+
+    public UttalelseEntitet getUttalelse() {
+        return uttalelse;
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
@@ -27,12 +27,15 @@ public class EtterlysningRepository {
     }
 
     public EtterlysningEntitet lagre(EtterlysningEntitet etterlysning) {
+        if (etterlysning.getUttalelse() != null) {
+            entityManager.persist(etterlysning.getUttalelse());
+        }
         entityManager.persist(etterlysning);
         return etterlysning;
     }
 
     public List<EtterlysningEntitet> lagre(List<EtterlysningEntitet> etterlysninger) {
-        etterlysninger.forEach(entityManager::persist);
+        etterlysninger.forEach(this::lagre);
         return etterlysninger;
     }
 

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
@@ -10,8 +10,6 @@ import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
 
-import java.util.List;
-
 @ApplicationScoped
 public class EtterlysningRepository {
 

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
@@ -26,7 +26,7 @@ public class EtterlysningRepository {
         this.entityManager = entityManager;
     }
 
-    public EtterlysningEntitet lagre(EtterlysningEntitet etterlysning) {
+    public Etterlysning lagre(Etterlysning etterlysning) {
         if (etterlysning.getUttalelse() != null) {
             entityManager.persist(etterlysning.getUttalelse());
         }
@@ -34,22 +34,22 @@ public class EtterlysningRepository {
         return etterlysning;
     }
 
-    public List<EtterlysningEntitet> lagre(List<EtterlysningEntitet> etterlysninger) {
+    public List<Etterlysning> lagre(List<Etterlysning> etterlysninger) {
         etterlysninger.forEach(this::lagre);
         return etterlysninger;
     }
 
-    public List<EtterlysningEntitet> hentEtterlysninger(Long behandlingId) {
+    public List<Etterlysning> hentEtterlysninger(Long behandlingId) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                                                             "where e.behandlingId = :behandlingId", EtterlysningEntitet.class)
+                                                             "where e.behandlingId = :behandlingId", Etterlysning.class)
             .setParameter("behandlingId", behandlingId)
             .getResultList();
         return etterlysninger;
     }
 
-    public List<EtterlysningEntitet> hentEtterlysninger(Long behandlingId, EtterlysningType type) {
+    public List<Etterlysning> hentEtterlysninger(Long behandlingId, EtterlysningType type) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                                                             "where e.behandlingId = :behandlingId and e.type = :type", EtterlysningEntitet.class)
+                                                             "where e.behandlingId = :behandlingId and e.type = :type", Etterlysning.class)
             .setParameter("behandlingId", behandlingId)
             .setParameter("type", type)
             .getResultList();
@@ -57,9 +57,9 @@ public class EtterlysningRepository {
     }
 
 
-    public List<EtterlysningEntitet> hentOpprettetEtterlysninger(Long behandlingId, EtterlysningType type) {
+    public List<Etterlysning> hentOpprettetEtterlysninger(Long behandlingId, EtterlysningType type) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                                                             "where e.behandlingId = :behandlingId and e.type = :type and status = :status", EtterlysningEntitet.class)
+                                                             "where e.behandlingId = :behandlingId and e.type = :type and status = :status", Etterlysning.class)
             .setParameter("behandlingId", behandlingId)
             .setParameter("type", type)
             .setParameter("status", EtterlysningStatus.OPPRETTET)
@@ -67,9 +67,9 @@ public class EtterlysningRepository {
         return etterlysninger;
     }
 
-    public List<EtterlysningEntitet> hentEtterlysningerSomSkalAvbrytes(Long behandlingId) {
+    public List<Etterlysning> hentEtterlysningerSomSkalAvbrytes(Long behandlingId) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                                                             "where e.behandlingId = :behandlingId and e.type = :type and status = :status", EtterlysningEntitet.class)
+                                                             "where e.behandlingId = :behandlingId and e.type = :type and status = :status", Etterlysning.class)
             .setParameter("behandlingId", behandlingId)
             .setParameter("status", EtterlysningStatus.SKAL_AVBRYTES)
             .getResultList();
@@ -88,20 +88,20 @@ public class EtterlysningRepository {
     }
 
 
-    public EtterlysningEntitet hentEtterlysningForEksternReferanse(UUID eksternReferanse) {
+    public Etterlysning hentEtterlysningForEksternReferanse(UUID eksternReferanse) {
         return HibernateVerktøy.hentEksaktResultat(
             entityManager.createQuery(
                     "select e from Etterlysning e " +
-                    "where e.eksternReferanse = :eksternReferanse", EtterlysningEntitet.class)
+                    "where e.eksternReferanse = :eksternReferanse", Etterlysning.class)
                 .setParameter("eksternReferanse", eksternReferanse)
         );
     }
 
-    public EtterlysningEntitet hentEtterlysning(Long id) {
+    public Etterlysning hentEtterlysning(Long id) {
         return HibernateVerktøy.hentEksaktResultat(
             entityManager.createQuery(
                     "select e from Etterlysning e " +
-                    "where e.id = :id", EtterlysningEntitet.class)
+                    "where e.id = :id", Etterlysning.class)
                 .setParameter("id", id)
         );
     }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
@@ -1,12 +1,15 @@
 package no.nav.ung.sak.behandlingslager.etterlysning;
 
+import java.util.List;
+import java.util.UUID;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @ApplicationScoped
@@ -23,27 +26,27 @@ public class EtterlysningRepository {
         this.entityManager = entityManager;
     }
 
-    public Etterlysning lagre(Etterlysning etterlysning) {
+    public EtterlysningEntitet lagre(EtterlysningEntitet etterlysning) {
         entityManager.persist(etterlysning);
         return etterlysning;
     }
 
-    public List<Etterlysning> lagre(List<Etterlysning> etterlysninger) {
+    public List<EtterlysningEntitet> lagre(List<EtterlysningEntitet> etterlysninger) {
         etterlysninger.forEach(entityManager::persist);
         return etterlysninger;
     }
 
-    public List<Etterlysning> hentEtterlysninger(Long behandlingId) {
+    public List<EtterlysningEntitet> hentEtterlysninger(Long behandlingId) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                "where e.behandlingId = :behandlingId", Etterlysning.class)
+                                                             "where e.behandlingId = :behandlingId", EtterlysningEntitet.class)
             .setParameter("behandlingId", behandlingId)
             .getResultList();
         return etterlysninger;
     }
 
-    public List<Etterlysning> hentEtterlysninger(Long behandlingId, EtterlysningType type) {
+    public List<EtterlysningEntitet> hentEtterlysninger(Long behandlingId, EtterlysningType type) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                "where e.behandlingId = :behandlingId and e.type = :type", Etterlysning.class)
+                                                             "where e.behandlingId = :behandlingId and e.type = :type", EtterlysningEntitet.class)
             .setParameter("behandlingId", behandlingId)
             .setParameter("type", type)
             .getResultList();
@@ -51,9 +54,9 @@ public class EtterlysningRepository {
     }
 
 
-    public List<Etterlysning> hentOpprettetEtterlysninger(Long behandlingId, EtterlysningType type) {
+    public List<EtterlysningEntitet> hentOpprettetEtterlysninger(Long behandlingId, EtterlysningType type) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                "where e.behandlingId = :behandlingId and e.type = :type and status = :status", Etterlysning.class)
+                                                             "where e.behandlingId = :behandlingId and e.type = :type and status = :status", EtterlysningEntitet.class)
             .setParameter("behandlingId", behandlingId)
             .setParameter("type", type)
             .setParameter("status", EtterlysningStatus.OPPRETTET)
@@ -61,9 +64,9 @@ public class EtterlysningRepository {
         return etterlysninger;
     }
 
-    public List<Etterlysning> hentEtterlysningerSomSkalAvbrytes(Long behandlingId) {
+    public List<EtterlysningEntitet> hentEtterlysningerSomSkalAvbrytes(Long behandlingId) {
         final var etterlysninger = entityManager.createQuery("select e from Etterlysning e " +
-                "where e.behandlingId = :behandlingId and e.type = :type and status = :status", Etterlysning.class)
+                                                             "where e.behandlingId = :behandlingId and e.type = :type and status = :status", EtterlysningEntitet.class)
             .setParameter("behandlingId", behandlingId)
             .setParameter("status", EtterlysningStatus.SKAL_AVBRYTES)
             .getResultList();
@@ -82,4 +85,21 @@ public class EtterlysningRepository {
     }
 
 
+    public EtterlysningEntitet hentEtterlysningForEksternReferanse(UUID eksternReferanse) {
+        return HibernateVerktøy.hentEksaktResultat(
+            entityManager.createQuery(
+                    "select e from Etterlysning e " +
+                    "where e.eksternReferanse = :eksternReferanse", EtterlysningEntitet.class)
+                .setParameter("eksternReferanse", eksternReferanse)
+        );
+    }
+
+    public EtterlysningEntitet hentEtterlysning(Long id) {
+        return HibernateVerktøy.hentEksaktResultat(
+            entityManager.createQuery(
+                    "select e from Etterlysning e " +
+                    "where e.id = :id", EtterlysningEntitet.class)
+                .setParameter("id", id)
+        );
+    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
@@ -1,14 +1,15 @@
 package no.nav.ung.sak.behandlingslager.etterlysning;
 
-import java.util.List;
-import java.util.UUID;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @ApplicationScoped
 public class EtterlysningRepository {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/UttalelseEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/UttalelseEntitet.java
@@ -16,7 +16,7 @@ import no.nav.ung.sak.behandlingslager.BaseEntitet;
 public class UttalelseEntitet extends BaseEntitet {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "seq_uttalelse")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_UTTALELSE")
     private Long id;
 
     @Column(name = "uttalelse", updatable = false, nullable = false)

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/UttalelseEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/UttalelseEntitet.java
@@ -1,0 +1,43 @@
+package no.nav.ung.sak.behandlingslager.etterlysning;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import no.nav.ung.sak.behandlingslager.BaseEntitet;
+
+@Entity(name = "Uttalelse")
+@Table(name = "UTTALELSE")
+@Immutable
+public class UttalelseEntitet extends BaseEntitet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "seq_uttalelse")
+    private Long id;
+
+    @Column(name = "uttalelse", updatable = false, nullable = false)
+    private String uttalelseTekst;
+
+    @Column(name = "etterlysning_id", updatable = false, nullable = false)
+    private long etterlysningId;
+
+
+    private UttalelseEntitet() {
+        // Hibernate
+    }
+
+    public UttalelseEntitet(String uttalelseTekst, long etterlysningId) {
+        this.uttalelseTekst = uttalelseTekst;
+        this.etterlysningId = etterlysningId;
+    }
+
+
+    public String getUttalelseTekst() {
+        return uttalelseTekst;
+    }
+
+}

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
@@ -5,6 +5,7 @@
         version="3.0">
 
     <sequence-generator name="SEQ_ETTERLYSNING" allocation-size="50" sequence-name="SEQ_ETTERLYSNING"/>
+    <sequence-generator name="SEQ_UTTALELSE" allocation-size="50" sequence-name="SEQ_UTTALELSE"/>
 
     <entity class="no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet"/>
     <entity class="no.nav.ung.sak.behandlingslager.etterlysning.UttalelseEntitet"/>

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
@@ -7,7 +7,7 @@
     <sequence-generator name="SEQ_ETTERLYSNING" allocation-size="50" sequence-name="SEQ_ETTERLYSNING"/>
     <sequence-generator name="SEQ_UTTALELSE" allocation-size="50" sequence-name="SEQ_UTTALELSE"/>
 
-    <entity class="no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet"/>
+    <entity class="no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning"/>
     <entity class="no.nav.ung.sak.behandlingslager.etterlysning.UttalelseEntitet"/>
 
 </entity-mappings>

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
@@ -7,5 +7,6 @@
     <sequence-generator name="SEQ_ETTERLYSNING" allocation-size="50" sequence-name="SEQ_ETTERLYSNING"/>
 
     <entity class="no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet"/>
+    <entity class="no.nav.ung.sak.behandlingslager.etterlysning.UttalelseEntitet"/>
 
 </entity-mappings>

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.etterlysning.orm.xml
@@ -6,6 +6,6 @@
 
     <sequence-generator name="SEQ_ETTERLYSNING" allocation-size="50" sequence-name="SEQ_ETTERLYSNING"/>
 
-    <entity class="no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning"/>
+    <entity class="no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet"/>
 
 </entity-mappings>

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/OppgittOpptjeningMapper.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/OppgittOpptjeningMapper.java
@@ -13,6 +13,13 @@ import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
 import no.nav.abakus.iaygrunnlag.kodeverk.VirksomhetType;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.OppgittOpptjeningMottattRequest;
+import no.nav.k9.søknad.felles.opptjening.AnnenAktivitet;
+import no.nav.k9.søknad.felles.opptjening.Frilanser;
+import no.nav.k9.søknad.felles.opptjening.OpptjeningAktivitet;
+import no.nav.k9.søknad.felles.opptjening.SelvstendigNæringsdrivende;
+import no.nav.k9.søknad.felles.opptjening.UtenlandskArbeidsforhold;
+import no.nav.k9.søknad.felles.type.Organisasjonsnummer;
+import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.ung.kodeverk.arbeidsforhold.ArbeidType;
 import no.nav.ung.kodeverk.geografisk.Landkoder;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -25,15 +32,9 @@ import no.nav.ung.sak.domene.iay.modell.OppgittOpptjeningBuilder.EgenNæringBuil
 import no.nav.ung.sak.domene.iay.modell.OppgittUtenlandskVirksomhet;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.typer.OrgNummer;
-import no.nav.k9.søknad.felles.opptjening.AnnenAktivitet;
-import no.nav.k9.søknad.felles.opptjening.Frilanser;
-import no.nav.k9.søknad.felles.opptjening.OpptjeningAktivitet;
-import no.nav.k9.søknad.felles.opptjening.SelvstendigNæringsdrivende;
-import no.nav.k9.søknad.felles.opptjening.UtenlandskArbeidsforhold;
-import no.nav.k9.søknad.felles.type.Organisasjonsnummer;
-import no.nav.k9.søknad.felles.type.Periode;
 
 @Dependent
+//TODO trengs denne?
 public class OppgittOpptjeningMapper {
 
     @Inject

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/inntektrapportering/OppgittOpptjeningMapper.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/inntektrapportering/OppgittOpptjeningMapper.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.OppgittOpptjeningMottattRequest;
-import no.nav.k9.søknad.ytelse.ung.v1.OppgittInntekt;
+import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt;
 import no.nav.ung.kodeverk.arbeidsforhold.ArbeidType;
 import no.nav.ung.sak.behandling.BehandlingReferanse;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/BekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/BekreftelseHåndterer.java
@@ -1,0 +1,7 @@
+package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
+
+public interface BekreftelseHåndterer {
+
+    void håndter(OppgaveBekreftelseInnhold bekreftelse);
+
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DatoEndringBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DatoEndringBekreftelseHåndterer.java
@@ -32,7 +32,6 @@ public class DatoEndringBekreftelseHåndterer implements BekreftelseHåndterer {
     public void håndter(OppgaveBekreftelseInnhold oppgaveBekreftelse) {
         DatoEndring bekreftelse = oppgaveBekreftelse.oppgaveBekreftelse().getBekreftelse();
 
-        //todo flytt dette til ny håndterer
         final var bekreftetPeriodeEndring = new UngdomsprogramBekreftetPeriodeEndring(
             bekreftelse.getNyDato(),
             oppgaveBekreftelse.journalpostId(),

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DatoEndringBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DatoEndringBekreftelseHåndterer.java
@@ -9,7 +9,6 @@ import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretTomDatoBekreftelse
 import no.nav.ung.kodeverk.ungdomsytelse.periodeendring.UngdomsprogramPeriodeEndringType;
 import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsprogramBekreftetPeriodeEndring;
 import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
-import no.nav.ung.sak.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 
 @Dependent
 @OppgaveTypeRef(Bekreftelse.Type.UNG_ENDRET_FOM_DATO)
@@ -18,14 +17,11 @@ public class DatoEndringBekreftelseHåndterer implements BekreftelseHåndterer {
 
 
     private final UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository;
-    private final HistorikkinnslagTjeneste historikkinnslagTjeneste;
 
     @Inject
     public DatoEndringBekreftelseHåndterer(
-        UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository,
-        HistorikkinnslagTjeneste historikkinnslagTjeneste) {
+        UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository) {
         this.ungdomsytelseStartdatoRepository = ungdomsytelseStartdatoRepository;
-        this.historikkinnslagTjeneste = historikkinnslagTjeneste;
     }
 
     @Override
@@ -39,7 +35,6 @@ public class DatoEndringBekreftelseHåndterer implements BekreftelseHåndterer {
 
         var behandling = oppgaveBekreftelse.behandling();
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), bekreftetPeriodeEndring);
-        historikkinnslagTjeneste.opprettHistorikkinnslagForVedlegg(behandling.getFagsakId(), oppgaveBekreftelse.journalpostId());
     }
 
     private static UngdomsprogramPeriodeEndringType finnBekreftetPeriodeEndring(DatoEndring bekreftelse) {

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DatoEndringBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DatoEndringBekreftelseHåndterer.java
@@ -1,0 +1,55 @@
+package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.DatoEndring;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretFomDatoBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretTomDatoBekreftelse;
+import no.nav.ung.kodeverk.ungdomsytelse.periodeendring.UngdomsprogramPeriodeEndringType;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsprogramBekreftetPeriodeEndring;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
+import no.nav.ung.sak.mottak.dokumentmottak.HistorikkinnslagTjeneste;
+
+@Dependent
+@OppgaveTypeRef(Bekreftelse.Type.UNG_ENDRET_FOM_DATO)
+@OppgaveTypeRef(Bekreftelse.Type.UNG_ENDRET_TOM_DATO)
+public class DatoEndringBekreftelseHåndterer implements BekreftelseHåndterer {
+
+
+    private final UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository;
+    private final HistorikkinnslagTjeneste historikkinnslagTjeneste;
+
+    @Inject
+    public DatoEndringBekreftelseHåndterer(
+        UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository,
+        HistorikkinnslagTjeneste historikkinnslagTjeneste) {
+        this.ungdomsytelseStartdatoRepository = ungdomsytelseStartdatoRepository;
+        this.historikkinnslagTjeneste = historikkinnslagTjeneste;
+    }
+
+    @Override
+    public void håndter(OppgaveBekreftelseInnhold oppgaveBekreftelse) {
+        DatoEndring bekreftelse = oppgaveBekreftelse.oppgaveBekreftelse().getBekreftelse();
+
+        //todo flytt dette til ny håndterer
+        final var bekreftetPeriodeEndring = new UngdomsprogramBekreftetPeriodeEndring(
+            bekreftelse.getNyDato(),
+            oppgaveBekreftelse.journalpostId(),
+            finnBekreftetPeriodeEndring(bekreftelse));
+
+        var behandling = oppgaveBekreftelse.behandling();
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), bekreftetPeriodeEndring);
+        historikkinnslagTjeneste.opprettHistorikkinnslagForVedlegg(behandling.getFagsakId(), oppgaveBekreftelse.journalpostId());
+    }
+
+    private static UngdomsprogramPeriodeEndringType finnBekreftetPeriodeEndring(DatoEndring bekreftelse) {
+        if (bekreftelse instanceof EndretTomDatoBekreftelse) {
+            return UngdomsprogramPeriodeEndringType.ENDRET_OPPHØRSDATO;
+        } else if (bekreftelse instanceof EndretFomDatoBekreftelse) {
+            return UngdomsprogramPeriodeEndringType.ENDRET_STARTDATO;
+        }
+        throw new IllegalArgumentException("Kunne ikke håndtere bekreftelse av type " + bekreftelse.getType());
+    }
+
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DokumentMottakerOppgaveBekreftelseUng.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DokumentMottakerOppgaveBekreftelseUng.java
@@ -18,10 +18,8 @@ import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
-import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.mottak.dokumentmottak.DokumentGruppeRef;
 import no.nav.ung.sak.mottak.dokumentmottak.Dokumentmottaker;
-import no.nav.ung.sak.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.ung.sak.mottak.dokumentmottak.Trigger;
 
 
@@ -32,8 +30,6 @@ public class DokumentMottakerOppgaveBekreftelseUng implements Dokumentmottaker {
 
     private OppgaveBekreftelseParser oppgaveBekreftelseParser;
     private MottatteDokumentRepository mottatteDokumentRepository;
-    private UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository;
-    private HistorikkinnslagTjeneste historikkinnslagTjeneste;
     private Instance<BekreftelseHåndterer> bekreftelseMottakere;
 
     public DokumentMottakerOppgaveBekreftelseUng() {
@@ -42,14 +38,10 @@ public class DokumentMottakerOppgaveBekreftelseUng implements Dokumentmottaker {
     @Inject
     public DokumentMottakerOppgaveBekreftelseUng(OppgaveBekreftelseParser oppgaveBekreftelseParser,
                                                  MottatteDokumentRepository mottatteDokumentRepository,
-                                                 UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository,
-                                                 HistorikkinnslagTjeneste historikkinnslagTjeneste,
                                                  Instance<BekreftelseHåndterer> bekreftelseMottakere
     ) {
         this.oppgaveBekreftelseParser = oppgaveBekreftelseParser;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
-        this.ungdomsytelseStartdatoRepository = ungdomsytelseStartdatoRepository;
-        this.historikkinnslagTjeneste = historikkinnslagTjeneste;
         this.bekreftelseMottakere = bekreftelseMottakere;
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DokumentMottakerOppgaveBekreftelseUng.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DokumentMottakerOppgaveBekreftelseUng.java
@@ -61,7 +61,7 @@ public class DokumentMottakerOppgaveBekreftelseUng implements Dokumentmottaker {
                 .get();
 
             bekreftelseHåndterer.håndter(new OppgaveBekreftelseInnhold(
-                dokument.getJournalpostId(), behandling, oppgaveBekreftelse
+                dokument.getJournalpostId(), behandling, oppgaveBekreftelse, dokument.getInnsendingstidspunkt(), dokument.getType()
             ));
         }
         mottatteDokumentRepository.oppdaterStatus(mottattDokument.stream().toList(), DokumentStatus.GYLDIG);
@@ -73,7 +73,7 @@ public class DokumentMottakerOppgaveBekreftelseUng implements Dokumentmottaker {
         } else if (bekreftelse instanceof EndretFomDatoBekreftelse) {
             return UngdomsprogramPeriodeEndringType.ENDRET_STARTDATO;
         }
-        throw new IllegalArgumentException("Kunne ikke håndtere bekreftelse av type " + bekreftelse.getType());
+        throw new IllegalArgumentException("Kunne ikke håndtere bekreftelse av brevkode " + bekreftelse.getType());
     }
 
     @Override

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DokumentMottakerOppgaveBekreftelseUng.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/DokumentMottakerOppgaveBekreftelseUng.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import no.nav.ung.kodeverk.dokument.Brevkode;
@@ -36,7 +37,7 @@ public class DokumentMottakerOppgaveBekreftelseUng implements Dokumentmottaker {
     @Inject
     public DokumentMottakerOppgaveBekreftelseUng(OppgaveBekreftelseParser oppgaveBekreftelseParser,
                                                  MottatteDokumentRepository mottatteDokumentRepository,
-                                                 Instance<BekreftelseHåndterer> bekreftelseMottakere,
+                                                 @Any Instance<BekreftelseHåndterer> bekreftelseMottakere,
                                                  HistorikkinnslagTjeneste historikkinnslagTjeneste) {
         this.oppgaveBekreftelseParser = oppgaveBekreftelseParser;
         this.mottatteDokumentRepository = mottatteDokumentRepository;

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -49,9 +49,6 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
         // lagre grunnlag
         var abakusTask = lagOppdaterAbakusTask(oppgaveBekreftelseInnhold);
 
-        // opprett uttalelse hvis finnes
-
-
         // ta behandling av vent (lukker autopunkt også)
         var fortsettTask = ProsessTaskData.forProsessTask(FortsettBehandlingTask.class);
         Behandling behandling = oppgaveBekreftelseInnhold.behandling();
@@ -67,7 +64,12 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
         // hent tilhørende etterlysning og marker den som løst
         UUID oppgaveId = inntektBekreftelse.getOppgaveId();
         EtterlysningEntitet etterlysning = etterlysningRepository.hentEtterlysningForEksternReferanse(oppgaveId);
-        etterlysning.mottattSvar();
+
+        if (inntektBekreftelse.getUttalelseFraBruker() != null) {
+            etterlysning.mottattUttalelse(inntektBekreftelse.getUttalelseFraBruker(), oppgaveBekreftelseInnhold.journalpostId());
+        } else {
+            etterlysning.mottattSvar(oppgaveBekreftelseInnhold.journalpostId());
+        }
         etterlysningRepository.lagre(etterlysning);
 
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -1,39 +1,113 @@
 package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
+import no.nav.abakus.iaygrunnlag.JsonObjectMapper;
+import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
+import no.nav.abakus.iaygrunnlag.request.OppgittOpptjeningMottattRequest;
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.ung.kodeverk.arbeidsforhold.ArbeidType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
+import no.nav.ung.sak.domene.abakus.AbakusInntektArbeidYtelseTjenesteFeil;
+import no.nav.ung.sak.domene.abakus.mapping.IAYTilDtoMapper;
+import no.nav.ung.sak.domene.iay.modell.OppgittOpptjeningBuilder;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.mottak.dokumentmottak.AsyncAbakusLagreOpptjeningTask;
 
 @Dependent
 @OppgaveTypeRef(Bekreftelse.Type.UNG_AVVIK_REGISTERINNTEKT)
 public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
 
 
-    private EtterlysningRepository etterlysningRepository;
+    private final EtterlysningRepository etterlysningRepository;
+    private final ProsessTaskTjeneste prosessTaskTjeneste;
 
     @Inject
-    public InntektBekreftelseHåndterer(EtterlysningRepository etterlysningRepository) {
+    public InntektBekreftelseHåndterer(EtterlysningRepository etterlysningRepository, ProsessTaskTjeneste prosessTaskTjeneste) {
         this.etterlysningRepository = etterlysningRepository;
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
     }
 
     @Override
     public void håndter(OppgaveBekreftelseInnhold bekreftelse) {
-        // hent tilhørende etterlysning og marker den som løst
         InntektBekreftelse b = bekreftelse.oppgaveBekreftelse().getBekreftelse();
+
+        // lagre grunnlag
+        var oppgittOpptjeningMottattRequest = mapOppgittOpptjeningRequest(bekreftelse);
+        lagreOppgittOpptjeningFraSøknad(bekreftelse, oppgittOpptjeningMottattRequest);
+
+        // hent tilhørende etterlysning og marker den som løst
         UUID oppgaveId = b.getOppgaveId();
         EtterlysningEntitet etterlysning = etterlysningRepository.hentEtterlysningForEksternReferanse(oppgaveId);
         etterlysning.mottattSvar();
         etterlysningRepository.lagre(etterlysning);
 
         // opprett uttalelse hvis finnes
-        // lagre grunnlag
 
 
         // ta behandling av vent
+
     }
+
+    /**
+     * Lagrer oppgitt opptjening til abakus fra mottatt dokument.
+     */
+    private void lagreOppgittOpptjeningFraSøknad(OppgaveBekreftelseInnhold bekreftelseInnhold, OppgittOpptjeningMottattRequest request) {
+        try {
+            var behandling = bekreftelseInnhold.behandling();
+            var enkeltTask = ProsessTaskData.forProsessTask(AsyncAbakusLagreOpptjeningTask.class);
+            var payload = JsonObjectMapper.getMapper().writeValueAsString(request);
+            enkeltTask.setPayload(payload);
+
+            enkeltTask.setProperty(AsyncAbakusLagreOpptjeningTask.JOURNALPOST_ID, bekreftelseInnhold.journalpostId().getJournalpostId().getVerdi());
+            enkeltTask.setProperty(AsyncAbakusLagreOpptjeningTask.BREVKODER, bekreftelseInnhold.brevkode().getKode());
+
+            enkeltTask.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getAktørId());
+            enkeltTask.setSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
+            enkeltTask.setCallIdFraEksisterende();
+
+            prosessTaskTjeneste.lagre(enkeltTask);
+        } catch (IOException e) {
+            throw AbakusInntektArbeidYtelseTjenesteFeil.FEIL.feilVedKallTilAbakus("Opprettelse av task for lagring av oppgitt opptjening i abakus feiler.", e).toException();
+        }
+    }
+
+    private static OppgittOpptjeningMottattRequest mapOppgittOpptjeningRequest(OppgaveBekreftelseInnhold bekreftelse) {
+        InntektBekreftelse inntektBekreftelse = bekreftelse.oppgaveBekreftelse().getBekreftelse();
+        var oppgittArbeidOgFrilans = inntektBekreftelse.getOppgittePeriodeinntekter()
+            .stream()
+            .filter(it -> it.getArbeidstakerOgFrilansInntekt() != null)
+            .map(inntekter -> OppgittOpptjeningBuilder.OppgittArbeidsforholdBuilder.ny()
+                .medInntekt(inntekter.getArbeidstakerOgFrilansInntekt())
+                .medArbeidType(ArbeidType.VANLIG)
+                .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(inntekter.getPeriode().getFraOgMed(), inntekter.getPeriode().getTilOgMed())))
+            .toList();
+
+        if (oppgittArbeidOgFrilans.isEmpty()) {
+            throw new IllegalStateException("Mangler arbeid og frilansinntekt");
+
+        }
+
+        var builder = OppgittOpptjeningBuilder.ny(UUID.randomUUID(), LocalDateTime.now());
+        builder.leggTilOppgittArbeidsforhold(oppgittArbeidOgFrilans);
+        builder.leggTilJournalpostId(bekreftelse.journalpostId().getJournalpostId());
+        builder.leggTilInnsendingstidspunkt(bekreftelse.innsendingstidspunkt());
+        Behandling behandlingReferanse = bekreftelse.behandling();
+        var aktør = new AktørIdPersonident(behandlingReferanse.getAktørId().getId());
+        var saksnummer = behandlingReferanse.getFagsak().getSaksnummer();
+        var ytelseType = YtelseType.fraKode(behandlingReferanse.getFagsakYtelseType().getKode());
+        var oppgittOpptjening = new IAYTilDtoMapper(behandlingReferanse.getAktørId(), null, behandlingReferanse.getUuid()).mapTilDto(builder);
+        return new OppgittOpptjeningMottattRequest(saksnummer.getVerdi(), behandlingReferanse.getUuid(), aktør, ytelseType, oppgittOpptjening);
+    }
+
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -15,6 +15,9 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
 
     @Override
     public void håndter(OppgaveBekreftelseInnhold bekreftelse) {
-
+        // hent tilhørende etterlysning og marker den som løst
+        // opprett uttalelse hvis finnes
+        // lagre grunnlag
+        // ta behandling av vent
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -1,12 +1,17 @@
 package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
 
 @Dependent
 @OppgaveTypeRef(Bekreftelse.Type.UNG_AVVIK_REGISTERINNTEKT)
 public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
 
+
+    @Inject
+    public InntektBekreftelseHåndterer() {
+    }
 
     @Override
     public void håndter(OppgaveBekreftelseInnhold bekreftelse) {

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -1,0 +1,15 @@
+package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
+
+import jakarta.enterprise.context.Dependent;
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+
+@Dependent
+@OppgaveTypeRef(Bekreftelse.Type.UNG_AVVIK_REGISTERINNTEKT)
+public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
+
+
+    @Override
+    public void håndter(OppgaveBekreftelseInnhold bekreftelse) {
+
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -42,7 +42,6 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
         this.prosessTaskTjeneste = prosessTaskTjeneste;
     }
 
-    //TODO hva hvis behandling er ikke på KONTROLLER_REGISTER_INNTEKT steg?
     @Override
     public void håndter(OppgaveBekreftelseInnhold oppgaveBekreftelseInnhold) {
         InntektBekreftelse inntektBekreftelse = oppgaveBekreftelseInnhold.oppgaveBekreftelse().getBekreftelse();
@@ -60,10 +59,6 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
                 "Uttalelse fra bruker må være satt når bruker ikke har godtatt endringen");
             etterlysning.mottattUttalelse(inntektBekreftelse.getUttalelseFraBruker(), oppgaveBekreftelseInnhold.journalpostId());
         }
-
-        // ta behandling av vent (lukker autopunkt også)
-        var fortsettTask = fortsettBehandlingTask(oppgaveBekreftelseInnhold.behandling());
-        gruppe.addNesteSekvensiell(fortsettTask);
 
         etterlysningRepository.lagre(etterlysning);
         prosessTaskTjeneste.lagre(gruppe);

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -1,23 +1,39 @@
 package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
 
+import java.util.UUID;
+
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 
 @Dependent
 @OppgaveTypeRef(Bekreftelse.Type.UNG_AVVIK_REGISTERINNTEKT)
 public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
 
 
+    private EtterlysningRepository etterlysningRepository;
+
     @Inject
-    public InntektBekreftelseHåndterer() {
+    public InntektBekreftelseHåndterer(EtterlysningRepository etterlysningRepository) {
+        this.etterlysningRepository = etterlysningRepository;
     }
 
     @Override
     public void håndter(OppgaveBekreftelseInnhold bekreftelse) {
         // hent tilhørende etterlysning og marker den som løst
+        InntektBekreftelse b = bekreftelse.oppgaveBekreftelse().getBekreftelse();
+        UUID oppgaveId = b.getOppgaveId();
+        EtterlysningEntitet etterlysning = etterlysningRepository.hentEtterlysningForEksternReferanse(oppgaveId);
+        etterlysning.mottattSvar();
+        etterlysningRepository.lagre(etterlysning);
+
         // opprett uttalelse hvis finnes
         // lagre grunnlag
+
+
         // ta behandling av vent
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -20,7 +20,7 @@ import no.nav.ung.kodeverk.arbeidsforhold.ArbeidType;
 import no.nav.ung.kodeverk.behandling.BehandlingStegType;
 import no.nav.ung.sak.behandling.prosessering.task.FortsettBehandlingTask;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
-import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
+import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.domene.abakus.AbakusInntektArbeidYtelseTjenesteFeil;
 import no.nav.ung.sak.domene.abakus.mapping.IAYTilDtoMapper;
@@ -46,7 +46,7 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
     public void håndter(OppgaveBekreftelseInnhold oppgaveBekreftelseInnhold) {
         InntektBekreftelse inntektBekreftelse = oppgaveBekreftelseInnhold.oppgaveBekreftelse().getBekreftelse();
 
-        EtterlysningEntitet etterlysning = etterlysningRepository.hentEtterlysningForEksternReferanse(inntektBekreftelse.getOppgaveId());
+        Etterlysning etterlysning = etterlysningRepository.hentEtterlysningForEksternReferanse(inntektBekreftelse.getOppgaveId());
 
         ProsessTaskGruppe gruppe = new ProsessTaskGruppe();
 

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/OppgaveBekreftelseInnhold.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/OppgaveBekreftelseInnhold.java
@@ -1,10 +1,13 @@
 package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
 
+import java.time.LocalDateTime;
+
 import no.nav.k9.oppgave.OppgaveBekreftelse;
+import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.typer.JournalpostId;
 
 public record OppgaveBekreftelseInnhold(
-    JournalpostId journalpostId, Behandling behandling, OppgaveBekreftelse oppgaveBekreftelse
-) {
+    JournalpostId journalpostId, Behandling behandling, OppgaveBekreftelse oppgaveBekreftelse, LocalDateTime innsendingstidspunkt,
+    Brevkode brevkode) {
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/OppgaveBekreftelseInnhold.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/OppgaveBekreftelseInnhold.java
@@ -1,0 +1,10 @@
+package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
+
+import no.nav.k9.oppgave.OppgaveBekreftelse;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.typer.JournalpostId;
+
+public record OppgaveBekreftelseInnhold(
+    JournalpostId journalpostId, Behandling behandling, OppgaveBekreftelse oppgaveBekreftelse
+) {
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/OppgaveTypeRef.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/OppgaveTypeRef.java
@@ -1,0 +1,60 @@
+package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Objects;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse.Type;
+
+/**
+ * Marker type som implementerer interface {@link OppgaveTypeRef}.
+ */
+@Repeatable(OppgaveTypeRef.ContainerOfOppgaveTypeRef.class)
+@Qualifier
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+@Documented
+public @interface OppgaveTypeRef {
+
+    /**
+     * {@link Type}
+     */
+    Type value();
+
+
+    /**
+     * container for repeatable annotations.
+     *
+     * @see https://docs.oracle.com/javase/tutorial/java/annotations/repeating.html
+     */
+    @Inherited
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+    @Documented
+    public @interface ContainerOfOppgaveTypeRef {
+        OppgaveTypeRef[] value();
+    }
+
+    class OppgaveTypeRefLiteral extends AnnotationLiteral<OppgaveTypeRef> implements OppgaveTypeRef {
+
+        private final Type type;
+
+        OppgaveTypeRefLiteral(Type type) {
+            this.type = Objects.requireNonNull(type, "Type");
+        }
+
+        @Override
+        public Type value() {
+            return type;
+        }
+    }
+
+}

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/inntektrapportering/OppgittOpptjeningMapperTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/inntektrapportering/OppgittOpptjeningMapperTest.java
@@ -1,10 +1,21 @@
 package no.nav.ung.sak.mottak.dokumentmottak.inntektrapportering;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
 import no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.k9.søknad.felles.type.Periode;
-import no.nav.k9.søknad.ytelse.ung.v1.OppgittInntekt;
-import no.nav.k9.søknad.ytelse.ung.v1.OppgittInntektForPeriode;
+import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt;
+import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntektForPeriode;
 import no.nav.ung.kodeverk.behandling.BehandlingResultatType;
 import no.nav.ung.kodeverk.behandling.BehandlingStatus;
 import no.nav.ung.kodeverk.behandling.BehandlingType;
@@ -16,16 +27,6 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
-import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 
 class OppgittOpptjeningMapperTest {

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -35,7 +35,6 @@ import no.nav.ung.kodeverk.behandling.BehandlingType;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.sak.behandling.prosessering.task.FortsettBehandlingTask;
-import no.nav.ung.sak.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
@@ -51,8 +50,6 @@ class InntektBekreftelseHåndtererTest {
 
     @Inject
     private EntityManager em;
-    @Inject
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private EtterlysningRepository etterlysningRepository;
     private ProsessTaskTjeneste prosessTaskTjeneste;
 
@@ -66,7 +63,7 @@ class InntektBekreftelseHåndtererTest {
     }
 
     @Test
-    void skalOppdatereEtterlysningOppdatereIayGrunnlagLagreUttalelseOgSetteBehandlingAvVent() {
+    void skalOppdatereEtterlysningOppdatereIayGrunnlagOgSetteBehandlingAvVent() {
         // Arrange
         TestScenarioBuilder scenarioBuilder = TestScenarioBuilder.builderMedSøknad()
             .medBehandlingType(BehandlingType.REVURDERING);
@@ -103,7 +100,7 @@ class InntektBekreftelseHåndtererTest {
                         BigDecimal.valueOf(oppgittInntekt),
                         BigDecimal.ZERO)),
                     true,
-                    "uttalelse")
+                    "en uttalelse")
             ),
             LocalDateTime.now(),
             Brevkode.UNGDOMSYTELSE_OPPGAVE_BEKREFTELSE
@@ -112,6 +109,7 @@ class InntektBekreftelseHåndtererTest {
         // Act
         var inntektBekreftelseHåndterer = new InntektBekreftelseHåndterer(etterlysningRepository, prosessTaskTjeneste);
         inntektBekreftelseHåndterer.håndter(bekreftelse);
+        em.flush();
 
         // Assert
         //abakus er oppdatert
@@ -130,5 +128,12 @@ class InntektBekreftelseHåndtererTest {
         //etterlysning er oppdatert
         var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
         assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
+        assertThat(oppdatertEtterlysning.getSvarJournalpostId().getJournalpostId().getVerdi()).isEqualTo(String.valueOf(journalpostId));
+        assertThat(oppdatertEtterlysning.getUttalelse().getUttalelseTekst()).isEqualTo("en uttalelse");
+    }
+
+    @Test
+    void skalIkkeOppdatereGrunnlagVedUttalelse(){
+
     }
 }

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -128,6 +128,7 @@ class InntektBekreftelseHåndtererTest {
         //etterlysning er oppdatert
         var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
         assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
+        //TODO flytt denne til andre testen.
         assertThat(oppdatertEtterlysning.getSvarJournalpostId().getJournalpostId().getVerdi()).isEqualTo(String.valueOf(journalpostId));
         assertThat(oppdatertEtterlysning.getUttalelse().getUttalelseTekst()).isEqualTo("en uttalelse");
     }

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -1,20 +1,5 @@
 package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
@@ -31,11 +16,9 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker;
 import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.SøknadId;
-import no.nav.ung.kodeverk.behandling.BehandlingStegType;
 import no.nav.ung.kodeverk.behandling.BehandlingType;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
-import no.nav.ung.sak.behandling.prosessering.task.FortsettBehandlingTask;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
@@ -44,6 +27,20 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.mottak.dokumentmottak.AsyncAbakusLagreOpptjeningTask;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.typer.JournalpostId;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(CdiAwareExtension.class)
 @ExtendWith(JpaExtension.class)
@@ -108,11 +105,6 @@ class InntektBekreftelseHåndtererTest {
         assertThat(abakusTask.getPropertyValue(AsyncAbakusLagreOpptjeningTask.BREVKODER)).isEqualTo(Brevkode.UNGDOMSYTELSE_OPPGAVE_BEKREFTELSE.getKode());
         assertThat(abakusTask.getPayloadAsString()).contains(String.valueOf(oppgittInntekt));
 
-        //behandling taes av vent
-        var fortsettSteg = prosessTaskTjeneste.finnAlle(FortsettBehandlingTask.TASKTYPE, ProsessTaskStatus.KLAR);
-        assertThat(fortsettSteg).hasSize(1);
-        assertThat(fortsettSteg.getFirst().getPropertyValue(FortsettBehandlingTask.GJENOPPTA_STEG)).isEqualTo(BehandlingStegType.KONTROLLER_REGISTER_INNTEKT.getKode());
-
         //etterlysning er oppdatert
         var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
         assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
@@ -160,11 +152,6 @@ class InntektBekreftelseHåndtererTest {
         //abakus skal ikke oppdateres
         List<ProsessTaskData> abakusTasker = prosessTaskTjeneste.finnAlle(AsyncAbakusLagreOpptjeningTask.TASKTYPE, ProsessTaskStatus.KLAR);
         assertThat(abakusTasker).hasSize(0);
-
-        //behandling taes av vent
-        var fortsettSteg = prosessTaskTjeneste.finnAlle(FortsettBehandlingTask.TASKTYPE, ProsessTaskStatus.KLAR);
-        assertThat(fortsettSteg).hasSize(1);
-        assertThat(fortsettSteg.getFirst().getPropertyValue(FortsettBehandlingTask.GJENOPPTA_STEG)).isEqualTo(BehandlingStegType.KONTROLLER_REGISTER_INNTEKT.getKode());
 
         //etterlysning er oppdatert
         var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -1,0 +1,139 @@
+package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.k9.oppgave.OppgaveBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.inntekt.OppgittInntektForPeriode;
+import no.nav.k9.søknad.felles.Versjon;
+import no.nav.k9.søknad.felles.personopplysninger.Søker;
+import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer;
+import no.nav.k9.søknad.felles.type.Periode;
+import no.nav.k9.søknad.felles.type.SøknadId;
+import no.nav.ung.kodeverk.behandling.BehandlingStegType;
+import no.nav.ung.kodeverk.behandling.BehandlingType;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
+import no.nav.ung.sak.domene.iay.modell.InntektArbeidYtelseGrunnlag;
+import no.nav.ung.sak.domene.iay.modell.OppgittOpptjeningBuilder;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
+import no.nav.ung.sak.typer.JournalpostId;
+
+@ExtendWith(CdiAwareExtension.class)
+@ExtendWith(JpaExtension.class)
+class InntektBekreftelseHåndtererTest {
+
+    @Inject
+    private EntityManager em;
+    private EtterlysningRepository etterlysningRepository;
+    private AbakusInMemoryInntektArbeidYtelseTjeneste abakusInMemoryInntektArbeidYtelseTjeneste;
+
+
+    @BeforeEach
+    void setup() {
+        etterlysningRepository = new EtterlysningRepository(em);
+        abakusInMemoryInntektArbeidYtelseTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
+
+    }
+
+    @Test
+    void skalOppdatereEtterlysningOppdatereIayGrunnlagLagreUttalelseOgSetteBehandlingAvVent() {
+
+
+        // Arrange
+        TestScenarioBuilder scenarioBuilder = TestScenarioBuilder.builderMedSøknad()
+            .medBehandlingType(BehandlingType.REVURDERING);
+
+        scenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_ETTERLYST_INNTEKTUTTALELSE, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
+        Behandling behandling = scenarioBuilder.lagre(em);
+
+        var opptjening = OppgittOpptjeningBuilder.ny();
+        var periode = DatoIntervallEntitet.fra(LocalDate.now(), LocalDate.now());
+//        opptjening.leggTilOppgittArbeidsforhold(OppgittOpptjeningBuilder.OppgittArbeidsforholdBuilder.ny()
+//            .medInntekt(BigDecimal.valueOf(10000))
+//            .medPeriode(periode)
+//        );
+
+//        var oppdatere = InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonType.REGISTER);
+//        var aktørInntektBuilder = oppdatere.getAktørInntektBuilder(behandling.getAktørId());
+//        InntektBuilder oppdatere1 = InntektBuilder.oppdatere(Optional.empty());
+//        oppdatere1.leggTilInntektspost(InntektspostBuilder.ny()
+//            .medInntektspostType(InntektspostType.LØNN.getKode())
+//            .medBeløp(BigDecimal.valueOf(5000))
+//        );
+//
+//        InntektArbeidYtelseGrunnlagBuilder nytt = InntektArbeidYtelseGrunnlagBuilder.nytt();
+//        aktørInntektBuilder.leggTilInntekt(oppdatere1);
+//        nytt.medRegister(oppdatere);
+
+        abakusInMemoryInntektArbeidYtelseTjeneste.lagreOppgittOpptjening(
+            behandling.getId(),
+            opptjening
+        );
+
+        var oppgaveId = UUID.randomUUID();
+        var etterlysning = etterlysningRepository.lagre(EtterlysningEntitet.forInntektKontrollUttalelse(
+            behandling.getId(),
+            abakusInMemoryInntektArbeidYtelseTjeneste.hentGrunnlag(behandling.getId()).getEksternReferanse(),
+            oppgaveId,
+            periode));
+
+        etterlysning.vent(LocalDateTime.now().plusDays(1));
+        etterlysningRepository.lagre(etterlysning);
+        em.flush();
+
+
+        var bekreftelse = new OppgaveBekreftelseInnhold(
+            new JournalpostId(123L),
+            behandling,
+            new OppgaveBekreftelse(
+                new SøknadId("456"),
+                Versjon.of("1"),
+                ZonedDateTime.now(),
+                new Søker(NorskIdentitetsnummer.of("12345678910")),
+                new InntektBekreftelse(
+                    oppgaveId,
+                    Set.of(new OppgittInntektForPeriode(
+                        new Periode(periode.getFomDato(), periode.getTomDato()),
+                        BigDecimal.valueOf(10000),
+                        BigDecimal.ZERO)),
+                    true,
+                    "uttalelse")
+            )
+        );
+
+        // Act
+        new InntektBekreftelseHåndterer(etterlysningRepository).håndter(bekreftelse);
+
+        // Assert
+        var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
+        //etterlysning er oppdatert
+        assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
+        //behandling er ikke lenger på vent
+        assertThat(behandling.getAksjonspunkter()).isEmpty();
+        //abakus er oppdatert
+        InntektArbeidYtelseGrunnlag nyttGrunnlag = abakusInMemoryInntektArbeidYtelseTjeneste.hentGrunnlag(behandling.getId());
+        BigDecimal inntekt = nyttGrunnlag.getOppgittOpptjening().get().getOppgittArbeidsforhold().getFirst().getInntekt();
+        assertThat(inntekt).isEqualTo(BigDecimal.valueOf(10000));
+    }
+}

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -19,6 +20,11 @@ import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
 import no.nav.k9.oppgave.OppgaveBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.OppgittInntektForPeriode;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskStatus;
+import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.k9.prosesstask.impl.ProsessTaskRepositoryImpl;
+import no.nav.k9.prosesstask.impl.ProsessTaskTjenesteImpl;
 import no.nav.k9.søknad.felles.Versjon;
 import no.nav.k9.søknad.felles.personopplysninger.Søker;
 import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer;
@@ -27,15 +33,14 @@ import no.nav.k9.søknad.felles.type.SøknadId;
 import no.nav.ung.kodeverk.behandling.BehandlingStegType;
 import no.nav.ung.kodeverk.behandling.BehandlingType;
 import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
-import no.nav.ung.sak.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
-import no.nav.ung.sak.domene.iay.modell.InntektArbeidYtelseGrunnlag;
-import no.nav.ung.sak.domene.iay.modell.OppgittOpptjeningBuilder;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.mottak.dokumentmottak.AsyncAbakusLagreOpptjeningTask;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.typer.JournalpostId;
 
@@ -46,13 +51,14 @@ class InntektBekreftelseHåndtererTest {
     @Inject
     private EntityManager em;
     private EtterlysningRepository etterlysningRepository;
-    private AbakusInMemoryInntektArbeidYtelseTjeneste abakusInMemoryInntektArbeidYtelseTjeneste;
+    private ProsessTaskTjeneste prosessTaskTjeneste;
 
 
     @BeforeEach
     void setup() {
         etterlysningRepository = new EtterlysningRepository(em);
-        abakusInMemoryInntektArbeidYtelseTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
+        ProsessTaskRepositoryImpl prosessTaskRepository = new ProsessTaskRepositoryImpl(em, null, null);
+        prosessTaskTjeneste = new ProsessTaskTjenesteImpl(prosessTaskRepository);
 
     }
 
@@ -67,34 +73,12 @@ class InntektBekreftelseHåndtererTest {
         scenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_ETTERLYST_INNTEKTUTTALELSE, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
         Behandling behandling = scenarioBuilder.lagre(em);
 
-        var opptjening = OppgittOpptjeningBuilder.ny();
         var periode = DatoIntervallEntitet.fra(LocalDate.now(), LocalDate.now());
-//        opptjening.leggTilOppgittArbeidsforhold(OppgittOpptjeningBuilder.OppgittArbeidsforholdBuilder.ny()
-//            .medInntekt(BigDecimal.valueOf(10000))
-//            .medPeriode(periode)
-//        );
-
-//        var oppdatere = InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonType.REGISTER);
-//        var aktørInntektBuilder = oppdatere.getAktørInntektBuilder(behandling.getAktørId());
-//        InntektBuilder oppdatere1 = InntektBuilder.oppdatere(Optional.empty());
-//        oppdatere1.leggTilInntektspost(InntektspostBuilder.ny()
-//            .medInntektspostType(InntektspostType.LØNN.getKode())
-//            .medBeløp(BigDecimal.valueOf(5000))
-//        );
-//
-//        InntektArbeidYtelseGrunnlagBuilder nytt = InntektArbeidYtelseGrunnlagBuilder.nytt();
-//        aktørInntektBuilder.leggTilInntekt(oppdatere1);
-//        nytt.medRegister(oppdatere);
-
-        abakusInMemoryInntektArbeidYtelseTjeneste.lagreOppgittOpptjening(
-            behandling.getId(),
-            opptjening
-        );
-
         var oppgaveId = UUID.randomUUID();
+        var grunnlagsreferanse = UUID.randomUUID();
         var etterlysning = etterlysningRepository.lagre(EtterlysningEntitet.forInntektKontrollUttalelse(
             behandling.getId(),
-            abakusInMemoryInntektArbeidYtelseTjeneste.hentGrunnlag(behandling.getId()).getEksternReferanse(),
+            grunnlagsreferanse,
             oppgaveId,
             periode));
 
@@ -103,8 +87,10 @@ class InntektBekreftelseHåndtererTest {
         em.flush();
 
 
+        long journalpostId = 892L;
+        int oppgittInntekt = 56321;
         var bekreftelse = new OppgaveBekreftelseInnhold(
-            new JournalpostId(123L),
+            new JournalpostId(journalpostId),
             behandling,
             new OppgaveBekreftelse(
                 new SøknadId("456"),
@@ -115,25 +101,34 @@ class InntektBekreftelseHåndtererTest {
                     oppgaveId,
                     Set.of(new OppgittInntektForPeriode(
                         new Periode(periode.getFomDato(), periode.getTomDato()),
-                        BigDecimal.valueOf(10000),
+                        BigDecimal.valueOf(oppgittInntekt),
                         BigDecimal.ZERO)),
                     true,
                     "uttalelse")
-            )
+            ),
+            LocalDateTime.now(),
+            Brevkode.UNGDOMSYTELSE_OPPGAVE_BEKREFTELSE
         );
 
         // Act
-        new InntektBekreftelseHåndterer(etterlysningRepository).håndter(bekreftelse);
+        var inntektBekreftelseHåndterer = new InntektBekreftelseHåndterer(etterlysningRepository, prosessTaskTjeneste);
+        inntektBekreftelseHåndterer.håndter(bekreftelse);
 
         // Assert
-        var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
-        //etterlysning er oppdatert
-        assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
+        //abakus er oppdatert
+        List<ProsessTaskData> abakusTasker = prosessTaskTjeneste.finnAlle(AsyncAbakusLagreOpptjeningTask.TASKTYPE, ProsessTaskStatus.KLAR);
+        assertThat(abakusTasker).hasSize(1);
+        var abakusTask = abakusTasker.getFirst();
+        assertThat(abakusTask.getPropertyValue(AsyncAbakusLagreOpptjeningTask.JOURNALPOST_ID)).isEqualTo(String.valueOf(journalpostId));
+        assertThat(abakusTask.getPropertyValue(AsyncAbakusLagreOpptjeningTask.BREVKODER)).isEqualTo(Brevkode.UNGDOMSYTELSE_OPPGAVE_BEKREFTELSE.getKode());
+        assertThat(abakusTask.getPayloadAsString()).contains(String.valueOf(oppgittInntekt));
+
+
         //behandling er ikke lenger på vent
         assertThat(behandling.getAksjonspunkter()).isEmpty();
-        //abakus er oppdatert
-        InntektArbeidYtelseGrunnlag nyttGrunnlag = abakusInMemoryInntektArbeidYtelseTjeneste.hentGrunnlag(behandling.getId());
-        BigDecimal inntekt = nyttGrunnlag.getOppgittOpptjening().get().getOppgittArbeidsforhold().getFirst().getInntekt();
-        assertThat(inntekt).isEqualTo(BigDecimal.valueOf(10000));
+
+        //etterlysning er oppdatert
+        var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
+        assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
     }
 }

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -37,7 +37,7 @@ import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.sak.behandling.prosessering.task.FortsettBehandlingTask;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
-import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningEntitet;
+import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
@@ -75,7 +75,7 @@ class InntektBekreftelseHåndtererTest {
         var oppgaveId = UUID.randomUUID();
         var grunnlagsreferanse = UUID.randomUUID();
 
-        var etterlysning = etterlysningRepository.lagre(EtterlysningEntitet.forInntektKontrollUttalelse(
+        var etterlysning = etterlysningRepository.lagre(Etterlysning.forInntektKontrollUttalelse(
             behandling.getId(),
             grunnlagsreferanse,
             oppgaveId,
@@ -132,7 +132,7 @@ class InntektBekreftelseHåndtererTest {
         var oppgaveId = UUID.randomUUID();
         var grunnlagsreferanse = UUID.randomUUID();
 
-        var etterlysning = etterlysningRepository.lagre(EtterlysningEntitet.forInntektKontrollUttalelse(
+        var etterlysning = etterlysningRepository.lagre(Etterlysning.forInntektKontrollUttalelse(
             behandling.getId(),
             grunnlagsreferanse,
             oppgaveId,

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_022__uttalelse.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_022__uttalelse.sql
@@ -1,0 +1,21 @@
+create table uttalelse
+(
+    id              bigint      not null primary key,
+    uttalelse      text        not null,
+    etterlysning_id bigint      not null references etterlysning (id),
+    opprettet_tid   timestamp            default CURRENT_TIMESTAMP not null,
+    opprettet_av    varchar(20) not null default 'VL',
+    endret_av       varchar(20),
+    endret_tid      timestamp
+);
+
+create sequence if not exists seq_uttalelse increment by 50 minvalue 1000000;
+
+comment on table uttalelse is 'Inneholder uttalelser typisk ved uenigheter på etterlysninger';
+comment on column uttalelse.uttalelse is 'Uttalelsetekst';
+
+alter table etterlysning add svar_journalpost_id varchar(20);
+comment on column etterlysning.svar_journalpost_id is 'journalpost_id for svar på etterlysning';
+
+create unique index idx_etterlysning_ekstern_ref on etterlysning (ekstern_ref);
+

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <felles.version>4.4.16</felles.version>
         <swagger.version>2.2.29</swagger.version>
         <junit.version>5.12.0</junit.version>
-        <k9format.version>qadeer-ung-SNAPSHOT</k9format.version>
+        <k9format.version>11.4.3</k9format.version>
         <jackson.version>2.18.3</jackson.version>
         <asm.version>9.7.1</asm.version>
         <kotlin-stdlib.version>2.1.10</kotlin-stdlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <felles.version>4.4.16</felles.version>
         <swagger.version>2.2.29</swagger.version>
         <junit.version>5.12.0</junit.version>
-        <k9format.version>11.4.2</k9format.version>
+        <k9format.version>qadeer-ung-SNAPSHOT</k9format.version>
         <jackson.version>2.18.3</jackson.version>
         <asm.version>9.7.1</asm.version>
         <kotlin-stdlib.version>2.1.10</kotlin-stdlib.version>


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ta i mot bekreftelser på inntektetterlysninger/oppgaver, oppdatere oppgitte inntekter og fortsette behandling. 
### **Løsning**
- Felles håndtering av bekreftelser på etterlysninger
- Bruker task for å oppdatere abakus
- Dokumenthåndtering spoler behandlingen tilbake til start og løser autopunkt (gjøre av eksisterende kode)