### PR TITLE
TSFF-1287: Håndterer bekreftelse inntekt for ulike måneder i samme behandling

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/TilkjentYtelseRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/TilkjentYtelseRepository.java
@@ -89,6 +89,7 @@ public class TilkjentYtelseRepository {
         if (eksisterende.isPresent()) {
             eksisterende.get().setIkkeAktiv();
             entityManager.persist(eksisterende.get());
+            entityManager.flush();
         }
         final var ny = TilkjentYtelse.ny(behandlingId)
             .medPerioder(perioder)

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -97,7 +97,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
         var kontrollResultat = KontrollerInntektTjeneste.utførKontroll(prosessTriggerTidslinje, rapporterteInntekterTidslinje, registerinntekterForEtterlysninger);
 
         log.info("Kontrollresultat ble {}", kontrollResultat.toSegments());
-        håndterPeriodisertKontrollresultat(kontekst, kontrollResultat, rapporterteInntekterTidslinje, prosessTriggerTidslinje, etterlysninger);
+        håndterPeriodisertKontrollresultat(kontekst, kontrollResultat, rapporterteInntekterTidslinje, etterlysninger);
         return avgjørResultat(behandlingId, kontrollResultat, prosessTriggerTidslinje);
     }
 
@@ -116,7 +116,6 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     private void håndterPeriodisertKontrollresultat(BehandlingskontrollKontekst kontekst,
                                                     LocalDateTimeline<KontrollResultat> kontrollResultat,
                                                     LocalDateTimeline<RapporterteInntekter> rapporterteInntekterTidslinje,
-                                                    LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje,
                                                     List<Etterlysning> etterlysninger) {
         List<Etterlysning> etterlysningerSomSkalAvbrytes = new ArrayList<>();
         List<Etterlysning> etterlysningerSomSkalOpprettes = new ArrayList<>();
@@ -128,8 +127,9 @@ public class KontrollerInntektSteg implements BehandlingSteg {
                     etterlysningerSomSkalAvbrytes.addAll(avbrytDersomEksisterendeEtterlysning(etterlysninger, kontrollSegment));
                     kontrollerteInntektperioderTjeneste.opprettKontrollerteInntekterPerioderFraBruker(
                         kontekst.getBehandlingId(),
-                        rapporterteInntekterTidslinje.mapValue(RapporterteInntekter::brukerRapporterteInntekter).intersection(kontrollSegment.getLocalDateInterval()),
-                        prosessTriggerTidslinje);
+                        kontrollSegment.getLocalDateInterval(),
+                        rapporterteInntekterTidslinje.mapValue(RapporterteInntekter::brukerRapporterteInntekter).intersection(kontrollSegment.getLocalDateInterval())
+                    );
                 }
                 case OPPRETT_OPPGAVE_TIL_BRUKER_MED_NY_FRIST -> {
                     log.info("Oppretter ny etterlysning med utvidet frist for periode {}", kontrollSegment.getLocalDateInterval());


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det skal være mulig for bruker å få flere oppgaver om inntekt og disse skal kunne bekreftes innenfor samme behandling.

### **Løsning**
Lagrer kun kontrollperiode for det aktuelle segmentet i kontrollresultatet (ikke hele tidslinjen til vurdering)
