### PR TITLE
TSFF-1432: Gjør avviksvurdering/kontroll mot ytelse i register. Sammenligner registeropplysninger for atfl dersom bruker har svart på etterlysning.

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/Avviksvurdering.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/Avviksvurdering.java
@@ -5,6 +5,7 @@ import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.fpsak.tidsserie.StandardCombinators;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.sak.ytelse.EtterlysningOgRegisterinntekt;
+import no.nav.ung.sak.ytelse.InntektType;
 import no.nav.ung.sak.ytelse.RapportertInntekt;
 import no.nav.ung.sak.ytelse.RapporterteInntekter;
 
@@ -15,24 +16,76 @@ import static no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll.Finn
 
 public class Avviksvurdering {
 
-    public static final BigDecimal AKSEPTERT_DIFFERANSE = BigDecimal.valueOf(1000);
 
+    private final BigDecimal akseptertDifferanse;
 
-    static LocalDateTimeline<KontrollResultat> gjørAvviksvurderingMotRegisterinntekt(
+    public Avviksvurdering(BigDecimal akseptertDifferanse) {
+        this.akseptertDifferanse = akseptertDifferanse;
+    }
+
+    LocalDateTimeline<KontrollResultat> gjørAvviksvurderingMotRegisterinntekt(
         LocalDateTimeline<RapporterteInntekter> gjeldendeRapporterteInntekter,
         LocalDateTimeline<EtterlysningOgRegisterinntekt> etterlysningTidslinje,
         LocalDateTimeline<Set<BehandlingÅrsakType>> tidslinjeRelevanteÅrsaker) {
 
         //Finner tidslinje der det er avvik mellom register og rapportert inntekt
-        final var inntektDiffKontrollResultat = finnKontrollresultatTidslinje(gjeldendeRapporterteInntekter, tidslinjeRelevanteÅrsaker);
-
-        final var tidslinjeForOppgaveTilBruker = inntektDiffKontrollResultat.filterValue(it -> it.equals(KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER));
+        final var kontrollTidslinje = finnKontrollresultatTidslinje(gjeldendeRapporterteInntekter, etterlysningTidslinje, tidslinjeRelevanteÅrsaker);
+        final var tidslinjeForOppgaveTilBruker = forOppgaveTilBruker(kontrollTidslinje);
 
         // Må finne ut om vi skal sette ny frist hvis registeret har oppdatert seg
         final var oppgaverTilBrukerTidslinje = finnNyOppgaveKontrollresultatTidslinje(gjeldendeRapporterteInntekter, etterlysningTidslinje, tidslinjeForOppgaveTilBruker);
 
         //Resultat
-        return inntektDiffKontrollResultat.crossJoin(oppgaverTilBrukerTidslinje, StandardCombinators::coalesceRightHandSide);
+        return kontrollTidslinje.crossJoin(oppgaverTilBrukerTidslinje, StandardCombinators::coalesceRightHandSide);
+    }
+
+    private LocalDateTimeline<KontrollResultat> finnKontrollresultatTidslinje(LocalDateTimeline<RapporterteInntekter> gjeldendeRapporterteInntekter,
+                                                                              LocalDateTimeline<EtterlysningOgRegisterinntekt> etterlysningTidslinje,
+                                                                              LocalDateTimeline<Set<BehandlingÅrsakType>> tidslinjeRelevanteÅrsaker) {
+        final var godkjentRegisterinntektTidslinje = etterlysningTidslinje
+            .intersection(tidslinjeRelevanteÅrsaker)
+            .filterValue(etterlysning -> etterlysning.etterlysning() != null && Boolean.TRUE.equals(etterlysning.etterlysning().erEndringenGodkjent()))
+            .mapValue(EtterlysningOgRegisterinntekt::registerInntekt);
+
+        final var brukersRapporteInntekter = gjeldendeRapporterteInntekter
+            .intersection(tidslinjeRelevanteÅrsaker)
+            .mapValue(RapporterteInntekter::brukerRapporterteInntekter);
+
+        final var brukersGodkjenteEllerRapporterteInntekter = godkjentRegisterinntektTidslinje.crossJoin(brukersRapporteInntekter);
+
+        final var registerinntektTidslinje = gjeldendeRapporterteInntekter
+            .intersection(tidslinjeRelevanteÅrsaker)
+            .mapValue(RapporterteInntekter::registerRapporterteInntekter);
+
+
+        return registerinntektTidslinje.combine(brukersGodkjenteEllerRapporterteInntekter, (di, lhs, rhs) -> {
+                if (rhs == null) {
+                    return new LocalDateSegment<>(di, KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER);
+                }
+                return new LocalDateSegment<>(di, finnSamletKontrollresultat(lhs, rhs));
+            }, LocalDateTimeline.JoinStyle.CROSS_JOIN)
+            .crossJoin(tidslinjeRelevanteÅrsaker.mapValue(it -> KontrollResultat.BRUK_GODKJENT_ELLER_RAPPORTERT_INNTEKT_FRA_BRUKER));
+    }
+
+    private KontrollResultat finnSamletKontrollresultat(LocalDateSegment<Set<RapportertInntekt>> register, LocalDateSegment<Set<RapportertInntekt>> godkjentEllerRapportertAvBruker) {
+        final var kontrollResultatATFL = finnKontrollresultatForType(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, register.getValue(), godkjentEllerRapportertAvBruker.getValue());
+        final var kontrollResultatYtelse = finnKontrollresultatForType(InntektType.YTELSE, register.getValue(), godkjentEllerRapportertAvBruker.getValue());
+
+        if (kontrollResultatATFL.equals(KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER) || kontrollResultatYtelse.equals(KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER)) {
+            // Prioriterer å opprette oppgave dersom det er avvik på ytelse eller atfl
+            return KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER;
+        } else if (kontrollResultatATFL.equals(KontrollResultat.OPPRETT_AKSJONSPUNKT) || kontrollResultatYtelse.equals(KontrollResultat.OPPRETT_AKSJONSPUNKT)) {
+            // Deretter sjekke vi aksjonspunkt
+            return KontrollResultat.OPPRETT_AKSJONSPUNKT;
+        } else {
+            // Til slutt, bruk godkjent/rapportert fra bruker
+            return KontrollResultat.BRUK_GODKJENT_ELLER_RAPPORTERT_INNTEKT_FRA_BRUKER;
+        }
+    }
+
+    private static LocalDateTimeline<KontrollResultat> forOppgaveTilBruker(LocalDateTimeline<KontrollResultat> atflInntektDiffKontrollResultat) {
+        return atflInntektDiffKontrollResultat
+            .filterValue(it -> it.equals(KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER));
     }
 
     private static LocalDateTimeline<KontrollResultat> finnNyOppgaveKontrollresultatTidslinje(
@@ -55,27 +108,24 @@ public class Avviksvurdering {
         return oppgaverTilBrukerTidslinje;
     }
 
-    private static LocalDateTimeline<KontrollResultat> finnKontrollresultatTidslinje(LocalDateTimeline<RapporterteInntekter> gjeldendeRapporterteInntekter, LocalDateTimeline<Set<BehandlingÅrsakType>> tidslinjeRelevanteÅrsaker) {
-        final var inntektDiffKontrollResultat = gjeldendeRapporterteInntekter.intersection(tidslinjeRelevanteÅrsaker)
-            .mapValue(it ->
-            {
-                final var register = it.registerRapporterteInntekter().stream()
-                    .map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
-                final var bruker = it.brukerRapporterteInntekter().stream()
-                    .map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
+    private KontrollResultat finnKontrollresultatForType(InntektType inntektType, Set<RapportertInntekt> registerinntekter, Set<RapportertInntekt> brukersInntekter) {
+        final var register = registerinntekter.stream()
+            .filter(inntekt -> inntekt.inntektType().equals(inntektType))
+            .map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
+        final var bruker = brukersInntekter.stream()
+            .filter(inntekt -> inntekt.inntektType().equals(inntektType))
+            .map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
 
-                final var differanse = register.subtract(bruker).abs();
+        final var differanse = register.subtract(bruker).abs();
 
-                if (differanse.compareTo(AKSEPTERT_DIFFERANSE) > 0) {
-                    if (register.compareTo(BigDecimal.ZERO) == 0) {
-                        return KontrollResultat.OPPRETT_AKSJONSPUNKT;
-                    }
-                    return KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER;
-                } else {
-                    return KontrollResultat.BRUK_INNTEKT_FRA_BRUKER;
-                }
-            });
-        return inntektDiffKontrollResultat.crossJoin(tidslinjeRelevanteÅrsaker.mapValue(it -> KontrollResultat.BRUK_INNTEKT_FRA_BRUKER), StandardCombinators::coalesceLeftHandSide);
+        if (differanse.compareTo(akseptertDifferanse) > 0) {
+            if (register.compareTo(BigDecimal.ZERO) == 0) {
+                return KontrollResultat.OPPRETT_AKSJONSPUNKT;
+            }
+            return KontrollResultat.OPPRETT_OPPGAVE_TIL_BRUKER;
+        } else {
+            return KontrollResultat.BRUK_GODKJENT_ELLER_RAPPORTERT_INNTEKT_FRA_BRUKER;
+        }
     }
 
 

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollResultat.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollResultat.java
@@ -1,7 +1,7 @@
 package no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll;
 
 public enum KontrollResultat {
-    BRUK_INNTEKT_FRA_BRUKER,
+    BRUK_GODKJENT_ELLER_RAPPORTERT_INNTEKT_FRA_BRUKER,
     OPPRETT_AKSJONSPUNKT,
     OPPRETT_OPPGAVE_TIL_BRUKER,
     OPPRETT_OPPGAVE_TIL_BRUKER_MED_NY_FRIST,

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjeneste.java
@@ -6,6 +6,7 @@ import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.sak.ytelse.EtterlysningOgRegisterinntekt;
 import no.nav.ung.sak.ytelse.RapporterteInntekter;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
 
@@ -13,7 +14,13 @@ import static no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll.Finn
 
 public class KontrollerInntektTjeneste {
 
-    public static LocalDateTimeline<KontrollResultat> utførKontroll(
+    private final BigDecimal akseptertDifferanse;
+
+    public KontrollerInntektTjeneste(BigDecimal akseptertDifferanse) {
+        this.akseptertDifferanse = akseptertDifferanse;
+    }
+
+    public LocalDateTimeline<KontrollResultat> utførKontroll(
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje,
         LocalDateTimeline<RapporterteInntekter> gjeldendeRapporterteInntekter,
         LocalDateTimeline<EtterlysningOgRegisterinntekt> etterlysningTidslinje) {
@@ -34,7 +41,7 @@ public class KontrollerInntektTjeneste {
         var kontrollresultatForIkkeGodkjentUttalelse = finnKontrollresultatForIkkeGodkjentUttalelse(gjeldendeRapporterteInntekter, relevantIkkeGodkjentUttalelse);
         resultatTidslinje = resultatTidslinje.crossJoin(kontrollresultatForIkkeGodkjentUttalelse, StandardCombinators::coalesceLeftHandSide);
 
-        var avviksvurderingMotRegisterinntekt = Avviksvurdering.gjørAvviksvurderingMotRegisterinntekt(
+        var avviksvurderingMotRegisterinntekt = new Avviksvurdering(akseptertDifferanse).gjørAvviksvurderingMotRegisterinntekt(
             gjeldendeRapporterteInntekter,
             etterlysningTidslinje,
             tidslinjeRelevanteÅrsaker);

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/uttak/RapportertInntektMapperTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/uttak/RapportertInntektMapperTest.java
@@ -69,7 +69,7 @@ class RapportertInntektMapperTest {
         final var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().with(TemporalAdjusters.lastDayOfMonth()));
         final var arbeidsinntekt = BigDecimal.TEN;
         final var næringsinntekt = BigDecimal.ONE;
-        final var oppgittOpptjening = lagMottattATFLOgNæringInntekt(periode, arbeidsinntekt, næringsinntekt, LocalDateTime.now());
+        final var oppgittOpptjening = lagMottattATFLInntekt(periode, arbeidsinntekt, næringsinntekt, LocalDateTime.now());
         mockIAY(List.of(oppgittOpptjening));
 
         // Act
@@ -78,9 +78,8 @@ class RapportertInntektMapperTest {
         // Assert
         final var forventet = new LocalDateTimeline<>(periode.getFomDato(), periode.getTomDato(),
             new RapporterteInntekter(Set.of(
-                new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, arbeidsinntekt),
-                new RapportertInntekt(InntektType.SELVSTENDIG_NÆRINGSDRIVENDE, næringsinntekt)
-                ), Set.of()));
+                new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, arbeidsinntekt)
+            ), Set.of()));
         assertThat(tidslinje).isEqualTo(forventet);
     }
 
@@ -109,11 +108,11 @@ class RapportertInntektMapperTest {
             List.of(
                 new LocalDateSegment<>(periode.getFomDato(), periode.getTomDato(), new RapporterteInntekter(
                     Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, inntekt)),
-                        Set.of())),
+                    Set.of())),
                 new LocalDateSegment<>(periode2.getFomDato(), periode2.getTomDato(), new RapporterteInntekter(
                     Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, inntekt2)),
                     Set.of()))
-                ));
+            ));
         assertThat(tidslinje).isEqualTo(forventet);
     }
 
