### PR TITLE
Oppdater openapi-spec-utils til versjon 1.3.1

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>no.nav.openapi.spec.utils</groupId>
             <artifactId>openapi-spec-utils</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1</version>
         </dependency>
 
         <!-- CDI -->


### PR DESCRIPTION
### **Behov / Bakgrunn**
Av og til når server starta vart JacksonJsonProvider resolved til DefaultJacksonJaxbJsonProvider istadenfor DynamicJacksonJsonProvider. Dette førte til at DynamicObjectMapperResolver ikkje fungerte som den skulle (innstillinger frå DynamicJacksonJsonProvider vart ikkje aktivert).

### **Løsning**
Fikser annotasjoner i DynamicJacksonJsonProvider til å sette prioritet slik at den alltid blir brukt framfor DefaultJacksonJaxbJsonProvider. (https://github.com/navikt/openapi-spec-utils/pull/21)