### PR TITLE
TSFF-1275: Legger til manglende triggere

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -55,6 +55,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     private EtterlysningRepository etterlysningRepository;
     private InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste;
     private ProsessTaskTjeneste prosessTaskTjeneste;
+    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
 
 
 
@@ -65,7 +66,8 @@ public class KontrollerInntektSteg implements BehandlingSteg {
                                  BehandlingRepository behandlingRepository,
                                  EtterlysningRepository etterlysningRepository,
                                  InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste,
-                                 ProsessTaskTjeneste prosessTaskTjeneste) {
+                                 ProsessTaskTjeneste prosessTaskTjeneste,
+                                 ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste) {
         this.prosessTriggerPeriodeUtleder = prosessTriggerPeriodeUtleder;
         this.rapportertInntektMapper = rapportertInntektMapper;
         this.kontrollerteInntektperioderTjeneste = kontrollerteInntektperioderTjeneste;
@@ -73,6 +75,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
         this.etterlysningRepository = etterlysningRepository;
         this.inntektArbeidYtelseTjeneste = inntektArbeidYtelseTjeneste;
         this.prosessTaskTjeneste = prosessTaskTjeneste;
+        this.manglendeKontrollperioderTjeneste = manglendeKontrollperioderTjeneste;
     }
 
     public KontrollerInntektSteg() {
@@ -81,8 +84,11 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         Long behandlingId = kontekst.getBehandlingId();
-        var rapporterteInntekterTidslinje = rapportertInntektMapper.mapAlleGjeldendeRegisterOgBrukersInntekter(behandlingId);
+        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandlingId);
+
         var prosessTriggerTidslinje = prosessTriggerPeriodeUtleder.utledTidslinje(behandlingId);
