### PR TITLE
Utvider UngOppgaveKlient med nye metoder.

### DIFF
--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/UngOppgaveKlient.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/UngOppgaveKlient.java
@@ -6,6 +6,7 @@ import no.nav.k9.felles.integrasjon.rest.OidcRestClient;
 import no.nav.k9.felles.integrasjon.rest.ScopedRestIntegration;
 import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO;
+import no.nav.ung.deltakelseopplyser.kontrakt.veileder.EndrePeriodeDatoDTO;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,17 +16,22 @@ import java.util.UUID;
 @ScopedRestIntegration(scopeKey = "ungdomsprogramregister.scope", defaultScope = "api://prod-gcp.k9saksbehandling.ung-deltakelse-opplyser/.default")
 public class UngOppgaveKlient {
     private final OidcRestClient restClient;
-    private final URI opprettURI;
+    private final URI opprettKontrollerRegisterInntektURI;
     private final URI avbrytURI;
+    private final URI utløptURI;
+    private final URI opprettEndretStartdatoURI;
+    private final URI opprettEndretSluttdatoURI;
 
     @Inject
     public UngOppgaveKlient(
         OidcRestClient restClient,
         @KonfigVerdi(value = "ungdomsprogramregister.url", defaultVerdi = "http://ung-deltakelse-opplyser.k9saksbehandling") String url) {
         this.restClient = restClient;
-        opprettURI = tilUri(url, "oppgave/opprett");
+        opprettKontrollerRegisterInntektURI = tilUri(url, "oppgave/opprett/kontroll/registerinntekt");
+        opprettEndretStartdatoURI = tilUri(url, "oppgave/opprett/endre/startdato");
+        opprettEndretSluttdatoURI = tilUri(url, "oppgave/opprett/endre/sluttdato");
         avbrytURI = tilUri(url, "oppgave/avbryt");
-
+        utløptURI = tilUri(url, "oppgave/utløpt");
     }
 
     public void avbrytOppgave(UUID eksternRef) {
@@ -39,16 +45,36 @@ public class UngOppgaveKlient {
 
     public void opprettOppgave(RegisterInntektOppgaveDTO oppgaver) {
         try {
-            restClient.post(opprettURI, oppgaver);
+            restClient.post(opprettKontrollerRegisterInntektURI, oppgaver);
         } catch (Exception e) {
             throw UngOppgavetjenesteFeil.FACTORY.feilVedKallTilUngOppgaveTjeneste(e).toException();
         }
 
     }
 
+    public void oppgaveUtløpt(UUID eksternRef) {
+        try {
+            restClient.post(utløptURI, eksternRef);
+        } catch (Exception e) {
+            throw UngOppgavetjenesteFeil.FACTORY.feilVedKallTilUngOppgaveTjeneste(e).toException();
+        }
+    }
 
+    public void opprettEndretStartdatoOppgave(EndrePeriodeDatoDTO endrePeriodeDatoDTO) {
+        try {
+            restClient.post(opprettEndretStartdatoURI, endrePeriodeDatoDTO);
+        } catch (Exception e) {
+            throw UngOppgavetjenesteFeil.FACTORY.feilVedKallTilUngOppgaveTjeneste(e).toException();
+        }
+    }
 
-
+    public void opprettEndretSluttdatoOppgave(EndrePeriodeDatoDTO endrePeriodeDatoDTO) {
+        try {
+            restClient.post(opprettEndretSluttdatoURI, endrePeriodeDatoDTO);
+        } catch (Exception e) {
+            throw UngOppgavetjenesteFeil.FACTORY.feilVedKallTilUngOppgaveTjeneste(e).toException();
+        }
+    }
 
     private static URI tilUri(String baseUrl, String path) {
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <pdfgen-core.version>1.1.43</pdfgen-core.version>
         <confluent.platform.version>7.9.0</confluent.platform.version>
         <mockito.version>5.16.1</mockito.version>
-        <ung-deltakelse-opplyser.version>1.0.7</ung-deltakelse-opplyser.version>
+        <ung-deltakelse-opplyser.version>1.1.0</ung-deltakelse-opplyser.version>
     </properties>
 
     <!-- NB: Unngå å put scope (test, provided) i dependency management. Det

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -3529,6 +3529,37 @@
         "required" : [ "aktørIder" ],
         "type" : "object"
       },
+      "PipDtoV2" : {
+        "properties" : {
+          "aktørIder" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "ansvarligSaksbehandler" : {
+            "type" : "string"
+          },
+          "behandlingStatus" : {
+            "$ref" : "#/components/schemas/PipDtoV2BehandlingStatus"
+          },
+          "fagsakStatus" : {
+            "$ref" : "#/components/schemas/PipDtoV2FagsakStatus"
+          }
+        },
+        "type" : "object"
+      },
+      "PipDtoV2BehandlingStatus" : {
+        "enum" : [ "AVSLU", "FVED", "IVED", "OPPRE", "UTRED" ],
+        "type" : "string",
+        "x-enum-varnames" : [ "AVSLUTTET", "FATTER_VEDTAK", "IVERKSETTER_VEDTAK", "OPPRETTET", "UTREDES" ]
+      },
+      "PipDtoV2FagsakStatus" : {
+        "enum" : [ "OPPR", "UBEH", "LOP", "AVSLU" ],
+        "type" : "string",
+        "x-enum-varnames" : [ "OPPRETTET", "UNDER_BEHANDLING", "LØPENDE", "AVSLUTTET" ]
+      },
       "ProsessTaskDataDto" : {
         "properties" : {
           "gruppe" : {
@@ -7567,6 +7598,36 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/PipDto"
+                }
+              }
+            },
+            "description" : "default response"
+          }
+        },
+        "tags" : [ "pip" ]
+      }
+    },
+    "/api/pip/pipdata-for-behandling-v2" : {
+      "get" : {
+        "description" : "Henter aktørIder, fagsak- og behandlingstatus og ansvarlig saksbehandler tilknyttet til en behandling",
+        "operationId" : "hentPipDataTilknyttetBehandlingV2",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "behandlingUuid",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "allOf" : [ {
+                    "$ref" : "#/components/schemas/PipDtoV2"
+                  } ],
+                  "nullable" : true
                 }
               }
             },


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ung-sak skal på sikt opprette oppgaver for endret startdato og slutt, samt markere en oppgave som utløpt.

### **Løsning**
- Utvider UngOppgaveKlient med nye metoder for å kunne opprette oppgave for endret startdato/sluttdato, samt markere en 
oppgave som utløpt.
- Migrerer til nytt endepunkt for opprettelse av oppgave for kontroll av registerinntekt.

### **Andre endringer**
- Bumper ung-deltakelse-opplyser.version med kontakt for å kunne opprette oppgaver for endret startdato/sluttdato.
