### PR TITLE
TSFF-1398: Bruker kun gjeldende etterlysning for å avgjøre om vi har mottatt svar for gjeldende registeropplysninger

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/Etterlysning.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/Etterlysning.java
@@ -8,6 +8,7 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.typer.JournalpostId;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 @Entity(name = "Etterlysning")
@@ -182,7 +183,7 @@ public class Etterlysning extends BaseEntitet {
         this.uttalelse = new UttalelseEntitet(erEndringGodkjent, uttalelse, svarJournalpostId);
     }
 
-    public UttalelseEntitet getUttalelse() {
-        return uttalelse;
+    public Optional<UttalelseEntitet> getUttalelse() {
+        return Optional.ofNullable(uttalelse);
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/etterlysning/EtterlysningRepository.java
@@ -27,9 +27,8 @@ public class EtterlysningRepository {
     }
 
     public Etterlysning lagre(Etterlysning etterlysning) {
-        if (etterlysning.getUttalelse() != null) {
-            entityManager.persist(etterlysning.getUttalelse());
-            entityManager.flush();
+        if (etterlysning.getUttalelse().isPresent()) {
+            entityManager.persist(etterlysning.getUttalelse().get());
         }
         entityManager.persist(etterlysning);
         entityManager.flush();

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/varselrevurdering/VarselRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/varselrevurdering/VarselRevurderingStegImpl.java
@@ -4,7 +4,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
-import no.nav.ung.kodeverk.behandling.aksjonspunkt.Venteårsak;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
 import no.nav.ung.sak.behandlingskontroll.*;

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/varselrevurdering/ProgramperiodeendringEtterlysningTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/varselrevurdering/ProgramperiodeendringEtterlysningTjenesteTest.java
@@ -7,6 +7,7 @@ import no.nav.k9.prosesstask.impl.ProsessTaskTjenesteImpl;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
@@ -14,6 +15,7 @@ import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.etterlysning.EtterlysningTjeneste;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.ungdomsprogram.UngdomsprogramPeriodeTjeneste;
@@ -58,7 +60,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
             ungdomsprogramPeriodeTjeneste,
             ungdomsprogramPeriodeRepository,
             prosessTaskTjeneste,
-            etterlysningRepository
+            etterlysningRepository,
+            new EtterlysningTjeneste(new MottatteDokumentRepository(entityManager), etterlysningRepository)
         );
     }
 

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/varselrevurdering/ProgramperiodeendringEtterlysningTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/varselrevurdering/ProgramperiodeendringEtterlysningTjenesteTest.java
@@ -2,12 +2,10 @@ package no.nav.ung.sak.domene.behandling.steg.varselrevurdering;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import no.nav.k9.felles.exception.TekniskException;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
 import no.nav.k9.prosesstask.impl.ProsessTaskTjenesteImpl;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
 import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
-import no.nav.ung.sak.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
@@ -26,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/EtterlysningTjeneste.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/EtterlysningTjeneste.java
@@ -1,0 +1,128 @@
+package no.nav.ung.sak.etterlysning;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.etterlysning.EtterlysningStatus;
+import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
+import no.nav.ung.sak.behandlingslager.BaseEntitet;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
+import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
+import no.nav.ung.sak.behandlingslager.etterlysning.UttalelseEntitet;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Dependent
+public class EtterlysningTjeneste {
+
+    private MottatteDokumentRepository mottatteDokumentRepository;
+    private EtterlysningRepository etterlysningRepository;
+
+    @Inject
+    public EtterlysningTjeneste(MottatteDokumentRepository mottatteDokumentRepository,
+                                EtterlysningRepository etterlysningRepository) {
+        this.mottatteDokumentRepository = mottatteDokumentRepository;
+        this.etterlysningRepository = etterlysningRepository;
+    }
+
+    /**
+     * Henter gjeldende etterlysninger for en behandling og fagsak.
+     * Gjeldende etterlysning er den som ble opprettet sist for en periode dersom den ikke er koblet til en uttalelse (statuser VENTER eller UTLØPT)
+     * eller den etterlysningern som sist fikk innsendt uttalelse dersom den er koblet til en uttalelse (status MOTTATT_SVAR)
+     *
+     * @param behandlingId Behandling ID
+     * @param fagsakId     Fagsak ID
+     * @param type         Type av etterlysning
+     * @return Liste med gjeldende etterlysninger
+     */
+    public List<Etterlysning> hentGjeldendeEtterlysninger(
+        Long behandlingId,
+        Long fagsakId,
+        EtterlysningType type) {
+        final var etterlysninger = etterlysningRepository.hentEtterlysninger(behandlingId, type);
+        final var journalpostIder = etterlysninger.stream().flatMap(it -> it.getUttalelse().stream().map(UttalelseEntitet::getSvarJournalpostId)).collect(Collectors.toSet());
+        final var mottattDokumenter = mottatteDokumentRepository.hentMottatteDokument(fagsakId, journalpostIder);
+
+        // Ønsker å finne siste gjeldende etterlysning for en periode
+        // Ved delvis overlappende etterlysninger finner vi siste blant de som overlapper med minst en annen etterlysning i samme gruppe
+
+        List<Etterlysning> gjeldendeEtterlysningerListe = new ArrayList<>();
+
+        // Sorter etterlysningene etter periode
+        final var sorterteEtterlysninger = etterlysninger.stream()
+            .sorted(Comparator.comparing(Etterlysning::getPeriode))
+            .toList();
+
+        // Starter for-løkke med tom tidsline og tom liste med etterlysninger
+        List<Etterlysning> etterlysningerForSammePeriode = new ArrayList<>();
+        LocalDateTimeline<Boolean> tidslinjeForSamledeEtterlysninger = LocalDateTimeline.empty();
+        for (var etterlysning : sorterteEtterlysninger) {
+            final var overlapperMedSamledeEtterlysninger = !tidslinjeForSamledeEtterlysninger.intersection(etterlysning.getPeriode().toLocalDateInterval()).isEmpty();
+            if (overlapperMedSamledeEtterlysninger) {
+                // Dersom etterlysningen overlapper med eksisterende etterlysninger i tidslinjen legges den til i listen og tidslinjen utvides
+                tidslinjeForSamledeEtterlysninger = tidslinjeForSamledeEtterlysninger.crossJoin(new LocalDateTimeline<>(etterlysning.getPeriode().toLocalDateInterval(), true));
+                etterlysningerForSammePeriode.add(etterlysning);
+            } else {
+                // Finner gjeldende fra forrige gruppe
+                finnGjeldendeForPeriode(etterlysningerForSammePeriode, mottattDokumenter)
+                    .ifPresent(gjeldendeEtterlysningerListe::add);
+
+                // Starter ny gruppe med etterlysninger
+                tidslinjeForSamledeEtterlysninger = new LocalDateTimeline<>(etterlysning.getPeriode().toLocalDateInterval(), true);
+                etterlysningerForSammePeriode.clear();
+                etterlysningerForSammePeriode.add(etterlysning);
+            }
+        }
+
+        // Finner gjeldende etterlysning for siste gruppe
+        finnGjeldendeForPeriode(etterlysningerForSammePeriode, mottattDokumenter)
+            .ifPresent(gjeldendeEtterlysningerListe::add);
+
+
+        return gjeldendeEtterlysningerListe;
+    }
+
+    private static Optional<Etterlysning> finnGjeldendeForPeriode(List<Etterlysning> etterlysningerForSammePeriode,
+                                                                  List<MottattDokument> mottattDokumenter) {
+        if (etterlysningerForSammePeriode.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (etterlysningerForSammePeriode.stream().filter(it -> it.getStatus().equals(EtterlysningStatus.VENTER)).count() > 1) {
+           throw new IllegalStateException("Fant flere etterlysninger på vent for samme periode");
+        }
+
+        // Dersom etterlysningen ikke overlapper med eksisterende etterlysninger i tidslinjen har vi en ny gruppe
+        final var sisteOpprettetEtterlysningForPeriode = etterlysningerForSammePeriode.stream()
+            .max(Comparator.comparing(BaseEntitet::getOpprettetTidspunkt))
+            .orElseThrow(() -> new IllegalStateException("Kunne ikke finne siste opprettede etterlysning"));
+
+        if (sisteOpprettetEtterlysningForPeriode.getUttalelse().isEmpty()) {
+            return Optional.of(sisteOpprettetEtterlysningForPeriode);
+        } else {
+            // Bruker innsendt tidspunkt fra mottatt dokument siden dette er mer robust (støtter f.eks. kopi fra original behandling til revurdering)
+            return etterlysningerForSammePeriode.stream()
+                .filter(it -> it.getStatus().equals(EtterlysningStatus.MOTTATT_SVAR))
+                .max(Comparator.comparing(
+                it -> finnInnsendingstidspunkt(it, mottattDokumenter)
+            ));
+        }
+    }
+
+    private static LocalDateTime finnInnsendingstidspunkt(Etterlysning it, List<MottattDokument> mottattDokumenter) {
+        return finnMottattDokument(it, mottattDokumenter).getInnsendingstidspunkt();
+    }
+
+    private static MottattDokument finnMottattDokument(Etterlysning it, List<MottattDokument> mottattDokumenter) {
+        return mottattDokumenter.stream().filter(md -> md.getJournalpostId().equals(it.getUttalelse().get().getSvarJournalpostId())).findFirst().orElseThrow(() -> new IllegalStateException("Fant ikke mottatt dokument for etterlysning " + it.getId() + " med journalpostId " + it.getUttalelse().get().getSvarJournalpostId()));
+    }
+
+
+}

--- a/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/EtterlysningTjenesteTest.java
+++ b/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/EtterlysningTjenesteTest.java
@@ -1,0 +1,242 @@
+package no.nav.ung.sak.etterlysning;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.dokument.DokumentStatus;
+import no.nav.ung.kodeverk.etterlysning.EtterlysningType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
+import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
+import no.nav.ung.sak.typer.JournalpostId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(JpaExtension.class)
+@ExtendWith(CdiAwareExtension.class)
+class EtterlysningTjenesteTest {
+
+    @Inject
+    private MottatteDokumentRepository mottatteDokumentRepository;
+    @Inject
+    private EtterlysningRepository etterlysningRepository;
+
+    @Inject
+    private EntityManager entityManager;
+    private Behandling behandling;
+
+    private EtterlysningTjeneste etterlysningTjeneste;
+
+
+    @BeforeEach
+    void setUp() {
+        behandling = TestScenarioBuilder.builderMedSøknad().lagre(entityManager);
+        etterlysningTjeneste = new EtterlysningTjeneste(
+            mottatteDokumentRepository,
+            etterlysningRepository);
+    }
+
+    @Test
+    void skal_finne_en_etterlysning_på_vent() {
+        // Arrange
+        final var etterlysning = lagEtterlysningPåVent(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now()));
+        etterlysningRepository.lagre(etterlysning);
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(1);
+    }
+
+    @Test
+    void skal_finne_to_etterlysninger_på_vent_for_periode_kant_i_kant() {
+        // Arrange
+        final var periode1 = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now());
+        final var periode2 = DatoIntervallEntitet.fraOgMedTilOgMed(periode1.getTomDato().plusDays(1), periode1.getTomDato().plusDays(1));
+
+        final var etterlysning1 = lagEtterlysningPåVent(periode1);
+        final var etterlysning2 = lagEtterlysningPåVent(periode2);
+        etterlysningRepository.lagre(List.of(etterlysning1, etterlysning2));
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(2);
+    }
+
+    @Test
+    void skal_finne_en_utløpt_etterlysning_for_to_delvis_overlappende_etterlysninger() {
+        // Arrange
+        final var periode1 = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(3));
+        final var periode2 = DatoIntervallEntitet.fraOgMedTilOgMed(periode1.getTomDato(), periode1.getTomDato().plusDays(1));
+
+        final var etterlysning1 = lagUtløptEtterlysning(periode1);
+        etterlysningRepository.lagre(etterlysning1);
+        final var etterlysning2 = lagUtløptEtterlysning(periode2);
+        etterlysningRepository.lagre(etterlysning2);
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(1);
+        final var faktisk = gjeldendeEtterlysninger.get(0);
+        assertThat(faktisk.getPeriode()).isEqualTo(periode2);
+    }
+
+    @Test
+    void skal_finne_en_utløpt_etterlysning_for_tre_delvis_overlappende_etterlysninger() {
+        // Arrange
+        final var periode1 = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(3));
+        final var periode2 = DatoIntervallEntitet.fraOgMedTilOgMed(periode1.getTomDato(), periode1.getTomDato().plusDays(3));
+        final var periode3 = DatoIntervallEntitet.fraOgMedTilOgMed(periode2.getTomDato(), periode2.getTomDato().plusDays(3));
+
+        final var etterlysning1 = lagUtløptEtterlysning(periode1);
+        etterlysningRepository.lagre(etterlysning1);
+        final var etterlysning2 = lagUtløptEtterlysning(periode2);
+        etterlysningRepository.lagre(etterlysning2);
+        final var etterlysning3 = lagUtløptEtterlysning(periode3);
+        etterlysningRepository.lagre(etterlysning3);
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(1);
+        final var faktisk = gjeldendeEtterlysninger.get(0);
+        assertThat(faktisk.getPeriode()).isEqualTo(periode3);
+    }
+
+    @Test
+    void skal_finne_to_utløpte_etterlysninger_for_to_ikke_overlappende_perioder_med_to_delvis_overlappende_etterlysninger_i_første_periode() {
+        // Arrange
+        final var periode1 = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(3));
+        final var periode2 = DatoIntervallEntitet.fraOgMedTilOgMed(periode1.getTomDato(), periode1.getTomDato().plusDays(3));
+        final var periode3 = DatoIntervallEntitet.fraOgMedTilOgMed(periode2.getTomDato().plusDays(2), periode2.getTomDato().plusDays(4));
+
+        final var etterlysning1 = lagUtløptEtterlysning(periode1);
+        etterlysningRepository.lagre(etterlysning1);
+        final var etterlysning2 = lagUtløptEtterlysning(periode2);
+        etterlysningRepository.lagre(etterlysning2);
+        final var etterlysning3 = lagUtløptEtterlysning(periode3);
+        etterlysningRepository.lagre(etterlysning3);
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(2);
+        final var faktisk1 = gjeldendeEtterlysninger.get(0);
+        assertThat(faktisk1.getPeriode()).isEqualTo(periode2);
+        final var faktisk2 = gjeldendeEtterlysninger.get(1);
+        assertThat(faktisk2.getPeriode()).isEqualTo(periode3);
+    }
+
+    @Test
+    void skal_finne_en_etterlysning_med_mottatt_svar_for_tre_delvis_overlappende_etterlysninger_med_to_utløpte() {
+        // Arrange
+        final var periode1 = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(3));
+        final var periode2 = DatoIntervallEntitet.fraOgMedTilOgMed(periode1.getTomDato(), periode1.getTomDato().plusDays(3));
+        final var periode3 = DatoIntervallEntitet.fraOgMedTilOgMed(periode2.getTomDato(), periode2.getTomDato().plusDays(3));
+
+        final var etterlysning1 = lagUtløptEtterlysning(periode1);
+        etterlysningRepository.lagre(etterlysning1);
+        final var etterlysning2 = lagUtløptEtterlysning(periode2);
+        etterlysningRepository.lagre(etterlysning2);
+
+        final var svarJournalpostId = new JournalpostId(2L);
+        opprettMottattDokument(svarJournalpostId, LocalDateTime.now());
+        final var etterlysning3 = lagEtterlysningMedSvar(periode3, svarJournalpostId);
+        etterlysningRepository.lagre(etterlysning3);
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(1);
+        final var faktisk = gjeldendeEtterlysninger.get(0);
+        assertThat(faktisk.getPeriode()).isEqualTo(periode3);
+    }
+
+
+    @Test
+    void skal_finne_en_etterlysning_med_mottatt_svar_for_tre_delvis_overlappende_etterlysninger() {
+        // Arrange
+        final var periode1 = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(3));
+        final var periode2 = DatoIntervallEntitet.fraOgMedTilOgMed(periode1.getTomDato(), periode1.getTomDato().plusDays(3));
+        final var periode3 = DatoIntervallEntitet.fraOgMedTilOgMed(periode2.getTomDato(), periode2.getTomDato().plusDays(3));
+
+        final var svarJournalpostId1 = new JournalpostId(2L);
+        opprettMottattDokument(svarJournalpostId1, LocalDateTime.now().minusDays(2));
+        final var etterlysning1 = lagEtterlysningMedSvar(periode1, svarJournalpostId1);
+        etterlysningRepository.lagre(etterlysning1);
+
+        final var svarJournalpostId2 = new JournalpostId(3L);
+        opprettMottattDokument(svarJournalpostId2, LocalDateTime.now());
+        final var etterlysning2 = lagEtterlysningMedSvar(periode2, svarJournalpostId2);
+        etterlysningRepository.lagre(etterlysning2);
+
+        final var svarJournalpostId = new JournalpostId(4L);
+        opprettMottattDokument(svarJournalpostId, LocalDateTime.now().minusDays(1));
+        final var etterlysning3 = lagEtterlysningMedSvar(periode3, svarJournalpostId);
+        etterlysningRepository.lagre(etterlysning3);
+
+        // Act
+        final var gjeldendeEtterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(behandling.getId(), behandling.getFagsakId(), EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+
+        // Assert
+        assertThat(gjeldendeEtterlysninger.size()).isEqualTo(1);
+        final var faktisk = gjeldendeEtterlysninger.get(0);
+        assertThat(faktisk.getPeriode()).isEqualTo(periode2);
+    }
+
+    private void opprettMottattDokument(JournalpostId svarJournalpostId, LocalDateTime innsendingstidspunkt) {
+        mottatteDokumentRepository.lagre(new MottattDokument.Builder()
+            .medFagsakId(behandling.getFagsakId())
+            .medJournalPostId(svarJournalpostId)
+            .medInnsendingstidspunkt(innsendingstidspunkt)
+            .build(), DokumentStatus.GYLDIG);
+    }
+
+
+    private Etterlysning lagEtterlysningPåVent(DatoIntervallEntitet periode) {
+        final var etterlysning = Etterlysning.opprettForType(behandling.getId(), UUID.randomUUID(), UUID.randomUUID(),
+            periode,
+            EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+        etterlysning.vent(LocalDateTime.now());
+        return etterlysning;
+    }
+
+    private Etterlysning lagUtløptEtterlysning(DatoIntervallEntitet periode) {
+        final var etterlysning = Etterlysning.opprettForType(behandling.getId(), UUID.randomUUID(), UUID.randomUUID(),
+            periode,
+            EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+        etterlysning.vent(LocalDateTime.now());
+        etterlysning.utløpt();
+        return etterlysning;
+    }
+
+    private Etterlysning lagEtterlysningMedSvar(DatoIntervallEntitet periode, JournalpostId svarJournalpostId) {
+        final var etterlysning = Etterlysning.opprettForType(behandling.getId(), UUID.randomUUID(), UUID.randomUUID(),
+            periode,
+            EtterlysningType.UTTALELSE_ENDRET_PROGRAMPERIODE);
+        etterlysning.vent(LocalDateTime.now());
+        etterlysning.mottattUttalelse(svarJournalpostId, false, "Uttalelse");
+        return etterlysning;
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/ProgramperiodeEndringBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/ProgramperiodeEndringBekreftelseHåndterer.java
@@ -3,7 +3,6 @@ package no.nav.ung.sak.mottak.dokumentmottak.oppgavebekreftelse;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
-import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.DatoEndring;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretProgramperiodeBekreftelse;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.dokument.DokumentStatus;

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -30,7 +30,6 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.mottak.dokumentmottak.AsyncAbakusLagreOpptjeningTask;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.typer.JournalpostId;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndtererTest.java
@@ -118,9 +118,9 @@ class InntektBekreftelseHåndtererTest {
         //etterlysning er oppdatert
         var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
         assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
-        assertThat(oppdatertEtterlysning.getUttalelse().getUttalelseBegrunnelse()).isNull();
-        assertThat(oppdatertEtterlysning.getUttalelse().harGodtattEndringen()).isTrue();
-        assertThat(oppdatertEtterlysning.getUttalelse().getSvarJournalpostId().getJournalpostId().getVerdi()).isEqualTo(String.valueOf(journalpostId));
+        assertThat(oppdatertEtterlysning.getUttalelse().get().getUttalelseBegrunnelse()).isNull();
+        assertThat(oppdatertEtterlysning.getUttalelse().get().harGodtattEndringen()).isTrue();
+        assertThat(oppdatertEtterlysning.getUttalelse().get().getSvarJournalpostId().getJournalpostId().getVerdi()).isEqualTo(String.valueOf(journalpostId));
     }
 
     @Test
@@ -171,9 +171,9 @@ class InntektBekreftelseHåndtererTest {
         //etterlysning er oppdatert
         var oppdatertEtterlysning = etterlysningRepository.hentEtterlysning(etterlysning.getId());
         assertThat(oppdatertEtterlysning.getStatus()).isEqualTo(EtterlysningStatus.MOTTATT_SVAR);
-        assertThat(oppdatertEtterlysning.getUttalelse().getUttalelseBegrunnelse()).isEqualTo("en uttalelse");
-        assertThat(oppdatertEtterlysning.getUttalelse().harGodtattEndringen()).isFalse();
-        assertThat(oppdatertEtterlysning.getUttalelse().getSvarJournalpostId().getJournalpostId().getVerdi()).isEqualTo(String.valueOf(journalpostId));
+        assertThat(oppdatertEtterlysning.getUttalelse().get().getUttalelseBegrunnelse()).isEqualTo("en uttalelse");
+        assertThat(oppdatertEtterlysning.getUttalelse().get().harGodtattEndringen()).isFalse();
+        assertThat(oppdatertEtterlysning.getUttalelse().get().getSvarJournalpostId().getJournalpostId().getVerdi()).isEqualTo(String.valueOf(journalpostId));
     }
 
     private MottattDokument lagMottattDokument(Behandling behandling, long journalpostId) {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved flere runder med etterlysning til bruker skal kun siste etterlysning brukes til å vurdere om den fortsatt er gyldig. For etterlysninger som ikke har mottatt svar brukes opprettet tidspunkt. For etterlysninger som har mottatt svar brukes innsendingstidspunktet for journalposten/mottatt dokument for uttalelsen.