### PR TITLE
TSFF-1279: Oppretter revurdering etter iverksettelse i staden for å ta inn kontroll i førstegangsbehandling

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -26,7 +26,6 @@ import no.nav.ung.sak.perioder.ProsessTriggerPeriodeUtleder;
 import no.nav.ung.sak.uttalelse.EtterlysningInfo;
 import no.nav.ung.sak.uttalelse.EtterlysningsPeriode;
 import no.nav.ung.sak.ytelse.KontrollerteInntektperioderTjeneste;
-import no.nav.ung.sak.ytelse.ManglendeKontrollperioderTjeneste;
 import no.nav.ung.sak.ytelse.RapportertInntektMapper;
 import no.nav.ung.sak.ytelse.RapporterteInntekter;
 import org.slf4j.Logger;

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -26,6 +26,7 @@ import no.nav.ung.sak.perioder.ProsessTriggerPeriodeUtleder;
 import no.nav.ung.sak.uttalelse.EtterlysningInfo;
 import no.nav.ung.sak.uttalelse.EtterlysningsPeriode;
 import no.nav.ung.sak.ytelse.KontrollerteInntektperioderTjeneste;
+import no.nav.ung.sak.ytelse.ManglendeKontrollperioderTjeneste;
 import no.nav.ung.sak.ytelse.RapportertInntektMapper;
 import no.nav.ung.sak.ytelse.RapporterteInntekter;
 import org.slf4j.Logger;
@@ -55,7 +56,6 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     private EtterlysningRepository etterlysningRepository;
     private InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste;
     private ProsessTaskTjeneste prosessTaskTjeneste;
-    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
 
 
 
@@ -66,8 +66,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
                                  BehandlingRepository behandlingRepository,
                                  EtterlysningRepository etterlysningRepository,
                                  InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste,
-                                 ProsessTaskTjeneste prosessTaskTjeneste,
-                                 ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste) {
+                                 ProsessTaskTjeneste prosessTaskTjeneste) {
         this.prosessTriggerPeriodeUtleder = prosessTriggerPeriodeUtleder;
         this.rapportertInntektMapper = rapportertInntektMapper;
         this.kontrollerteInntektperioderTjeneste = kontrollerteInntektperioderTjeneste;
@@ -75,7 +74,6 @@ public class KontrollerInntektSteg implements BehandlingSteg {
         this.etterlysningRepository = etterlysningRepository;
         this.inntektArbeidYtelseTjeneste = inntektArbeidYtelseTjeneste;
         this.prosessTaskTjeneste = prosessTaskTjeneste;
-        this.manglendeKontrollperioderTjeneste = manglendeKontrollperioderTjeneste;
     }
 
     public KontrollerInntektSteg() {
@@ -84,9 +82,6 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         Long behandlingId = kontekst.getBehandlingId();
-        // Må legge til manglende triggere før resten av steget kjøres
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandlingId);
-
         var prosessTriggerTidslinje = prosessTriggerPeriodeUtleder.utledTidslinje(behandlingId);
 
         var rapporterteInntekterTidslinje = rapportertInntektMapper.mapAlleGjeldendeRegisterOgBrukersInntekter(behandlingId);

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjenesteTest.java
@@ -2,7 +2,8 @@ package no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll;
 
 import jakarta.inject.Inject;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
-import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.impl.ProsessTaskRepositoryImpl;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -20,12 +21,13 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.perioder.ProsessTriggerPeriodeUtleder;
 import no.nav.ung.sak.perioder.UngdomsytelseSøknadsperiodeTjeneste;
 import no.nav.ung.sak.trigger.ProsessTriggereRepository;
-import no.nav.ung.sak.trigger.Trigger;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
+import no.nav.ung.sak.typer.Periode;
 import no.nav.ung.sak.typer.Saksnummer;
 import no.nav.ung.sak.ungdomsprogram.UngdomsprogramPeriodeTjeneste;
 import no.nav.ung.sak.ytelse.KontrollerteInntektperioderTjeneste;
+import no.nav.ung.sak.ytelse.ManglendeKontrollperioderTjeneste;
 import no.nav.ung.sak.ytelseperioder.YtelseperiodeUtleder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,8 +35,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -54,6 +59,8 @@ class ManglendeKontrollperioderTjenesteTest {
     private UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository;
     @Inject
     private FagsakRepository fagsakRepository;
+    @Inject
+    private ProsessTaskRepositoryImpl prosessTaskRepository;
     private Behandling behandling;
     private ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder;
     private KontrollerteInntektperioderTjeneste kontrollerteInntektperioderTjeneste;
@@ -80,7 +87,9 @@ class ManglendeKontrollperioderTjenesteTest {
     @Test
     void skal_ikke_legge_til_trigger_dersom_kun_en_måned() {
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, prosessTriggereRepository, 6);
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste,
+                ytelseperiodeUtleder,
+                prosessTriggerPeriodeUtleder, 6);
 
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(2).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().minusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
@@ -88,16 +97,15 @@ class ManglendeKontrollperioderTjenesteTest {
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(startdatoUngdomsprogram, new JournalpostId(1L))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(startdatoUngdomsprogram, sluttdatoUngdomsprogram)));
 
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandling.getId());
+        final var prosessTaskData = manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId());
 