@@ -155,14 +154,12 @@ class RapportertInntektMapperTest {
         return oppgittOpptjening;
     }
 
-    private static OppgittOpptjening lagMottattATFLOgNæringInntekt(DatoIntervallEntitet periode, BigDecimal atflInntekt, BigDecimal næringsinntekt, LocalDateTime innsendt) {
+    private static OppgittOpptjening lagMottattATFLInntekt(DatoIntervallEntitet periode, BigDecimal atflInntekt, BigDecimal næringsinntekt, LocalDateTime innsendt) {
         final var oppgittArbeidsforhold = lagOppgittArbeidOgFrilansInntekt(periode, atflInntekt);
-        final var oppgittNæring = lagOppgittNæringsinntekt(periode, næringsinntekt);
         final var oppgittOpptjening = OppgittOpptjeningBuilder.ny()
             .medInnsendingstidspunkt(innsendt)
             .medJournalpostId(new JournalpostId("21412"))
             .leggTilOppgittArbeidsforhold(oppgittArbeidsforhold)
-            .leggTilEgneNæringer(List.of(oppgittNæring))
             .build();
         return oppgittOpptjening;
     }
@@ -179,11 +176,4 @@ class RapportertInntektMapperTest {
             .medPeriode(periode)
             .medInntekt(inntekt);
     }
-
-    private static OppgittOpptjeningBuilder.EgenNæringBuilder lagOppgittNæringsinntekt(DatoIntervallEntitet periode, BigDecimal inntekt) {
-        return OppgittOpptjeningBuilder.EgenNæringBuilder.ny()
-            .medPeriode(periode)
-            .medBruttoInntekt(inntekt);
-    }
-
 }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/InntektType.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/InntektType.java
