### PR TITLE
FIX: Endrer innhenting av programperiode til registerinnhentingtask med tilhørende startpunktutledning

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/hendelser/StartpunktType.java
@@ -18,17 +18,10 @@ import no.nav.ung.kodeverk.api.Kodeverdi;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum StartpunktType implements Kodeverdi {
 
-    INIT_PERIODER("INIT_PERIODER", "Initier perioder", 1),
-    KONTROLLER_ARBEIDSFORHOLD("KONTROLLER_ARBEIDSFORHOLD", "Startpunkt kontroller arbeidsforhold", 2),
-    KONTROLLER_FAKTA("KONTROLLER_FAKTA", "Kontroller fakta", 3),
-    INNGANGSVILKÅR_OPPLYSNINGSPLIKT("INNGANGSVILKÅR_OPPL", "Inngangsvilkår opplysningsplikt", 4),
-    INNGANGSVILKÅR_OMSORGENFOR("INNGANGSVILKÅR_OMSORGENFOR", "Inngangsvilkår omsorgen for", 10),
-    INNGANGSVILKÅR_MEDISINSK("INNGANGSVILKÅR_MEDISINSK", "Inngangsvilkår sykdom", 12),
-    INNGANGSVILKÅR_MEDLEMSKAP("INNGANGSVILKÅR_MEDL", "Inngangsvilkår medlemskapsvilkår", 15),
-    OPPTJENING("OPPTJENING", "Opptjening", 20),
+    INNHENT_REGISTEROPPLYSNINGER("INNHENT_REGISTEROPPLYSNINGER", "Innhent registeropplysninger", 1),
+    INIT_PERIODER("INIT_PERIODER", "Initier perioder", 2),
     BEREGNING("BEREGNING", "Beregning", 25),
     UTTAKSVILKÅR("UTTAKSVILKÅR", "Uttaksvilkår", 30),
-    UTTAKSVILKÅR_VURDERING("UTTAKSVILKÅR_VURDERING", "Uttaksvilkår", 35),
 
     UDEFINERT("-", "Ikke definert", 99),
     ;

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/perioder/UngdomsprogramPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/perioder/UngdomsprogramPeriode.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.behandlingslager.perioder;
 
 import java.time.LocalDate;
 
+import no.nav.ung.sak.behandlingslager.diff.ChangeTracked;
 import org.hibernate.annotations.Immutable;
 
 import jakarta.persistence.AttributeOverride;
@@ -31,6 +32,7 @@ public class UngdomsprogramPeriode extends BaseEntitet {
             @AttributeOverride(name = "fomDato", column = @Column(name = "fom", nullable = false)),
             @AttributeOverride(name = "tomDato", column = @Column(name = "tom", nullable = false))
     })