-        final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
-        assertThat(prosessTriggere.isEmpty()).isTrue();
+        assertThat(prosessTaskData.isEmpty()).isTrue();
     }
 
     @Test
     void skal_ikke_legge_til_trigger_dersom_programdeltakelse_over_to_måneder() {
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, prosessTriggereRepository, 6);
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, 6);
 
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(3).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().minusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
@@ -105,16 +113,15 @@ class ManglendeKontrollperioderTjenesteTest {
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(startdatoUngdomsprogram, new JournalpostId(1L))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(startdatoUngdomsprogram, sluttdatoUngdomsprogram)));
 
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandling.getId());
+        final var prosessTaskData = manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId());
 
-        final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
-        assertThat(prosessTriggere.isEmpty()).isTrue();
+        assertThat(prosessTaskData.isEmpty()).isTrue();
     }
 
     @Test
     void skal_legge_til_trigger_for_måned_nr_to_dersom_programdeltakelse_over_tre_måneder_og_passert_rapporteringsfrist() {
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, prosessTriggereRepository, 6);
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, 6);
 
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(4).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().minusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
@@ -122,15 +129,13 @@ class ManglendeKontrollperioderTjenesteTest {
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(startdatoUngdomsprogram, new JournalpostId(1L))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(startdatoUngdomsprogram, sluttdatoUngdomsprogram)));
 
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandling.getId());
+        final var prosessTaskData = manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId());
 
-        final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
-        assertThat(prosessTriggere.isEmpty()).isFalse();
-        final var triggere = prosessTriggere.get().getTriggere();
-        assertThat(triggere.size()).isEqualTo(1);
-        final var nyTrigger = triggere.iterator().next();
+        assertThat(prosessTaskData.isEmpty()).isFalse();
+        final var perioder = parseToPeriodeSet(prosessTaskData.get().getPropertyValue("perioder"));
+        assertThat(perioder.size()).isEqualTo(1);
         final var månedNrTre = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(3).withDayOfMonth(1), LocalDate.now().minusMonths(3).with(TemporalAdjusters.lastDayOfMonth()));
-        assertThat(nyTrigger.getPeriode()).isEqualTo(månedNrTre);
+        assertThat(perioder.getFirst()).isEqualTo(månedNrTre);
     }
 
     @Test
@@ -138,13 +143,13 @@ class ManglendeKontrollperioderTjenesteTest {
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(2).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().with(TemporalAdjusters.lastDayOfMonth());
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, prosessTriggereRepository, LocalDate.now().getDayOfMonth());
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, LocalDate.now().getDayOfMonth());
 
 
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(startdatoUngdomsprogram, new JournalpostId(1L))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(startdatoUngdomsprogram, sluttdatoUngdomsprogram)));
 
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandling.getId());
+        manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId());
 
         final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
         assertThat(prosessTriggere.isEmpty()).isTrue();
@@ -156,27 +161,25 @@ class ManglendeKontrollperioderTjenesteTest {
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(2).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().with(TemporalAdjusters.lastDayOfMonth());
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, prosessTriggereRepository, LocalDate.now().getDayOfMonth()-1);
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, LocalDate.now().getDayOfMonth()-1);
 
 
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(startdatoUngdomsprogram, new JournalpostId(1L))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(startdatoUngdomsprogram, sluttdatoUngdomsprogram)));
 
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandling.getId());
+        final var prosessTaskData = manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId());
 
-        final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
-        assertThat(prosessTriggere.isEmpty()).isFalse();
-        final var triggere = prosessTriggere.get().getTriggere();
-        assertThat(triggere.size()).isEqualTo(1);
-        final var nyTrigger = triggere.iterator().next();
+        assertThat(prosessTaskData.isEmpty()).isFalse();
+        final var perioder = parseToPeriodeSet(prosessTaskData.get().getPropertyValue("perioder"));
+        assertThat(perioder.size()).isEqualTo(1);
         final var månedNrTre = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(1).withDayOfMonth(1), LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth()));