@@ -3,7 +3,6 @@ package no.nav.ung.sak.ytelse;
 public enum InntektType {
 
     ARBEIDSTAKER_ELLER_FRILANSER,
-    SELVSTENDIG_NÆRINGSDRIVENDE,
     YTELSE
 
 }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/RapportertInntektMapper.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/RapportertInntektMapper.java
@@ -201,20 +201,8 @@ public class RapportertInntektMapper {
     }
 
     private static InntektForMottattidspunkt finnInntekterPrMottattidspunkt(OppgittOpptjening o) {
-        final var res = new ArrayList<LocalDateSegment<Set<RapportertInntekt>>>();
-        res.addAll(finnArbeidOgFrilansSegmenter(o));
-        res.addAll(finnNæringssegmenter(o));
+        final var res = new ArrayList<>(finnArbeidOgFrilansSegmenter(o));
         return new InntektForMottattidspunkt(o.getInnsendingstidspunkt(), new LocalDateTimeline<>(res, StandardCombinators::union));
-    }
-
-    private static List<LocalDateSegment<Set<RapportertInntekt>>> finnNæringssegmenter(OppgittOpptjening o) {
-        return o.getEgenNæring().stream()
-            .map(it -> new LocalDateSegment<>(
-                it.getPeriode().toLocalDateInterval(),
-                Set.of(new RapportertInntekt(
-                    InntektType.SELVSTENDIG_NÆRINGSDRIVENDE,
-                    it.getBruttoInntekt())
-                ))).toList();
     }
 
     private static List<LocalDateSegment<Set<RapportertInntekt>>> finnArbeidOgFrilansSegmenter(OppgittOpptjening o) {

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/inntektrapportering/OppgittOpptjeningMapper.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/inntektrapportering/OppgittOpptjeningMapper.java
@@ -1,9 +1,5 @@
 package no.nav.ung.sak.mottak.dokumentmottak.inntektrapportering;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.UUID;
-
 import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.OppgittOpptjeningMottattRequest;
@@ -15,20 +11,16 @@ import no.nav.ung.sak.domene.abakus.mapping.IAYTilDtoMapper;
 import no.nav.ung.sak.domene.iay.modell.OppgittOpptjeningBuilder;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
 public class OppgittOpptjeningMapper {
 
     public static Optional<OppgittOpptjeningMottattRequest> mapRequest(BehandlingReferanse behandlingReferanse,
-                                                                MottattDokument dokument,
-                                                                OppgittInntekt oppgittInntekt) {
+                                                                       MottattDokument dokument,
+                                                                       OppgittInntekt oppgittInntekt) {
 
-
-        final var oppgittNæring = oppgittInntekt.getOppgittePeriodeinntekter()
-            .stream()
-            .filter(it -> it.getNæringsinntekt() != null)
-            .map(inntekter -> OppgittOpptjeningBuilder.EgenNæringBuilder.ny()
-                .medBruttoInntekt(inntekter.getNæringsinntekt())
-                .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(inntekter.getPeriode().getFraOgMed(), inntekter.getPeriode().getTilOgMed())))
-            .toList();
 
         final var oppgittArbeidOgFrilans = oppgittInntekt.getOppgittePeriodeinntekter()
             .stream()
@@ -39,10 +31,9 @@ public class OppgittOpptjeningMapper {
                 .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(inntekter.getPeriode().getFraOgMed(), inntekter.getPeriode().getTilOgMed())))
             .toList();
 
-        if (!oppgittArbeidOgFrilans.isEmpty() || !oppgittNæring.isEmpty()) {
+        if (!oppgittArbeidOgFrilans.isEmpty()) {
             var builder = OppgittOpptjeningBuilder.ny(UUID.randomUUID(), LocalDateTime.now());
             builder.leggTilOppgittArbeidsforhold(oppgittArbeidOgFrilans);
-            builder.leggTilEgneNæringer(oppgittNæring);
             builder.leggTilJournalpostId(dokument.getJournalpostId());
             builder.leggTilInnsendingstidspunkt(dokument.getInnsendingstidspunkt());
             return Optional.of(byggRequest(behandlingReferanse, builder));

--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/InntektBekreftelseHåndterer.java
@@ -39,16 +39,13 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
 
 
     private final EtterlysningRepository etterlysningRepository;
-    private final ProsessTaskTjeneste prosessTaskTjeneste;
     private final MottatteDokumentRepository mottatteDokumentRepository;
 
 
     @Inject
     public InntektBekreftelseHåndterer(EtterlysningRepository etterlysningRepository,
-                                       ProsessTaskTjeneste prosessTaskTjeneste,
                                        MottatteDokumentRepository mottatteDokumentRepository) {
         this.etterlysningRepository = etterlysningRepository;
-        this.prosessTaskTjeneste = prosessTaskTjeneste;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
     }
 
@@ -62,16 +59,9 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
             throw new IllegalStateException("Etterlysning må hå status VENTER for å motta bekreftelse. Status var " + etterlysning.getStatus());
         }
 
-        ProsessTaskGruppe gruppe = new ProsessTaskGruppe();
-
-        if (inntektBekreftelse.harBrukerGodtattEndringen()) {
-            var abakusTask = lagOppdaterAbakusTask(oppgaveBekreftelseInnhold);
-            gruppe.addNesteSekvensiell(abakusTask);
-        } else {
-            mottatteDokumentRepository.oppdaterStatus(List.of(oppgaveBekreftelseInnhold.mottattDokument()), DokumentStatus.GYLDIG);
-            Objects.requireNonNull(inntektBekreftelse.getUttalelseFraBruker(),
-                "Uttalelsestekst fra bruker må være satt når bruker ikke har godtatt endringen");
-        }
+        mottatteDokumentRepository.oppdaterStatus(List.of(oppgaveBekreftelseInnhold.mottattDokument()), DokumentStatus.GYLDIG);
+        Objects.requireNonNull(inntektBekreftelse.getUttalelseFraBruker(),
+            "Uttalelsestekst fra bruker må være satt når bruker ikke har godtatt endringen");
 
         etterlysning.mottattUttalelse(
             oppgaveBekreftelseInnhold.mottattDokument().getJournalpostId(),
@@ -80,7 +70,6 @@ public class InntektBekreftelseHåndterer implements BekreftelseHåndterer {
         );
 
         etterlysningRepository.lagre(etterlysning);
-        prosessTaskTjeneste.lagre(gruppe);
     }
 
     @Override


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom bruker har mottatt ytelse og dette er registrert i a-ordningen skal bruker få en oppgave for å bekrefte at dette er riktig.

### **Løsning**
Sammenligner alltid siste godkjente registeropplysninger med gjeldende registeropplysninger dersom vi har mottatt svar på etterlysning. Dersom vi ikke har mottatt svar på etterlysning brukes opplysninger som bruker eventuelt har rapportert selv.

SIden bruker ikke har mulighet til å rapportere ytelse vil dette føre til en diff ved første kontroll dersom vi finner ytelse i register.

### **Andre endringer**
Fjerner mapping av næringsinntekt.

Fjerner lagring av inntekt som rapporteres via svar på etterlysning (her skal vi kun bruke grunnlagsreferansen til å finne hvilken inntekt bruker godkjente).

