### PR TITLE
TSFF-1456: Endre høy sats til 2,041 og lav sats defineres fra høy sats

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/ytelse/sats/GrunnbeløpfaktorTidslinje.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/ytelse/sats/GrunnbeløpfaktorTidslinje.java
@@ -9,19 +9,15 @@ import java.time.LocalDate;
 import java.util.List;
 
 public class GrunnbeløpfaktorTidslinje {
-    private static LocalDateTimeline<BigDecimal> LAV_GRUNNBELØPFAKTOR_TIDSLINJE = new LocalDateTimeline<>(
-        List.of(
-            new LocalDateSegment<>(LocalDate.of(2025, 1, 1), LocalDate.of(2099, 12, 31), BigDecimal.valueOf(4).divide(BigDecimal.valueOf(3), 5, RoundingMode.HALF_UP)),
-            new LocalDateSegment<>(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), BigDecimal.valueOf(4).divide(BigDecimal.valueOf(3), 5, RoundingMode.HALF_UP)) // TODO: Kan fjernes før lansering
-        )
-    );
 
-    private static LocalDateTimeline<BigDecimal> HØY_GRUNNBELØPFAKTOR_TIDSLINJE = new LocalDateTimeline<>(
+    private static final LocalDateTimeline<BigDecimal> HØY_GRUNNBELØPFAKTOR_TIDSLINJE = new LocalDateTimeline<>(
         List.of(
-            new LocalDateSegment<>(LocalDate.of(2025, 1, 1), LocalDate.of(2099, 12, 31), BigDecimal.valueOf(2)),
+            new LocalDateSegment<>(LocalDate.of(2025, 1, 1), LocalDate.of(2099, 12, 31), BigDecimal.valueOf(2.041)),
             new LocalDateSegment<>(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), BigDecimal.valueOf(2)) // TODO: Kan fjernes før lansering
         )
     );