+
+        var rapporterteInntekterTidslinje = rapportertInntektMapper.mapAlleGjeldendeRegisterOgBrukersInntekter(behandlingId);
         var etterlysninger = etterlysningRepository.hentEtterlysninger(kontekst.getBehandlingId(), EtterlysningType.UTTALELSE_KONTROLL_INNTEKT);
 
         var etterlysningsperioder = etterlysninger.stream()

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -84,6 +84,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         Long behandlingId = kontekst.getBehandlingId();
+        // Må legge til manglende triggere før resten av steget kjøres
         manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandlingId);
 
         var prosessTriggerTidslinje = prosessTriggerPeriodeUtleder.utledTidslinje(behandlingId);

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjeneste.java
@@ -1,0 +1,100 @@
+package no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.perioder.ProsessTriggerPeriodeUtleder;
+import no.nav.ung.sak.trigger.ProsessTriggereRepository;
+import no.nav.ung.sak.trigger.Trigger;
+import no.nav.ung.sak.ytelse.KontrollerteInntektperioderTjeneste;
+import no.nav.ung.sak.ytelseperioder.YtelseperiodeUtleder;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static no.nav.ung.sak.domene.typer.tid.AbstractLocalDateInterval.TIDENES_BEGYNNELSE;
+
+@Dependent
+public class ManglendeKontrollperioderTjeneste {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManglendeKontrollperioderTjeneste.class);
+
+    public static final int RAPPORTERINGSFRIST_I_MÅNED = 7;
+    private KontrollerteInntektperioderTjeneste kontrollerteInntektperioderTjeneste;
+    private YtelseperiodeUtleder ytelseperiodeUtleder;
+    private ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder;
+    private ProsessTriggereRepository prosessTriggereRepository;
+
+    @Inject
+    public ManglendeKontrollperioderTjeneste(KontrollerteInntektperioderTjeneste kontrollerteInntektperioderTjeneste,
+                                             YtelseperiodeUtleder ytelseperiodeUtleder,
+                                             ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder, ProsessTriggereRepository prosessTriggereRepository) {
+        this.kontrollerteInntektperioderTjeneste = kontrollerteInntektperioderTjeneste;
+        this.ytelseperiodeUtleder = ytelseperiodeUtleder;
+        this.prosessTriggerPeriodeUtleder = prosessTriggerPeriodeUtleder;
+        this.prosessTriggereRepository = prosessTriggereRepository;
+    }
+
+    /** Legger til triggere for kontroll der denne mangler
+     * Dette kan skje dersom programperioden er flyttet langt nok tilbake i tid eller at første søknad er sendt inn etter at rapporteringsfristen for andre måned er passert.
+     * @param behandlingId BehandlingId
+     */
+    public void leggTilManglendeKontrollTriggere(Long behandlingId) {
+        final var ytelsesPerioder = ytelseperiodeUtleder.utledYtelsestidslinje(behandlingId);
+        final var påkrevdKontrollTidslinje = finnPerioderSomSkalKontrolleres(ytelsesPerioder);
+        final var passertRapporteringsfristTidslinje = finnPerioderMedPassertRapporteringsfrist();
+        final var markertForKontrollTidslinje = finnPerioderMarkertForKontroll(behandlingId);
+        var utførtKontrollTidslinje = finnPerioderSomErKontrollertITidligereBehandlinger(behandlingId);
+        final var manglendeKontrollTidslinje = påkrevdKontrollTidslinje.disjoint(utførtKontrollTidslinje).disjoint(markertForKontrollTidslinje).intersection(passertRapporteringsfristTidslinje);
+
+        final var manglendeTriggere = mapTilProsessTriggere(manglendeKontrollTidslinje);
+
+        if (!manglendeTriggere.isEmpty()) {
+            LOG.info("Legger til manglende triggere for kontroll: {}", manglendeTriggere);
+            prosessTriggereRepository.leggTil(behandlingId, manglendeTriggere);
+        }
+    }
+
+    private static Set<Trigger> mapTilProsessTriggere(LocalDateTimeline<Boolean> manglendeKontrollTidslinje) {
+        final var manglendeTriggere = manglendeKontrollTidslinje.compress().getLocalDateIntervals().stream()
+            .map(di -> new Trigger(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT, DatoIntervallEntitet.fra(di)))
+            .collect(Collectors.toSet());
+        return manglendeTriggere;
+    }
+
+    private LocalDateTimeline<Set<BehandlingÅrsakType>> finnPerioderMarkertForKontroll(Long behandlingId) {
+        return prosessTriggerPeriodeUtleder.utledTidslinje(behandlingId).filterValue(it -> it.contains(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT));
+    }
+
+    private LocalDateTimeline<Boolean> finnPerioderSomErKontrollertITidligereBehandlinger(Long behandlingId) {
+        return kontrollerteInntektperioderTjeneste.hentTidslinje(behandlingId).mapValue(it -> true);
+    }
+
+    private static LocalDateTimeline<Boolean> finnPerioderMedPassertRapporteringsfrist() {
+        return new LocalDateTimeline<>(TIDENES_BEGYNNELSE, getTomDatoForPassertRapporteringsfrist(), true);
+    }
+
+    private static LocalDateTimeline<Boolean> finnPerioderSomSkalKontrolleres(LocalDateTimeline<Boolean> ytelsesPerioder) {
+        LocalDateTimeline<Boolean> perioderForKontroll = LocalDateTimeline.empty();
+        if (ytelsesPerioder.toSegments().size() > 2) {
+            final var segmenterForKontroll = ytelsesPerioder.toSegments();
+            segmenterForKontroll.removeFirst();
+            segmenterForKontroll.removeLast();
+            perioderForKontroll = new LocalDateTimeline<>(segmenterForKontroll);
+        }
+        return perioderForKontroll;
+    }
+
+    private static LocalDate getTomDatoForPassertRapporteringsfrist() {
+        final var dagensDato = LocalDate.now();
+        return dagensDato.getDayOfMonth() < RAPPORTERINGSFRIST_I_MÅNED ? dagensDato.minusMonths(2).with(TemporalAdjusters.lastDayOfMonth()) : dagensDato.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+    }
+
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det finnes to scenarioer der vi kan mangle kontrolltrigger for en periode
1) Dersom startdato for en programperiode er flyttet tilstrekkelig langt nok tilbake i tid
2) Dersom søknad er sendt inn etter at rapporteringsfrist for andre måned er passert

### **Løsning**
Legge til manglende trigger før resten av kontrollsteget kjøres