-        assertThat(nyTrigger.getPeriode()).isEqualTo(månedNrTre);
+        assertThat(perioder.getFirst()).isEqualTo(månedNrTre);
     }
 
     @Test
     void skal_ikke_legge_til_trigger_dersom_allerede_kontrollert() {
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, prosessTriggereRepository, 6);
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, 6);
 
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(4).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().minusMonths(2).with(TemporalAdjusters.lastDayOfMonth());
@@ -186,7 +189,7 @@ class ManglendeKontrollperioderTjenesteTest {
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(startdatoUngdomsprogram, sluttdatoUngdomsprogram)));
         tilkjentYtelseRepository.lagre(behandling.getId(), List.of(KontrollertInntektPeriode.ny().medPeriode(månedNrTre).medKilde(KontrollertInntektKilde.BRUKER).medErManueltVurdert(false).build()));
 
-        manglendeKontrollperioderTjeneste.leggTilManglendeKontrollTriggere(behandling.getId());
+        manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId());
 
         final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
         assertThat(prosessTriggere.isEmpty()).isTrue();
@@ -200,6 +203,10 @@ class ManglendeKontrollperioderTjenesteTest {
         behandling = Behandling.forFørstegangssøknad(fagsak).build();
         behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
         return behandling.getId();
+    }
+
+    private TreeSet<DatoIntervallEntitet> parseToPeriodeSet(String perioderString) {
+        return Arrays.stream(perioderString.split("\\|")).map(Periode::new).map(DatoIntervallEntitet::fra).collect(Collectors.toCollection(TreeSet::new));
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjenesteTest.java
@@ -2,8 +2,6 @@ package no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll;
 
 import jakarta.inject.Inject;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
-import no.nav.k9.prosesstask.api.ProsessTaskData;
-import no.nav.k9.prosesstask.impl.ProsessTaskRepositoryImpl;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -37,7 +35,6 @@ import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -59,8 +56,6 @@ class ManglendeKontrollperioderTjenesteTest {
     private UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository;
     @Inject
     private FagsakRepository fagsakRepository;
-    @Inject
-    private ProsessTaskRepositoryImpl prosessTaskRepository;
     private Behandling behandling;
     private ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder;
     private KontrollerteInntektperioderTjeneste kontrollerteInntektperioderTjeneste;
@@ -74,14 +69,7 @@ class ManglendeKontrollperioderTjenesteTest {
         prosessTriggerPeriodeUtleder = new ProsessTriggerPeriodeUtleder(prosessTriggereRepository, ungdomsytelseSøknadsperiodeTjeneste);
         kontrollerteInntektperioderTjeneste = new KontrollerteInntektperioderTjeneste(tilkjentYtelseRepository);
         ytelseperiodeUtleder = new YtelseperiodeUtleder(ungdomsprogramPeriodeTjeneste, behandlingRepository);
-
-
-
         lagFagsakOgBehandling(LocalDate.now().minusMonths(6));
-
-
-
-
     }
 
     @Test
@@ -161,7 +149,7 @@ class ManglendeKontrollperioderTjenesteTest {
         final var startdatoUngdomsprogram = LocalDate.now().minusMonths(2).withDayOfMonth(1);
         final var sluttdatoUngdomsprogram = LocalDate.now().with(TemporalAdjusters.lastDayOfMonth());
 
-        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, LocalDate.now().getDayOfMonth()-1);
+        var manglendeKontrollperioderTjeneste = new ManglendeKontrollperioderTjeneste(behandlingRepository, kontrollerteInntektperioderTjeneste, ytelseperiodeUtleder, prosessTriggerPeriodeUtleder, LocalDate.now().getDayOfMonth() - 1);
 
 
         ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(startdatoUngdomsprogram, new JournalpostId(1L))));
@@ -194,7 +182,6 @@ class ManglendeKontrollperioderTjenesteTest {
         final var prosessTriggere = prosessTriggereRepository.hentGrunnlag(behandling.getId());
         assertThat(prosessTriggere.isEmpty()).isTrue();
     }