+
+    private static final LocalDateTimeline<BigDecimal> LAV_GRUNNBELØPFAKTOR_TIDSLINJE = HØY_GRUNNBELØPFAKTOR_TIDSLINJE.mapValue(it -> it.multiply(BigDecimal.valueOf(2).divide(BigDecimal.valueOf(3), 10, RoundingMode.HALF_UP)).setScale(5, RoundingMode.HALF_UP));
 
     public static LocalDateTimeline<SatsOgGrunnbeløpfaktor> hentGrunnbeløpfaktorTidslinjeFor(LocalDateTimeline<Sats> sats) {
         return sats.stream()

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/ytelse/UngdomsytelseGrunnlagRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/ytelse/UngdomsytelseGrunnlagRepositoryTest.java
@@ -61,7 +61,7 @@ class UngdomsytelseGrunnlagRepositoryTest {
         var periode1 = new LocalDateInterval(LocalDate.now(), LocalDate.now());
         var dagsats = BigDecimal.TEN;
         var grunnbeløp = BigDecimal.valueOf(50);
-        var grunnbeløpFaktor = BigDecimal.valueOf(2);
+        var grunnbeløpFaktor = BigDecimal.valueOf(2.041);
         lagreBeregning(periode1, dagsats, grunnbeløp, hentSatstypeOgGrunnbeløp(Sats.HØY), 0, 0);
 
         var ungdomsytelseGrunnlag = repository.hentGrunnlag(behandling.getId());
@@ -81,7 +81,7 @@ class UngdomsytelseGrunnlagRepositoryTest {
         var periode1 = new LocalDateInterval(LocalDate.now(), LocalDate.now());
         var dagsats = BigDecimal.TEN;
         var grunnbeløp = BigDecimal.valueOf(50);
-        var grunnbeløpFaktor = BigDecimal.valueOf(2);
+        var grunnbeløpFaktor = BigDecimal.valueOf(2.041);
         var antallBarn = 2;
         var barnetilleggDagsats = 100;
         lagreBeregning(periode1, dagsats, grunnbeløp, hentSatstypeOgGrunnbeløp(Sats.HØY), antallBarn, barnetilleggDagsats);

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/beregning/UngdomsytelseTilkjentYtelseUtleder.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/beregning/UngdomsytelseTilkjentYtelseUtleder.java
@@ -8,6 +8,7 @@ import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseRepository;
 import no.nav.ung.sak.ytelse.DagsatsOgUtbetalingsgrad;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Dependent
 public class UngdomsytelseTilkjentYtelseUtleder implements TilkjentYtelseUtleder {
@@ -23,7 +24,7 @@ public class UngdomsytelseTilkjentYtelseUtleder implements TilkjentYtelseUtleder
     @Override
     public LocalDateTimeline<DagsatsOgUtbetalingsgrad> utledTilkjentYtelseTidslinje(Long behandlingId) {
         final var tilkjentYtelseTidslinje = tilkjentYtelseRepository.hentTidslinje(behandlingId);
-        return tilkjentYtelseTidslinje.mapValue(v -> new DagsatsOgUtbetalingsgrad(v.dagsats().longValue(), BigDecimal.valueOf(v.utbetalingsgrad())));
+        return tilkjentYtelseTidslinje.mapValue(v -> new DagsatsOgUtbetalingsgrad(v.dagsats().setScale(0, RoundingMode.HALF_UP ).longValue(), BigDecimal.valueOf(v.utbetalingsgrad())));
     }
 
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringHøySatsInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringHøySatsInnholdBygger.java
@@ -14,7 +14,6 @@ import no.nav.ung.sak.formidling.vedtak.DetaljertResultat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.RoundingMode;
 import java.time.LocalDate;
 
 @Dependent
@@ -46,9 +45,9 @@ public class EndringHøySatsInnholdBygger implements VedtaksbrevInnholdBygger {
         return new TemplateInnholdResultat(DokumentMalType.ENDRING_DOK, TemplateType.ENDRING_HØY_SATS,
                 new EndringHøySatsDto(
                         satsendringsdato,
-                        nyeSatser.dagsats().setScale(0, RoundingMode.HALF_UP).longValue(),
+                        VedtaksbrevInnholdBygger.tilHeltall(nyeSatser.dagsats()),
                         Sats.HØY.getFomAlder(),
-                        nyeSatser.grunnbeløpFaktor().setScale(2, RoundingMode.HALF_UP)
+                        VedtaksbrevInnholdBygger.tilFaktor(nyeSatser.grunnbeløpFaktor())
                 ));
     }
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektInnholdBygger.java
@@ -22,6 +22,8 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static no.nav.ung.sak.formidling.innhold.VedtaksbrevInnholdBygger.tilHeltall;
+
 @Dependent
 public class EndringRapportertInntektInnholdBygger implements VedtaksbrevInnholdBygger {
 
@@ -92,8 +94,8 @@ public class EndringRapportertInntektInnholdBygger implements VedtaksbrevInnhold
         return new LocalDateSegment<>(p,
             new EndringRapportertInntektPeriodeDto(
                 new PeriodeDto(p.getFomDato(), p.getTomDato()),
-                rhs.getValue().setScale(0, RoundingMode.HALF_UP).longValue(),
-                ty.redusertBeløp().setScale(0, RoundingMode.HALF_UP).longValue(),
+                tilHeltall(rhs.getValue()),
+                tilHeltall(ty.redusertBeløp()),
                 REDUSJON_PROSENT
             )
         );

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/GrunnlagOgTilkjentYtelse.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/GrunnlagOgTilkjentYtelse.java
@@ -1,15 +1,15 @@
 package no.nav.ung.sak.formidling.innhold;
 
-import java.math.BigDecimal;
-
 import no.nav.ung.kodeverk.ungdomsytelse.sats.UngdomsytelseSatsType;
+
+import java.math.BigDecimal;
 
 /**
  * Intermediary objekt for å periodisere felter for beregning og tilkjent ytelse i brev.
  */
 public record GrunnlagOgTilkjentYtelse(
     long dagsats,
-    BigDecimal utbetalingsgrad,
+    long utbetalingsgrad,
     UngdomsytelseSatsType satsType,
     BigDecimal grunnbeløpFaktor,
     long grunnbeløp,

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/VedtaksbrevInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/VedtaksbrevInnholdBygger.java
@@ -4,6 +4,9 @@ import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.formidling.vedtak.DetaljertResultat;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 public interface VedtaksbrevInnholdBygger {
 
     /**
@@ -15,6 +18,20 @@ public interface VedtaksbrevInnholdBygger {
      */
     TemplateInnholdResultat bygg(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultatTidslinje);
 
+
+    /**
+     * Standard desimal avrunding for brev
+     */
+    static BigDecimal tilFaktor(BigDecimal faktor) {
+        return faktor.setScale(3, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Standard heltall avrunding for brev
+     */
+    static long tilHeltall(BigDecimal faktor) {
+        return faktor.setScale(0, RoundingMode.HALF_UP).longValue();
+    }
 }
 
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringHøySatsTest.java
@@ -110,8 +110,8 @@ class BrevGenerererTjenesteEndringHøySatsTest {
         var ungTestGrunnlag = BrevScenarioer.endring25År(fødselsdato);
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             "Vi har endret ungdomsytelsen din " +
-            "Fra 25. mars 2024 får du ny dagsats på 954 kroner fordi du fyller 25 år. " +
-            "Nav utbetaler 2 ganger grunnbeløp fra deltager er 25 år. " +
+            "Fra 25. mars 2024 får du ny dagsats på 974 kroner fordi du fyller 25 år. " +
+            "Nav utbetaler 2.041 ganger grunnbeløp fra deltager er 25 år. " +
             "Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. ");
 
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteEndringInntektTest.java
@@ -111,7 +111,7 @@ class BrevGenerererTjenesteEndringInntektTest {
         var ungTestGrunnlag = BrevScenarioer.endringMedInntektPå10k_19år(fom);
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             "Vi har endret ungdomsytelsen din " +
-                "Du får 8 029 kroner i ungdomsytelse for perioden fra 1. januar 2025 til 31. januar 2025. " +
+                "Du får 8 329 kroner i ungdomsytelse for perioden fra 1. januar 2025 til 31. januar 2025. " +
                 "Det er fordi du har hatt en inntekt på 10 000 kroner i denne perioden. " +
                 "Pengene får du utbetalt før den 10. denne måneden. " +
                 "Når du har en inntekt, får du mindre penger i ungdomsytelse. " +
@@ -142,7 +142,7 @@ class BrevGenerererTjenesteEndringInntektTest {
         var ungTestGrunnlag = BrevScenarioer.endringMedInntektPå10k_flere_mnd_19år(fom);
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             "Vi har endret ungdomsytelsen din " +
-                "Du får 14 150 kroner i ungdomsytelse for perioden fra 1. januar 2025 til 28. februar 2025. " +
+                "Du får 14 711 kroner i ungdomsytelse for perioden fra 1. januar 2025 til 28. februar 2025. " +
                 "Det er fordi du har hatt en inntekt på 20 000 kroner i denne perioden. " +
                 "Pengene får du utbetalt før den 10. denne måneden. " +
                 "Vi har registrert følgende inntekter på deg: " +

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteNyInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteNyInnvilgelseTest.java
@@ -19,7 +19,6 @@ import no.nav.ung.sak.test.util.UnitTestLookupInstanceImpl;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.test.util.behandling.UngTestScenario;
 import no.nav.ung.sak.ungdomsprogram.UngdomsprogramPeriodeTjeneste;
-import no.nav.ung.sak.ytelse.beregning.UngdomsytelseTilkjentYtelseUtleder;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -72,8 +71,8 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
         InnvilgelseInnholdBygger innvilgelseInnholdBygger = new InnvilgelseInnholdBygger(
             ungTestRepositories.ungdomsytelseGrunnlagRepository(),
             ungdomsprogramPeriodeTjeneste,
-            new UngdomsytelseTilkjentYtelseUtleder(tilkjentYtelseRepository),
-            repositoryProvider.getPersonopplysningRepository());
+            repositoryProvider.getPersonopplysningRepository(),
+            tilkjentYtelseRepository);
 
         var ungdomsytelseSøknadsperiodeTjeneste =
             new UngdomsytelseSøknadsperiodeTjeneste(ungTestRepositories.ungdomsytelseStartdatoRepository(), ungdomsprogramPeriodeTjeneste, repositoryProvider.getBehandlingRepository());
@@ -130,7 +129,7 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
             """
                 Nav har innvilget søknaden din om ungdomsytelse \
                 Du har rett til ungdomsytelse fra 1. desember 2024 i 260 dager. \
-                Du får utbetalt 636 kroner dagen, før skatt. \
+                Du får utbetalt 649 kroner dagen, før skatt. \
                 Nav utbetaler pengene innen den 25. i hver måned. \
                 Informasjon om utbetaling finner du under utbetalingsoversikten på "Min side". \
                 Du får ungdomsytelse fordi du er med ungdomsprogrammet. \
@@ -139,11 +138,11 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
                 Det er derfor viktig at du melder i fra om endringer i din inntekt på nav.no/ungdomsytelse/endring og informerer veileder. \
                 Hvis du ikke gir beskjed om endringer i inntekten, kan Nav kreve penger tilbake, så det er viktig å gi beskjed med en gang det skjer endringer. \
                 Nav bruker grunnbeløpet på 124 028 kroner for å regne ut hvor mye du får. \
-                Siden du er under 25 år så får du 1.33 ganger grunnbeløpet. \
+                Siden du er under 25 år så får du 1.361 ganger grunnbeløpet. \
                 Nav regner med 260 virkedager per år utenom helger og ferie. \
                 For å regne ut hva du får per dag, deles årsbeløpet på antall dager. \
-                Det betyr at du har rett på 1.33 x 124 028 = 165 370 kroner i året. \
-                Dette gir en dagsats på 636 kroner. \
+                Det betyr at du har rett på 1.361 x 124 028 = 168 761 kroner i året. \
+                Dette gir en dagsats på 649 kroner. \
                 For å regne hva du får utbetalt i måneden ganges dagsatsen med antall virkedager i måneden. \
                 Du kan regne ut hva du får for en måned samt se flere eksempler på utregninger på nav.no/ungdomsytelse. \
                 Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
@@ -172,7 +171,7 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
             """
                 Nav har innvilget søknaden din om ungdomsytelse \
                 Du har rett til ungdomsytelse fra 1. desember 2024 i 260 dager. \
-                Du får utbetalt 954 kroner dagen, før skatt. \
+                Du får utbetalt 974 kroner dagen, før skatt. \
                 Nav utbetaler pengene innen den 25. i hver måned. \
                 Informasjon om utbetaling finner du under utbetalingsoversikten på "Min side". \
                 Du får ungdomsytelse fordi du er med ungdomsprogrammet. \
@@ -181,11 +180,11 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
                 Det er derfor viktig at du melder i fra om endringer i din inntekt på nav.no/ungdomsytelse/endring og informerer veileder. \
                 Hvis du ikke gir beskjed om endringer i inntekten, kan Nav kreve penger tilbake, så det er viktig å gi beskjed med en gang det skjer endringer. \
                 Nav bruker grunnbeløpet på 124 028 kroner for å regne ut hvor mye du får. \
-                Siden du er over 25 år så får du 2 ganger grunnbeløpet. \
+                Siden du er over 25 år så får du 2.041 ganger grunnbeløpet. \
                 Nav regner med 260 virkedager per år utenom helger og ferie. \
                 For å regne ut hva du får per dag, deles årsbeløpet på antall dager. \
-                Det betyr at du har rett på 2 x 124 028 = 248 056 kroner i året. \
-                Dette gir en dagsats på 954 kroner. \
+                Det betyr at du har rett på 2.041 x 124 028 = 253 141 kroner i året. \
+                Dette gir en dagsats på 974 kroner. \
                 For å regne hva du får utbetalt i måneden ganges dagsatsen med antall virkedager i måneden. \
                 Du kan regne ut hva du får for en måned samt se flere eksempler på utregninger på nav.no/ungdomsytelse. \
                 Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
@@ -207,7 +206,7 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
             """
                 Nav har innvilget søknaden din om ungdomsytelse \
                 Du har rett til ungdomsytelse fra 1. desember 2024 i 130 dager. \
-                Du får utbetalt 954 kroner dagen, før skatt. \
+                Du får utbetalt 974 kroner dagen, før skatt. \
                 Nav utbetaler pengene innen den 25. i hver måned. \
                 Informasjon om utbetaling finner du under utbetalingsoversikten på "Min side". \
                 Du får ungdomsytelse fordi du er med ungdomsprogrammet. \
@@ -216,11 +215,11 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
                 Det er derfor viktig at du melder i fra om endringer i din inntekt på nav.no/ungdomsytelse/endring og informerer veileder. \
                 Hvis du ikke gir beskjed om endringer i inntekten, kan Nav kreve penger tilbake, så det er viktig å gi beskjed med en gang det skjer endringer. \
                 Nav bruker grunnbeløpet på 124 028 kroner for å regne ut hvor mye du får. \
-                Siden du er over 25 år så får du 2 ganger grunnbeløpet til måneden du fyller 29 år. \
+                Siden du er over 25 år så får du 2.041 ganger grunnbeløpet til måneden du fyller 29 år. \
                 Nav regner med 260 virkedager per år utenom helger og ferie. \
                 For å regne ut hva du får per dag, deles årsbeløpet på antall dager. \
-                Det betyr at du har rett på 2 x 124 028 = 248 056 kroner i året. \
-                Dette gir en dagsats på 954 kroner. \
+                Det betyr at du har rett på 2.041 x 124 028 = 253 141 kroner i året. \
+                Dette gir en dagsats på 974 kroner. \
                 For å regne hva du får utbetalt i måneden ganges dagsatsen med antall virkedager i måneden. \
                 Du kan regne ut hva du får for en måned samt se flere eksempler på utregninger på nav.no/ungdomsytelse. \
                 Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
@@ -248,8 +247,8 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
             """
                 Nav har innvilget søknaden din om ungdomsytelse \
                 Du har rett til ungdomsytelse fra 1. mai 2025 i 260 dager. \
-                Fra 1. mai 2025 til 15. mai 2025 får du utbetalt 636 kroner dagen, før skatt. \
-                Fra 16. mai 2025 til 31. mai 2025 får du utbetalt 954 kroner dagen, før skatt. \
+                Fra 1. mai 2025 til 15. mai 2025 får du utbetalt 649 kroner dagen, før skatt. \
+                Fra 16. mai 2025 til 31. mai 2025 får du utbetalt 974 kroner dagen, før skatt. \
                 Nav utbetaler pengene innen den 25. i hver måned. \
                 Informasjon om utbetaling finner du under utbetalingsoversikten på "Min side". \
                 Du får ungdomsytelse fordi du er med ungdomsprogrammet. \
@@ -258,13 +257,13 @@ class BrevGenerererTjenesteNyInnvilgelseTest {
                 Det er derfor viktig at du melder i fra om endringer i din inntekt på nav.no/ungdomsytelse/endring og informerer veileder. \
                 Hvis du ikke gir beskjed om endringer i inntekten, kan Nav kreve penger tilbake, så det er viktig å gi beskjed med en gang det skjer endringer. \
                 Nav bruker grunnbeløpet på 124 028 kroner for å regne ut hvor mye du får. \
-                Du får 1.33 ganger grunnbeløpet mens du er under 25 år og 2 ganger grunnbeløpet fra måneden etter du fyller 25 år. \
+                Du får 1.361 ganger grunnbeløpet mens du er under 25 år og 2.041 ganger grunnbeløpet fra måneden etter du fyller 25 år. \
                 Nav regner med 260 virkedager per år utenom helger og ferie. \
                 For å regne ut hva du får per dag, deles årsbeløpet på antall dager. \
-                Fra 1. mai 2025 til 15. mai 2025 har du rett på 1.33 x 124 028 = 165 370 kroner i årsbeløp. \
-                Dette gir en dagsats på 636 kroner i perioden. \
-                Fra 16. mai 2025 til 31. mai 2025 har du rett på 2 x 124 028 = 248 056 kroner i årsbeløp. \
-                Dette gir en dagsats på 954 kroner i perioden. \
+                Fra 1. mai 2025 til 15. mai 2025 har du rett på 1.361 x 124 028 = 168 761 kroner i årsbeløp. \
+                Dette gir en dagsats på 649 kroner i perioden. \
+                Fra 16. mai 2025 til 31. mai 2025 har du rett på 2.041 x 124 028 = 253 141 kroner i årsbeløp. \
+                Dette gir en dagsats på 974 kroner i perioden. \
                 For å regne hva du får utbetalt i måneden ganges dagsatsen med antall virkedager i måneden. \
                 Du kan regne ut hva du får for en måned samt se flere eksempler på utregninger på nav.no/ungdomsytelse. \
                 Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteTest.java
@@ -17,7 +17,6 @@ import no.nav.ung.sak.formidling.vedtak.DetaljertResultatUtlederFake;
 import no.nav.ung.sak.test.util.UngTestRepositories;
 import no.nav.ung.sak.test.util.UnitTestLookupInstanceImpl;
 import no.nav.ung.sak.ungdomsprogram.UngdomsprogramPeriodeTjeneste;
-import no.nav.ung.sak.ytelse.beregning.UngdomsytelseTilkjentYtelseUtleder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,8 +57,8 @@ class BrevGenerererTjenesteTest {
         InnvilgelseInnholdBygger innvilgelseInnholdBygger = new InnvilgelseInnholdBygger(
             ungTestRepositories.ungdomsytelseGrunnlagRepository(),
             new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository()),
-            new UngdomsytelseTilkjentYtelseUtleder(ungTestRepositories.tilkjentYtelseRepository()),
-            repositoryProvider.getPersonopplysningRepository());
+            repositoryProvider.getPersonopplysningRepository(),
+            ungTestRepositories.tilkjentYtelseRepository());
         BrevGenerererTjeneste brevGenerererTjeneste = new BrevGenerererTjenesteImpl(
             repositoryProvider.getBehandlingRepository(),
             new AktørTjeneste(pdlKlient),

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevScenarioer.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevScenarioer.java
@@ -33,7 +33,6 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.time.temporal.TemporalAdjusters;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -314,13 +313,13 @@ public class BrevScenarioer {
         assertThat(andreMåned.getFom()).isEqualTo(LocalDate.of(2025, 1, 1));
         assertThat(andreMåned.getTom()).isEqualTo(LocalDate.of(2025, 1, 31));
 
-        //23 virkningsdager i januar 2025 med lav dagsats på 636,04. Rapportert inntekt er 10 000kr
+        //23 virkningsdager i januar 2025 med lav dagsats på 649,08. Rapportert inntekt er 10 000kr
         TilkjentYtelseVerdi t = andreMåned.getValue();
-        assertThat(t.uredusertBeløp()).isEqualByComparingTo("14628.92"); //636,04 * 23
+        assertThat(t.uredusertBeløp()).isEqualByComparingTo("14928.84"); //649,08 * 23
         assertThat(t.reduksjon()).isEqualByComparingTo("6600"); //66% av 10 0000
-        assertThat(t.dagsats()).isEqualByComparingTo("349"); //636 - ((6600/22)  )
-        assertThat(t.redusertBeløp()).isEqualByComparingTo("8028.92"); // 14628.92 - 6600
-        assertThat(t.utbetalingsgrad()).isEqualTo(55); // 8028.92 / 14628.92 * 100
+        assertThat(t.dagsats()).isEqualByComparingTo("362"); //649 - ((6600/22)  )
+        assertThat(t.redusertBeløp()).isEqualByComparingTo("8328.84"); // 14928.84 - 6600
+        assertThat(t.utbetalingsgrad()).isEqualTo(56); // 8328.84 / 14928.84 * 100
 
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Høringsnotatet sier at høg sats er 2,041 og lav sats defineres som 2/3 av dette.

Fra høringsnotat:
For å unngå at store deler av målgruppa har insentiv til å søke seg mot disse
ytelsene, foreslår departementet at ytelsen settes lik satsene for kvalifiseringsstønad og
minstesatsene for arbeidsavklaringspenger. Dette innebærer at årlig ytelse for deltakere
som har fylt 25 år vil utgjøre 2,041 ganger folketrygdens grunnbeløp (G). Årlig ytelse for
personer under 25 år vil utgjøre to tredjedeler av 2,041 G, altså omtrent 1,36 G.

https://www.regjeringen.no/globalassets/departementene/aid/dokumenter/2025/horingsnotat-forslag-om-forsok-med-ungdomsprogram.pdf

