### PR TITLE
TSFF-1188: Utvider vurdert periode til hele tidslinjen. Dersom det ikke finnes rapportert inntekt eller registerinntekt går vi videre med "brukers inntekt" (0 kr)

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/Avviksvurdering.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/Avviksvurdering.java
@@ -75,7 +75,7 @@ public class Avviksvurdering {
                     return KontrollResultat.BRUK_INNTEKT_FRA_BRUKER;
                 }
             });
-        return inntektDiffKontrollResultat;
+        return inntektDiffKontrollResultat.crossJoin(tidslinjeRelevanteÅrsaker.mapValue(it -> KontrollResultat.BRUK_INNTEKT_FRA_BRUKER), StandardCombinators::coalesceLeftHandSide);
     }
 
 

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjenesteTest.java
@@ -158,6 +158,23 @@ class KontrollerInntektTjenesteTest {
         assertEquals(new LocalDateTimeline<>(fom, tom, KontrollResultat.OPPRETT_AKSJONSPUNKT), resultat);
     }
 
+    @Test
+    void skal_gå_videre_med_brukers_inntekt_dersom_ingen_inntekt_i_register_eller_rapportert_fra_bruker() {
+        // Arrange
+        final var fom = LocalDate.now().minusDays(10);
+        final var tom = LocalDate.now().plusDays(10);
+        LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
+        final var gjeldendeRapporterteInntekter = new LocalDateTimeline<RapporterteInntekter>(Set.of());
+        LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
+
+        // Act
+        var resultat = KontrollerInntektTjeneste.utførKontroll(prosessTriggerTidslinje, gjeldendeRapporterteInntekter, ikkeGodkjentUttalelseTidslinje);
+
+        // Assert
+        assertEquals(new LocalDateTimeline<>(fom, tom, KontrollResultat.BRUK_INNTEKT_FRA_BRUKER), resultat);
+    }
+
+
 
 
     private static LocalDateTimeline<Set<BehandlingÅrsakType>> lagProsesstriggerTidslinjeForInntektRapportering(LocalDate fom, LocalDate tom) {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom det ikke finnes rapportert intekt eller registerinntekt skal vi gå videre med valg om å bruke brukers inntekt (altså 0kr)

### **Løsning**
Utvider med crossjoin i avviksvurderer og legger på årsak