-
 
 
     private Long lagFagsakOgBehandling(LocalDate fom) {

--- a/domenetjenester/beregning-ytelse/pom.xml
+++ b/domenetjenester/beregning-ytelse/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>etterlysning</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>no.nav.ung.sak</groupId>
+            <artifactId>behandling-revurdering</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/ManglendeKontrollperioderTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/ManglendeKontrollperioderTjeneste.java
@@ -65,7 +65,7 @@ public class ManglendeKontrollperioderTjeneste {
         var utførtKontrollTidslinje = finnPerioderSomErKontrollertITidligereBehandlinger(behandlingId);
         final var manglendeKontrollTidslinje = påkrevdKontrollTidslinje.disjoint(utførtKontrollTidslinje).disjoint(markertForKontrollTidslinje).intersection(passertRapporteringsfristTidslinje);
 
-        final var perioderMedManglendeKontroll = mapTilProsessTriggere(manglendeKontrollTidslinje, ytelsesPerioder);
+        final var perioderMedManglendeKontroll = splittPåYtelsesperioder(manglendeKontrollTidslinje, ytelsesPerioder);
 
         if (!perioderMedManglendeKontroll.isEmpty()) {
             final var behandling = behandlingRepository.hentBehandling(behandlingId);
@@ -88,7 +88,7 @@ public class ManglendeKontrollperioderTjeneste {
     }
 
 
-    private static Set<LocalDateInterval> mapTilProsessTriggere(LocalDateTimeline<Boolean> manglendeKontrollTidslinje, LocalDateTimeline<Boolean> ytelsesPerioder) {
+    private static Set<LocalDateInterval> splittPåYtelsesperioder(LocalDateTimeline<Boolean> manglendeKontrollTidslinje, LocalDateTimeline<Boolean> ytelsesPerioder) {
         return manglendeKontrollTidslinje.compress()
             .combine(ytelsesPerioder, StandardCombinators::leftOnly, LocalDateTimeline.JoinStyle.LEFT_JOIN)
             .getLocalDateIntervals();

--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/iverksett/UngdomsytelseOpprettProsessTaskIverksett.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/iverksett/UngdomsytelseOpprettProsessTaskIverksett.java
@@ -19,6 +19,7 @@ import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakProsessTaskRepository;
 import no.nav.ung.sak.domene.vedtak.intern.AvsluttBehandlingTask;
 import no.nav.ung.sak.hendelse.stønadstatistikk.StønadstatistikkService;
+import no.nav.ung.sak.ytelse.ManglendeKontrollperioderTjeneste;
 import no.nav.ung.sak.økonomi.SendØkonomiOppdragTask;
 
 @ApplicationScoped
@@ -27,6 +28,7 @@ public class UngdomsytelseOpprettProsessTaskIverksett implements OpprettProsessT
 
     protected FagsakProsessTaskRepository fagsakProsessTaskRepository;
     private StønadstatistikkService stønadstatistikkService;
+    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
 
     protected UngdomsytelseOpprettProsessTaskIverksett() {
         // for CDI proxy
@@ -34,9 +36,10 @@ public class UngdomsytelseOpprettProsessTaskIverksett implements OpprettProsessT
 
     @Inject
     public UngdomsytelseOpprettProsessTaskIverksett(FagsakProsessTaskRepository fagsakProsessTaskRepository,
-                                                    StønadstatistikkService stønadstatistikkService) {
+                                                    StønadstatistikkService stønadstatistikkService, ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste) {
         this.fagsakProsessTaskRepository = fagsakProsessTaskRepository;
         this.stønadstatistikkService = stønadstatistikkService;
+        this.manglendeKontrollperioderTjeneste = manglendeKontrollperioderTjeneste;
     }
 
     @Override
@@ -58,6 +61,7 @@ public class UngdomsytelseOpprettProsessTaskIverksett implements OpprettProsessT
 
         taskData.addNesteParallell(parallelle);
         taskData.addNesteSekvensiell(ProsessTaskData.forProsessTask(AvsluttBehandlingTask.class));
+        manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId()).ifPresent(taskData::addNesteSekvensiell);
         taskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
 
         taskData.setCallIdFraEksisterende();

--- a/migreringer/src/test/java/no/nav/ung/sak/db/util/Databaseskjemainitialisering.java
+++ b/migreringer/src/test/java/no/nav/ung/sak/db/util/Databaseskjemainitialisering.java
@@ -34,8 +34,6 @@ public final class Databaseskjemainitialisering {
             var location = "/db/postgres/";
 
             ClassicConfiguration conf = new ClassicConfiguration();
-
-
             conf.setDataSource(createDs(USER));
             conf.setLocationsAsStrings(location);
             conf.setBaselineOnMigrate(true);

--- a/migreringer/src/test/java/no/nav/ung/sak/db/util/Databaseskjemainitialisering.java
+++ b/migreringer/src/test/java/no/nav/ung/sak/db/util/Databaseskjemainitialisering.java
@@ -34,6 +34,8 @@ public final class Databaseskjemainitialisering {
             var location = "/db/postgres/";
 
             ClassicConfiguration conf = new ClassicConfiguration();
+
+
             conf.setDataSource(createDs(USER));
             conf.setLocationsAsStrings(location);
             conf.setBaselineOnMigrate(true);


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved endring av startdato tilbake i tid eller der bruker har søkt for seint ønsker vi å opprette kontroll av inntekt som en egen behandling for å redusere det som vurderes i kvar  behandling. Dette gjer brevet enklare samt åpner opp for at vi kan utbetale for første periode der bruker har søkt seint.

### **Løsning**
Oppretter task for revurdering etter iverksettelse dersom det er behov for kontroll.