+    @ChangeTracked
     private DatoIntervallEntitet periode;
 
     public UngdomsprogramPeriode() {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/perioder/UngdomsprogramPeriodeGrunnlag.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/perioder/UngdomsprogramPeriodeGrunnlag.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import no.nav.ung.sak.behandlingslager.diff.ChangeTracked;
 import org.hibernate.annotations.Immutable;
 
 import jakarta.persistence.Column;
@@ -30,6 +31,7 @@ public class UngdomsprogramPeriodeGrunnlag extends BaseEntitet {
 
     @ManyToOne
     @Immutable
+    @ChangeTracked
     @JoinColumn(name = "ung_ungdomsprogramperioder_id", nullable = false, updatable = false, unique = true)
     private UngdomsprogramPerioder ungdomsprogramPerioder;
 

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/initperioder/InitierPerioderSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/initperioder/InitierPerioderSteg.java
@@ -10,14 +10,10 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoGrunnlag;
 import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoer;
-import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.ungdomsprogram.UngdomsprogramPeriodeTjeneste;
-import no.nav.ung.sak.ungdomsprogram.UngdomsprogramTjeneste;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -31,7 +27,6 @@ import static no.nav.ung.kodeverk.uttak.Tid.TIDENES_ENDE;
 @FagsakYtelseTypeRef(UNGDOMSYTELSE)
 public class InitierPerioderSteg implements BehandlingSteg {
 
-    private UngdomsprogramTjeneste ungdomsprogramTjeneste;
     private BehandlingRepository behandlingRepository;
     private UngdomsytelseStartdatoRepository startdatoRepository;
     private MottatteDokumentRepository mottatteDokumentRepository;
@@ -39,12 +34,10 @@ public class InitierPerioderSteg implements BehandlingSteg {
     private FagsakRepository fagsakRepository;
 
     @Inject
-    public InitierPerioderSteg(UngdomsprogramTjeneste ungdomsprogramTjeneste,
-                               BehandlingRepository behandlingRepository,
+    public InitierPerioderSteg(BehandlingRepository behandlingRepository,
                                UngdomsytelseStartdatoRepository startdatoRepository,
                                MottatteDokumentRepository mottatteDokumentRepository,
                                UngdomsprogramPeriodeTjeneste ungdomsprogramPeriodeTjeneste, FagsakRepository fagsakRepository) {
-        this.ungdomsprogramTjeneste = ungdomsprogramTjeneste;
         this.behandlingRepository = behandlingRepository;
         this.startdatoRepository = startdatoRepository;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
@@ -57,7 +50,6 @@ public class InitierPerioderSteg implements BehandlingSteg {
 
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
-        ungdomsprogramTjeneste.innhentOpplysninger(kontekst);
         initierRelevanteSøknader(kontekst);
         var periodeTidslinje = ungdomsprogramPeriodeTjeneste.finnPeriodeTidslinje(kontekst.getBehandlingId());
         if (!periodeTidslinje.isEmpty()) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/OpprettRevurderingEllerOpprettDiffTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/OpprettRevurderingEllerOpprettDiffTask.java
@@ -45,6 +45,12 @@ public class OpprettRevurderingEllerOpprettDiffTask extends FagsakProsessTask {
     public static final String PERIODER = "perioder";
 
     private static final Logger log = LoggerFactory.getLogger(OpprettRevurderingEllerOpprettDiffTask.class);
+    public static final Set<BehandlingÅrsakType> REGISTERINNHENTING_ÅRSAKER = Set.of(
+        BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER,
+        BehandlingÅrsakType.RE_HENDELSE_DØD_BARN,
+        BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT,
+        BehandlingÅrsakType.RE_HENDELSE_ENDRET_STARTDATO_UNGDOMSPROGRAM,
+        BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM);
     private FagsakRepository fagsakRepository;
     private BehandlingRepository behandlingRepository;
     private ProsessTriggereRepository prosessTriggereRepository;
@@ -105,7 +111,7 @@ public class OpprettRevurderingEllerOpprettDiffTask extends FagsakProsessTask {
             var behandling = behandlingRepository.hentBehandling(behandlingId);
             BehandlingÅrsak.builder(behandlingÅrsakType).buildFor(behandling);
             behandlingRepository.lagre(behandling, behandlingLås);
-            var skalTvingeRegisterinnhenting = Set.of(BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER, BehandlingÅrsakType.RE_HENDELSE_DØD_BARN, BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT).contains(behandlingÅrsakType);
+            var skalTvingeRegisterinnhenting = REGISTERINNHENTING_ÅRSAKER.contains(behandlingÅrsakType);
 
             behandlingProsesseringTjeneste.opprettTasksForGjenopptaOppdaterFortsett(behandling, false, skalTvingeRegisterinnhenting);
 

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/BehandlingskontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/BehandlingskontrollTjeneste.java
@@ -241,18 +241,6 @@ public interface BehandlingskontrollTjeneste {
                                               Venteårsak venteårsak, String venteårsakVariant);
 
     /**
-     * Sjekker i behandlingsmodellen om aksjonspunktet skal løses i eller etter det angitte startpunktet.
-     *
-     * @param ytelseType
-     * @param behandlingType
-     * @param startpunkt startpunkt som angir steget som aksjonspunktet skal sjekkes mot
-     * @param aksjonspunktDefinisjon aksjonspunktet som skal sjekkes
-     * @return true dersom aksjonspunktet skal løses i eller etter det angitte steget.
-     */
-    boolean skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType ytelseType, BehandlingType behandlingType, StartpunktType startpunkt,
-                                                 AksjonspunktDefinisjon aksjonspunktDefinisjon);
-
-    /**
      * Ny metode som forbereder en behandling for prosessering - setter autopunkt til utført og evt tilbakeføring ved gjenopptak.
      * Behandlingen skal være klar til prosessering uten åpne autopunkt når kallet er ferdig.
      */

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/ProsessModell.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/ProsessModell.java
@@ -20,9 +20,9 @@ public class ProsessModell {
         var modellBuilder = BehandlingModellImpl.builder(BehandlingType.FØRSTEGANGSSØKNAD, FagsakYtelseType.UNGDOMSYTELSE);
         modellBuilder
             .medSteg(BehandlingStegType.START_STEG)
+            .medSteg(BehandlingStegType.INNHENT_REGISTEROPP, StartpunktType.INNHENT_REGISTEROPPLYSNINGER)
             .medSteg(BehandlingStegType.INIT_PERIODER, StartpunktType.INIT_PERIODER)
             .medSteg(BehandlingStegType.INIT_VILKÅR)
-            .medSteg(BehandlingStegType.INNHENT_REGISTEROPP)
             .medSteg(BehandlingStegType.VURDER_UNGDOMSPROGRAMVILKÅR)
             .medSteg(BehandlingStegType.ALDERSVILKÅRET)
             .medSteg(BehandlingStegType.FORESLÅ_BEHANDLINGSRESULTAT)
@@ -45,10 +45,10 @@ public class ProsessModell {
         var modellBuilder = BehandlingModellImpl.builder(BehandlingType.REVURDERING, FagsakYtelseType.UNGDOMSYTELSE);
         modellBuilder
             .medSteg(BehandlingStegType.START_STEG)
+            .medSteg(BehandlingStegType.INNHENT_REGISTEROPP, StartpunktType.INNHENT_REGISTEROPPLYSNINGER)
             .medSteg(BehandlingStegType.INIT_PERIODER, StartpunktType.INIT_PERIODER)
             .medSteg(BehandlingStegType.VARSEL_REVURDERING)
             .medSteg(BehandlingStegType.INIT_VILKÅR)
-            .medSteg(BehandlingStegType.INNHENT_REGISTEROPP)
             .medSteg(BehandlingStegType.VURDER_UNGDOMSPROGRAMVILKÅR)
             .medSteg(BehandlingStegType.ALDERSVILKÅRET)
             .medSteg(BehandlingStegType.FORESLÅ_BEHANDLINGSRESULTAT)

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
@@ -565,23 +565,7 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
         eventPubliserer.fireEvent(event);
     }
 
-    @Override
-    public boolean skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType ytelseType, BehandlingType behandlingType,
-                                                        StartpunktType startpunkt, AksjonspunktDefinisjon apDef) {
 
-        BehandlingModell modell = getModell(behandlingType, ytelseType);
-        BehandlingStegType behandlingSteg = finnBehandlingSteg(startpunkt, ytelseType, behandlingType);
-        BehandlingStegType apLøsesteg = Optional.ofNullable(modell
-                .finnTidligsteStegForAksjonspunktDefinisjon(singletonList(apDef.getKode())))
-            .map(BehandlingStegModell::getBehandlingStegType)
-            .orElse(null);
-        if (apLøsesteg == null) {
-            // AksjonspunktDefinisjon finnes ikke på stegene til denne behandlingstypen. Ap kan derfor ikke løses.
-            return false;
-        }
-
-        return behandlingSteg.equals(apLøsesteg) || modell.erStegAFørStegB(behandlingSteg, apLøsesteg);
-    }
 
     // TODO: (PK-49128) Midlertidig løsning for å filtrere aksjonspunkter til høyre for steg i hendelsemodul
     @Override

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
@@ -213,19 +213,6 @@ public class BehandlingskontrollTjenesteImplTest {
         });
     }
 
-    @Test
-    public void skal_returnere_true_når_aksjonspunktet_skal_løses_i_angitt_steg() {
-        assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(), behandling.getType(), StartpunktType.KONTROLLER_FAKTA,
-            steg3.getAksjonspunktDefinisjonerUtgang().get(0)))
-                .isTrue();
-    }
-
-    @Test
-    public void skal_returnere_false_når_aksjonspunktet_skal_løses_før_angitt_steg() {
-        assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(), behandling.getType(), StartpunktType.BEREGNING,
-            steg2.getAksjonspunktDefinisjonerUtgang().get(0)))
-                .isFalse();
-    }
 
     private void sjekkBehandlingStegTilstandHistorikk(Behandling behandling, BehandlingStegType stegType,
                                                       BehandlingStegStatus... stegStatuser) {

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/ung/sak/behandlingskontroll/testutilities/DummyProsessModell.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/ung/sak/behandlingskontroll/testutilities/DummyProsessModell.java
@@ -25,7 +25,7 @@ public class DummyProsessModell {
     public BehandlingModell førstegangsbehandling() {
         var modellBuilder = BehandlingModellImpl.builder(BehandlingType.FØRSTEGANGSSØKNAD, YTELSE_TYPE);
         modellBuilder
-            .medSteg(BehandlingStegType.KONTROLLER_FAKTA, StartpunktType.KONTROLLER_FAKTA)
+            .medSteg(BehandlingStegType.KONTROLLER_FAKTA, StartpunktType.INIT_PERIODER)
             .medSteg(BehandlingStegType.KONTROLLERER_SØKERS_OPPLYSNINGSPLIKT)
             .medSteg(BehandlingStegType.VURDER_SØKNADSFRIST)
             .medSteg(BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR)

--- a/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/personopplysning/PersonopplysningGrunnlagDiff.java
+++ b/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/personopplysning/PersonopplysningGrunnlagDiff.java
@@ -99,18 +99,10 @@ public class PersonopplysningGrunnlagDiff {
         return !Objects.equals(hentSivilstand(grunnlag1, søkerAktørId), hentSivilstand(grunnlag2, søkerAktørId));
     }
 
-    public boolean erRegionEndretForBruker() {
-        return !Objects.equals(hentRegion(grunnlag1, søkerAktørId), hentRegion(grunnlag2, søkerAktørId));
-    }
-
     public boolean erForeldreDødsdatoEndret() {
         Set<AktørId> foreldre = new HashSet<>();
         foreldre.add(søkerAktørId);
         return !Objects.equals(hentDødsdatoer(grunnlag1, foreldre), hentDødsdatoer(grunnlag2, foreldre));
-    }
-
-    public boolean erDødsdatoEndret(AktørId aktørId) {
-        return !Objects.equals(hentDødsdatoer(grunnlag1, Set.of(aktørId)), hentDødsdatoer(grunnlag2, Set.of(aktørId)));
     }
 
     public boolean erBarnDødsdatoEndret() {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/Endringskontroller.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/Endringskontroller.java
@@ -100,6 +100,7 @@ public class Endringskontroller {
         // Inkluderer tilbakeføring samme steg UTGANG->INNGANG
         boolean tilbakeføres = skalTilbakeføres(behandling, fraSteg, tilSteg);
 
+        // TODO: Vurder om dette kan fjernes sidan vi ikkje har KOARB
         // Gjør aksjonspunktutledning utenom steg kun hvis man har passert KOFAK og evt hopper tilbake. Dette pga KOARB.UT->INN
         if (harUtførtKontrollerFakta(behandling)) {
             BehandlingStegType funnetSteg = tilbakeføres ? tilSteg : fraSteg;

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/behandlingårsak/BehandlingÅrsakUtlederUngdomsprogramperiode.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/behandlingårsak/BehandlingÅrsakUtlederUngdomsprogramperiode.java
@@ -1,0 +1,60 @@
+package no.nav.ung.sak.domene.registerinnhenting.impl.behandlingårsak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.sak.behandling.BehandlingReferanse;
+import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPerioder;
+import no.nav.ung.sak.domene.registerinnhenting.GrunnlagRef;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+@GrunnlagRef(UngdomsprogramPeriodeGrunnlag.class)
+@FagsakYtelseTypeRef
+public class BehandlingÅrsakUtlederUngdomsprogramperiode implements BehandlingÅrsakUtleder {
+
+    private UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository;
+
+
+    BehandlingÅrsakUtlederUngdomsprogramperiode() {
+    }
+
+    @Inject
+    public BehandlingÅrsakUtlederUngdomsprogramperiode(UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository) {
+        this.ungdomsprogramPeriodeRepository = ungdomsprogramPeriodeRepository;
+    }
+
+    @Override
+    public Set<BehandlingÅrsakType> utledBehandlingÅrsaker(BehandlingReferanse ref, Object nyeste, Object eldste) {
+        var eldsteGrunnlag = new HashSet<>(ungdomsprogramPeriodeRepository.hentGrunnlagBasertPåId((Long) eldste)
+            .map(UngdomsprogramPeriodeGrunnlag::getUngdomsprogramPerioder)
+            .map(UngdomsprogramPerioder::getPerioder)
+            .orElseGet(Set::of));
+        var nyesteGrunnlag = new HashSet<>(ungdomsprogramPeriodeRepository.hentGrunnlagBasertPåId((Long) nyeste)
+            .map(UngdomsprogramPeriodeGrunnlag::getUngdomsprogramPerioder)
+            .map(UngdomsprogramPerioder::getPerioder)
+            .orElseGet(Set::of));
+
+        final var årsaker = new HashSet<BehandlingÅrsakType>();
+
+        var gamleFomDatoer = eldsteGrunnlag.stream().map(it -> it.getPeriode().getFomDato()).sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+        var nyeFomDatoer = nyesteGrunnlag.stream().map(it -> it.getPeriode().getFomDato()).sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+        if (nyeFomDatoer.equals(gamleFomDatoer)) {
+            årsaker.add(BehandlingÅrsakType.RE_HENDELSE_ENDRET_STARTDATO_UNGDOMSPROGRAM);
+        }
+
+        var gamleTomDatoer = eldsteGrunnlag.stream().map(it -> it.getPeriode().getTomDato()).sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+        var nyeTomDatoer = nyesteGrunnlag.stream().map(it -> it.getPeriode().getTomDato()).sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+        if (nyeTomDatoer.equals(gamleTomDatoer)) {
+            årsaker.add(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM);
+        }
+        return årsaker;
+    }
+}

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederPersonopplysning.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederPersonopplysning.java
@@ -1,26 +1,22 @@
 package no.nav.ung.sak.domene.registerinnhenting.impl.startpunkt;
 
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandling.BehandlingReferanse;
 import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.ung.sak.behandlingslager.behandling.personopplysning.PersonInformasjonEntitet;
 import no.nav.ung.sak.behandlingslager.behandling.personopplysning.PersonopplysningGrunnlagEntitet;
 import no.nav.ung.sak.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
-import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.behandlingslager.hendelser.StartpunktType;
 import no.nav.ung.sak.domene.person.personopplysning.PersonopplysningGrunnlagDiff;
 import no.nav.ung.sak.domene.registerinnhenting.EndringStartpunktUtleder;
 import no.nav.ung.sak.domene.registerinnhenting.GrunnlagRef;
-import no.nav.ung.sak.typer.AktørId;
+
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 @ApplicationScoped
 @GrunnlagRef(PersonInformasjonEntitet.class)
@@ -29,17 +25,14 @@ class StartpunktUtlederPersonopplysning implements EndringStartpunktUtleder {
 
     private final String source = this.getClass().getSimpleName();
     private PersonopplysningRepository personopplysningRepository;
-    private FagsakRepository fagsakRepository;
 
     StartpunktUtlederPersonopplysning() {
         // For CDI
     }
 
     @Inject
-    StartpunktUtlederPersonopplysning(PersonopplysningRepository personopplysningRepository,
-                                      FagsakRepository fagsakRepository) {
+    StartpunktUtlederPersonopplysning(PersonopplysningRepository personopplysningRepository) {
         this.personopplysningRepository = personopplysningRepository;
-        this.fagsakRepository = fagsakRepository;
     }
 
     @Override
@@ -61,8 +54,6 @@ class StartpunktUtlederPersonopplysning implements EndringStartpunktUtleder {
 
         PersonopplysningGrunnlagDiff poDiff = new PersonopplysningGrunnlagDiff(aktørId, oppdatertGrunnlag, forrigeGrunnlag);
         boolean forelderDødEndret = poDiff.erForeldreDødsdatoEndret();
-        boolean personstatusEndret = poDiff.erPersonstatusEndretForSøkerFør(null);
-        boolean personstatusUnntattDødEndret = personstatusUnntattDødEndret(personstatusEndret, forelderDødEndret);
 
         Set<StartpunktType> startpunkter = new LinkedHashSet<>();
         if (forelderDødEndret) {
@@ -79,21 +70,6 @@ class StartpunktUtlederPersonopplysning implements EndringStartpunktUtleder {
             startpunkter.add(StartpunktType.UTTAKSVILKÅR);
         }
 
-        final LocalDate skjæringstidspunkt = ref.getUtledetSkjæringstidspunkt();
-        if (personstatusUnntattDødEndret) {
-            leggTilBasertPåSTP(oppdatertGrunnlag.getId(), håndtereNull(forrigeGrunnlag), startpunkter, poDiff.erPersonstatusEndretForSøkerFør(skjæringstidspunkt), "personstatus");
-        }
-        if (!Set.of(FagsakYtelseType.PSB, FagsakYtelseType.PPN).contains(ref.getFagsakYtelseType()) && poDiff.erAdresserEndretFør(null)) {
-            leggTilBasertPåSTP(oppdatertGrunnlag.getId(), håndtereNull(forrigeGrunnlag), startpunkter, poDiff.erSøkersAdresseEndretFør(skjæringstidspunkt), "adresse");
-        }
-
-        if (poDiff.erRegionEndretForBruker()) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(source, StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP, "region", oppdatertGrunnlag.getId(), håndtereNull(forrigeGrunnlag));
-            startpunkter.add(StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP);
-        }
-        if (poDiff.erRelasjonerEndret()) {
-            leggTilForRelasjoner(oppdatertGrunnlag.getId(), håndtereNull(forrigeGrunnlag), poDiff, startpunkter);
-        }
         if (startpunkter.isEmpty()) {
             // Endringen som trigget utledning av startpunkt skal ikke styre startpunkt
             FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(source, StartpunktType.UDEFINERT, "personopplysning - andre endringer", oppdatertGrunnlag.getId(), håndtereNull(forrigeGrunnlag));
@@ -106,31 +82,4 @@ class StartpunktUtlederPersonopplysning implements EndringStartpunktUtleder {
         return forrigeGrunnlag != null ? forrigeGrunnlag.getId() : null;
     }
 
-    private void leggTilBasertPåSTP(Long g1Id, Long g2Id, Set<StartpunktType> startpunkter, boolean endretFørStp, String loggMelding) {
-        if (endretFørStp) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(source, StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP, loggMelding, g1Id, g2Id);
-            startpunkter.add(StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP);
-        }
-    }
-
-    private void leggTilForRelasjoner(Long g1Id, Long g2Id, PersonopplysningGrunnlagDiff poDiff, Set<StartpunktType> startpunkter) {
-        if (poDiff.erRelasjonerEndretSøkerAntallBarn()) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(source, StartpunktType.UDEFINERT, "personopplysning - relasjon på grunn av fødsel", g1Id, g2Id);
-            startpunkter.add(StartpunktType.UDEFINERT);
-        }
-
-        var relasjonStartpunkt = StartpunktType.KONTROLLER_FAKTA;
-        if (poDiff.erRelasjonerEndretForSøkerUtenomNyeBarn()) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(source, relasjonStartpunkt, "personopplysning - brukers relasjoner annet enn fødsel", g1Id, g2Id);
-            startpunkter.add(relasjonStartpunkt);
-        }
-        if (poDiff.erRelasjonerEndretForEksisterendeBarn()) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(source, relasjonStartpunkt, "personopplysning - barns relasjoner annet enn fødsel", g1Id, g2Id);
-            startpunkter.add(relasjonStartpunkt);
-        }
-    }
-
-    private boolean personstatusUnntattDødEndret(boolean personstatusEndret, boolean søkerErDødEndret) {
-        return personstatusEndret && !søkerErDødEndret;
-    }
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederProsessTriggere.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederProsessTriggere.java
@@ -59,17 +59,8 @@ class StartpunktUtlederProsessTriggere implements EndringStartpunktUtleder {
         if (BehandlingÅrsakType.RE_SATS_REGULERING.equals(it.getÅrsak())) {
             return StartpunktType.BEREGNING;
         }
-        if (BehandlingÅrsakType.RE_ENDRET_FORDELING.equals(it.getÅrsak())) {
-            return StartpunktType.BEREGNING;
-        }
-        if (Set.of(BehandlingÅrsakType.RE_ENDRING_FRA_ANNEN_OMSORGSPERSON, BehandlingÅrsakType.RE_UTSATT_BEHANDLING).contains(it.getÅrsak())) {
-            return StartpunktType.UTTAKSVILKÅR;
-        }
-        if (Objects.equals(BehandlingÅrsakType.RE_OPPLYSNINGER_OM_MEDLEMSKAP, it.getÅrsak())) {
-            return StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP;
-        }
         log.info("Ukjent trigger {} med ukjent startpunkt, starter fra starten", it.getÅrsak());
-        return StartpunktType.INIT_PERIODER;
+        return StartpunktType.INNHENT_REGISTEROPPLYSNINGER;
     }
 
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederUngdomsprogramperiode.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederUngdomsprogramperiode.java
@@ -1,0 +1,61 @@
+package no.nav.ung.sak.domene.registerinnhenting.impl.startpunkt;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.ung.sak.behandling.BehandlingReferanse;
+import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.hendelser.StartpunktType;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPerioder;
+import no.nav.ung.sak.domene.registerinnhenting.EndringStartpunktUtleder;
+import no.nav.ung.sak.domene.registerinnhenting.GrunnlagRef;
+import no.nav.ung.sak.trigger.ProsessTriggere;
+import no.nav.ung.sak.trigger.ProsessTriggereRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@ApplicationScoped
+@GrunnlagRef(UngdomsprogramPeriodeGrunnlag.class)
+@FagsakYtelseTypeRef
+class StartpunktUtlederUngdomsprogramperiode implements EndringStartpunktUtleder {
+
+    private static final Logger log = LoggerFactory.getLogger(StartpunktUtlederUngdomsprogramperiode.class);
+    private UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository;
+
+    StartpunktUtlederUngdomsprogramperiode() {
+        // For CDI
+    }
+
+    @Inject
+    public StartpunktUtlederUngdomsprogramperiode(UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository) {
+        this.ungdomsprogramPeriodeRepository = ungdomsprogramPeriodeRepository;
+    }
+
+    @Override
+    public StartpunktType utledStartpunkt(BehandlingReferanse ref, Object nyeste, Object eldste) {
+        var eldsteGrunnlag = new HashSet<>(ungdomsprogramPeriodeRepository.hentGrunnlagBasertPåId((Long) eldste)
+            .map(UngdomsprogramPeriodeGrunnlag::getUngdomsprogramPerioder)
+            .map(UngdomsprogramPerioder::getPerioder)
+            .orElseGet(Set::of));
+        var nyesteGrunnlag = new HashSet<>(ungdomsprogramPeriodeRepository.hentGrunnlagBasertPåId((Long) nyeste)
+            .map(UngdomsprogramPeriodeGrunnlag::getUngdomsprogramPerioder)
+            .map(UngdomsprogramPerioder::getPerioder)
+            .orElseGet(Set::of));
+
+        nyesteGrunnlag.removeAll(eldsteGrunnlag);
+
+        if (nyesteGrunnlag.isEmpty()) {
+            return StartpunktType.UDEFINERT;
+        }
+
+        log.info("Fant endringer i ungdomsprogramperioder. Flytter til innhenting av registeropplysninger.");
+
+        return StartpunktType.INNHENT_REGISTEROPPLYSNINGER;
+    }
+
+
+}

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/task/InnhentUngdomsprogramperioderTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/ung/sak/domene/registerinnhenting/task/InnhentUngdomsprogramperioderTask.java
@@ -1,0 +1,41 @@
+package no.nav.ung.sak.domene.registerinnhenting.task;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.k9.prosesstask.api.ProsessTask;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.ung.sak.behandlingslager.task.UnderBehandlingProsessTask;
+import no.nav.ung.sak.domene.registerinnhenting.RegisterdataInnhenter;
+import no.nav.ung.sak.ungdomsprogram.UngdomsprogramTjeneste;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+@ProsessTask(InnhentUngdomsprogramperioderTask.TASKTYPE)
+@FagsakProsesstaskRekkefølge(gruppeSekvens = true)
+public class InnhentUngdomsprogramperioderTask extends UnderBehandlingProsessTask {
+
+    public static final String TASKTYPE = "innhentsaksopplysninger.unggdomsprogramperioder";
+    private static final Logger LOGGER = LoggerFactory.getLogger(InnhentUngdomsprogramperioderTask.class);
+    private UngdomsprogramTjeneste ungdomsprogramTjeneste;
+
+    InnhentUngdomsprogramperioderTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public InnhentUngdomsprogramperioderTask(BehandlingRepositoryProvider repositoryProvider,
+                                             UngdomsprogramTjeneste ungdomsprogramTjeneste) {
+        super(repositoryProvider.getBehandlingRepository(), null /* håndterer låsing selv på senere tidspunkt */);
+        this.ungdomsprogramTjeneste = ungdomsprogramTjeneste;
+    }
+
+    @Override
+    public void doProsesser(ProsessTaskData prosessTaskData, Behandling behandling) {
+        LOGGER.info("Innhenter ungdomsprogramperioder for behandling: {}", behandling.getId());
+        ungdomsprogramTjeneste.innhentOpplysninger(behandling);
+    }
+}

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/ung/sak/domene/registerinnhenting/StartpunktTjenesteImplTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/ung/sak/domene/registerinnhenting/StartpunktTjenesteImplTest.java
@@ -57,7 +57,7 @@ public class StartpunktTjenesteImplTest {
         var behRef = BehandlingReferanse.fra(behandling, LocalDate.now());
 
         // Act/Assert
-        assertThat(tjeneste.utledStartpunktForDiffBehandlingsgrunnlag(behRef, endringsresultat)).isEqualTo(StartpunktType.KONTROLLER_FAKTA);
+        assertThat(tjeneste.utledStartpunktForDiffBehandlingsgrunnlag(behRef, endringsresultat)).isEqualTo(StartpunktType.INIT_PERIODER);
     }
 
     private EndringsresultatDiff opprettEndringsresultat(Long grunnlagId1, Long grunnlagId2) {

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/ung/sak/domene/registerinnhenting/StartpunktUtlederMock.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/ung/sak/domene/registerinnhenting/StartpunktUtlederMock.java
@@ -12,6 +12,6 @@ class StartpunktUtlederMock implements EndringStartpunktUtleder {
 
     @Override
     public StartpunktType utledStartpunkt(BehandlingReferanse ref, Object grunnlagId1, Object grunnlagId2) {
-        return StartpunktType.KONTROLLER_FAKTA;
+        return StartpunktType.INIT_PERIODER;
     }
 }

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/ung/sak/domene/registerinnhenting/impl/EndringskontrollerTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/ung/sak/domene/registerinnhenting/impl/EndringskontrollerTest.java
@@ -68,31 +68,6 @@ public class EndringskontrollerTest {
     }
 
     @Test
-    public void skal_håndtere_koarb_utgang_til_inngang() {
-        // Arrange
-        Behandling revurdering = TestScenarioBuilder.builderMedSøknad()
-            .medBehandlingType(BehandlingType.REVURDERING)
-            .lagMocked();
-        internalManipulerBehandling.forceOppdaterBehandlingSteg(revurdering, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD, BehandlingStegStatus.UTGANG, BehandlingStegStatus.UTGANG);
-        var startpunktKoarb = StartpunktType.KONTROLLER_ARBEIDSFORHOLD;
-
-        when(startpunktTjenesteMock.utledStartpunktForDiffBehandlingsgrunnlag(any(), any(EndringsresultatDiff.class))).thenReturn(startpunktKoarb);
-        when(behandlingskontrollTjenesteMock.erStegPassert(any(Long.class), any())).thenReturn(true);
-        when(behandlingskontrollTjenesteMock.erStegPassert(any(Behandling.class), any())).thenReturn(true);
-        when(behandlingskontrollTjenesteMock.sammenlignRekkefølge(any(), any(), any(), any())).thenReturn(0); // Samme steg
-
-        Endringskontroller endringskontroller = new Endringskontroller(behandlingskontrollTjenesteMock, startpunktTjenesteProviderMock, null, historikkinnslagTjenesteMock, kontrollerFaktaTjenesterMock, skjæringstidspunktTjeneste);
-
-        // Act
-        endringskontroller.spolTilStartpunkt(revurdering, EndringsresultatDiff.medDiff(AktørInntekt.class, 1L, 2L));
-
-        // Assert
-        assertThat(revurdering.getStartpunkt()).isEqualTo(UDEFINERT); // Ikke satt
-        verify(behandlingskontrollTjenesteMock, times(1)).behandlingTilbakeføringHvisTidligereBehandlingSteg(any(), any());
-        verifyNoInteractions(kontrollerFaktaTjenesteMock);
-    }
-
-    @Test
     public void skal_spole_til_start_når_førstegangsbehandling_får_utledet_startpunkt_til_venstre_for_aktivt_steg() {
         // Arrange
         Behandling behandling = TestScenarioBuilder.builderMedSøknad()
@@ -168,7 +143,7 @@ public class EndringskontrollerTest {
         StartpunktType startpunktTypePåBehandling = StartpunktType.UDEFINERT;
         revurdering.setStartpunkt(startpunktTypePåBehandling);
 
-        var startpunktUtledetFraEndringssjekk = StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP;
+        var startpunktUtledetFraEndringssjekk = StartpunktType.BEREGNING;
         when(startpunktTjenesteMock.utledStartpunktForDiffBehandlingsgrunnlag(any(), any(EndringsresultatDiff.class))).thenReturn(startpunktUtledetFraEndringssjekk);
         Endringskontroller endringskontroller = new Endringskontroller(behandlingskontrollTjenesteMock, startpunktTjenesteProviderMock, null,
             null, kontrollerFaktaTjenesterMock, skjæringstidspunktTjeneste);
@@ -186,13 +161,13 @@ public class EndringskontrollerTest {
         Behandling behandling = TestScenarioBuilder.builderMedSøknad()
             .medBehandlingType(BehandlingType.REVURDERING)
             .lagMocked();
-        internalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, BehandlingStegType.KONTROLLER_FAKTA, BehandlingStegStatus.UTGANG, BehandlingStegStatus.UTFØRT);
+        internalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, BehandlingStegType.INIT_PERIODER, BehandlingStegStatus.UTGANG, BehandlingStegStatus.UTFØRT);
 
-        var startpunktSrb = StartpunktType.KONTROLLER_FAKTA;
+        var startpunktSrb = StartpunktType.INIT_PERIODER;
         when(startpunktTjenesteMock.utledStartpunktForDiffBehandlingsgrunnlag(any(), any(EndringsresultatDiff.class))).thenReturn(startpunktSrb);
         Endringskontroller endringskontroller = new Endringskontroller(behandlingskontrollTjenesteMock, startpunktTjenesteProviderMock, null,
             historikkinnslagTjenesteMock, kontrollerFaktaTjenesterMock, skjæringstidspunktTjeneste);
-        when(behandlingskontrollTjenesteMock.finnBehandlingSteg(any(StartpunktType.class), any(FagsakYtelseType.class), any(BehandlingType.class))).thenReturn(BehandlingStegType.KONTROLLER_FAKTA);
+        when(behandlingskontrollTjenesteMock.finnBehandlingSteg(any(StartpunktType.class), any(FagsakYtelseType.class), any(BehandlingType.class))).thenReturn(BehandlingStegType.INIT_PERIODER);
         when(behandlingskontrollTjenesteMock.erStegPassert(any(Long.class), any())).thenReturn(false);
         when(behandlingskontrollTjenesteMock.erStegPassert(any(Behandling.class), any())).thenReturn(false);
         when(behandlingskontrollTjenesteMock.sammenlignRekkefølge(any(), any(), any(), any())).thenReturn(0);
@@ -201,7 +176,7 @@ public class EndringskontrollerTest {
         endringskontroller.spolTilStartpunkt(behandling, EndringsresultatDiff.medDiff(AktørInntekt.class, 1L, 2L));
 
         // Assert
-        verify(behandlingskontrollTjenesteMock).behandlingTilbakeføringHvisTidligereBehandlingSteg(any(), eq(BehandlingStegType.KONTROLLER_FAKTA));
+        verify(behandlingskontrollTjenesteMock).behandlingTilbakeføringHvisTidligereBehandlingSteg(any(), eq(BehandlingStegType.INIT_PERIODER));
     }
 
     @Test
@@ -210,9 +185,9 @@ public class EndringskontrollerTest {
         Behandling behandling = TestScenarioBuilder.builderMedSøknad()
             .medBehandlingType(BehandlingType.REVURDERING)
             .lagMocked();
-        internalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, BehandlingStegType.KONTROLLER_FAKTA, BehandlingStegStatus.INNGANG, BehandlingStegStatus.UTFØRT);
+        internalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, BehandlingStegType.INIT_PERIODER, BehandlingStegStatus.INNGANG, BehandlingStegStatus.UTFØRT);
 
-        var startpunktSrb = StartpunktType.KONTROLLER_FAKTA;
+        var startpunktSrb = StartpunktType.INIT_PERIODER;
         when(startpunktTjenesteMock.utledStartpunktForDiffBehandlingsgrunnlag(any(), any(EndringsresultatDiff.class))).thenReturn(startpunktSrb);
         Endringskontroller endringskontroller = new Endringskontroller(behandlingskontrollTjenesteMock, startpunktTjenesteProviderMock, null,
             historikkinnslagTjenesteMock, kontrollerFaktaTjenesterMock, skjæringstidspunktTjeneste);

--- a/domenetjenester/ungdomsprogram/src/main/java/no/nav/ung/sak/ungdomsprogram/UngdomsprogramTjeneste.java
+++ b/domenetjenester/ungdomsprogram/src/main/java/no/nav/ung/sak/ungdomsprogram/UngdomsprogramTjeneste.java
@@ -7,7 +7,7 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
-import no.nav.ung.sak.behandlingskontroll.BehandlingskontrollKontekst;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
@@ -28,8 +28,7 @@ public class UngdomsprogramTjeneste {
     public UngdomsprogramTjeneste() {
     }
 
-    public void innhentOpplysninger(BehandlingskontrollKontekst kontekst) {
-        var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
+    public void innhentOpplysninger(Behandling behandling) {
         var registerOpplysninger = ungdomsprogramRegisterKlient.hentForAktørId(behandling.getFagsak().getAktørId().getAktørId());
 
         if (registerOpplysninger.opplysninger().isEmpty()) {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved endring av en programperiode fram og tilbake vil endringen tilbake ikke medføre en endring i prosesstriggere, siden denne triggeren allerede er til stede (med samme periode). For at behandlingen skal rulles tilbake til riktig steg er vi avhengig av å detektere en endring i et grunnlag. Dette kan gjøres ved å innhente ungdomsprogrammet og diffe dette difftask som kjører registerinnhenting.

### **Løsning**
Tasken for opprettelse av revurdering og diff har i dag sjekk på enkelte behandlingsårsaker. Vi utvider denne til å sjekke på om vi har behandlingårsak for endring i ungdomsprogrammet. Deretter innhenter vi ny ungdomsprogramperiode via registerinnhenting og utleder diff for å flytte behandlingen tilbake.

### **Andre endringer**
Rydder opp i ubrukte startpunkttyper
