### PR TITLE
FIX: Sender alltid alle perioder til vurdering til frontend

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårDtoMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårDtoMapper.java
@@ -1,44 +1,36 @@
 package no.nav.ung.sak.web.app.tjenester.behandling.vilkår;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkår;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
-import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.kontrakt.vilkår.VilkårMedPerioderDto;
 import no.nav.ung.sak.kontrakt.vilkår.VilkårPeriodeDto;
 import no.nav.ung.sak.typer.Periode;
 
-class VilkårDtoMapper {
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
-    private static final Logger logger = LoggerFactory.getLogger(VilkårDtoMapper.class);
+class VilkårDtoMapper {
 
     private VilkårDtoMapper() {
         // SONAR - Utility classes should not have public constructors
     }
 
-    static List<VilkårMedPerioderDto> lagVilkarMedPeriodeDto(Behandling behandling, boolean medVilkårkjøring, Vilkårene vilkårene, Map<VilkårType, Set<DatoIntervallEntitet>> aktuelleVilkårsperioder) {
+    static List<VilkårMedPerioderDto> lagVilkarMedPeriodeDto(Behandling behandling, boolean medVilkårkjøring, Vilkårene vilkårene) {
         if (vilkårene != null) {
             return vilkårene.getVilkårene()
                 .stream()
                 .filter(it -> !VilkårType.OPPTJENINGSPERIODEVILKÅR.equals(it.getVilkårType()))
-                .map(vilkår -> mapVilkår(vilkår, medVilkårkjøring, behandling, aktuelleVilkårsperioder))
+                .map(vilkår -> mapVilkår(vilkår, medVilkårkjøring, behandling))
                 .collect(Collectors.toList());
         }
         return Collections.emptyList();
     }
 
-    private static VilkårPeriodeDto mapTilPeriode(boolean medVilkårkjøring, VilkårPeriode it, Set<DatoIntervallEntitet> aktuelleVilkårsperioder, VilkårType vilkårType) {
+    private static VilkårPeriodeDto mapTilPeriode(boolean medVilkårkjøring, VilkårPeriode it) {
         VilkårPeriodeDto dto = new VilkårPeriodeDto();
         dto.setPeriode(new Periode(it.getFom(), it.getTom()));
         dto.setAvslagKode(it.getAvslagsårsak() != null ? it.getAvslagsårsak().getKode() : null);
@@ -46,7 +38,7 @@ class VilkårDtoMapper {
         dto.setMerknadParametere(it.getMerknadParametere());
         dto.setBegrunnelse(it.getBegrunnelse());
         dto.setMerknad(it.getMerknad());
-        dto.setVurderesIBehandlingen(vurderesIBehandlingen(it, aktuelleVilkårsperioder, vilkårType));
+        dto.setVurderesIBehandlingen(true);
 
         if (medVilkårkjøring) {
             dto.setInput(it.getRegelInput());
@@ -55,24 +47,8 @@ class VilkårDtoMapper {
         return dto;
     }
 
-    private static boolean vurderesIBehandlingen(VilkårPeriode vilkårPeriode, Set<DatoIntervallEntitet> aktuelleVilkårsperioder, VilkårType vilkårType) {
-        if (aktuelleVilkårsperioder == null) {
-            return false;
-        }
-        boolean match = aktuelleVilkårsperioder.stream().anyMatch(p -> p.overlapper(vilkårPeriode.getPeriode()));
-        if (match) {
-            return true;
-        }
-        for (DatoIntervallEntitet aktuellVilkårsperiode : aktuelleVilkårsperioder) {
-            if (aktuellVilkårsperiode.overlapper(vilkårPeriode.getPeriode())) {
-                logger.warn("Delvis treff på vilkårsperiodesammenligning (forventer kun hele treff, bortsett fra for rammevedtak). VilkårTyp=" + vilkårType + " VilkårPeriode " + vilkårPeriode.getPeriode() + " overlapper delvis periode fra " + aktuelleVilkårsperioder);
-            }
-        }
-        return false;
-    }
-
-    private static VilkårMedPerioderDto mapVilkår(Vilkår vilkår, boolean medVilkårkjøring, Behandling behandling, Map<VilkårType, Set<DatoIntervallEntitet>> aktuelleVilkårsperioder) {
-        var vilkårsPerioder = vilkår.getPerioder().stream().map(it -> mapTilPeriode(medVilkårkjøring, it, aktuelleVilkårsperioder.get(vilkår.getVilkårType()), vilkår.getVilkårType()))
+    private static VilkårMedPerioderDto mapVilkår(Vilkår vilkår, boolean medVilkårkjøring, Behandling behandling) {
+        var vilkårsPerioder = vilkår.getPerioder().stream().map(it -> mapTilPeriode(medVilkårkjøring, it))
             .collect(Collectors.toList());
         var vilkårMedPerioderDto = new VilkårMedPerioderDto(vilkår.getVilkårType(), vilkårsPerioder);
         vilkårMedPerioderDto.setLovReferanse(vilkår.getVilkårType().getLovReferanse(behandling.getFagsakYtelseType()));

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårDtoMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårDtoMapper.java
@@ -1,6 +1,5 @@
 package no.nav.ung.sak.web.app.tjenester.behandling.vilkår;
 
-import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkår;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
@@ -23,7 +22,6 @@ class VilkårDtoMapper {
         if (vilkårene != null) {
             return vilkårene.getVilkårene()
                 .stream()
-                .filter(it -> !VilkårType.OPPTJENINGSPERIODEVILKÅR.equals(it.getVilkårType()))
                 .map(vilkår -> mapVilkår(vilkår, medVilkårkjøring, behandling))
                 .collect(Collectors.toList());
         }

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårRestTjeneste.java
@@ -102,7 +102,7 @@ public class VilkårRestTjeneste {
         var vilkåreneOpt = vilkårTjeneste.hentHvisEksisterer(behandling.getId());
         var dto = vilkåreneOpt.map(vilkårene -> {
             var vilkårPeriodeMap = utledFaktiskeVilkårPerioder(behandling, vilkårene);
-            return VilkårDtoMapper.lagVilkarMedPeriodeDto(behandling, inkluderVilkårkjøring, vilkårene, vilkårPeriodeMap);
+            return VilkårDtoMapper.lagVilkarMedPeriodeDto(behandling, inkluderVilkårkjøring, vilkårene);
         }).orElse(Collections.emptyList());
         return dto;
     }

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vilkår/VilkårRestTjeneste.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -20,25 +18,16 @@ import jakarta.ws.rs.core.MediaType;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.k9.felles.sikkerhet.abac.TilpassetAbacAttributt;
-import no.nav.ung.kodeverk.vilkår.VilkårType;
-import no.nav.ung.sak.behandling.BehandlingReferanse;
-import no.nav.ung.sak.behandlingskontroll.BehandlingTypeRef;
-import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkår;
-import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
-import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.kontrakt.behandling.BehandlingUuidDto;
 import no.nav.ung.sak.kontrakt.vilkår.VilkårMedPerioderDto;
 import no.nav.ung.sak.kontrakt.vilkår.VilkårUtfallSamlet;
-import no.nav.ung.sak.perioder.VilkårsPerioderTilVurderingTjeneste;
 import no.nav.ung.sak.vilkår.VilkårTjeneste;
-import no.nav.ung.sak.vilkår.VilkårUtleder;
 import no.nav.ung.sak.web.server.abac.AbacAttributtSupplier;
 import no.nav.ung.sak.web.server.caching.CacheControl;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.List;
 
 import static no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionAttributt.READ;
 import static no.nav.ung.abac.BeskyttetRessursKoder.FAGSAK;
@@ -55,8 +44,6 @@ public class VilkårRestTjeneste {
 
     private BehandlingRepository behandlingRepository;
     private VilkårTjeneste vilkårTjeneste;
-    private Instance<VilkårUtleder> vilkårUtledere;
-    private Instance<VilkårsPerioderTilVurderingTjeneste> vilkårsPerioderTilVurderingTjenester;
 
     public VilkårRestTjeneste() {
         // for CDI proxy
@@ -64,13 +51,9 @@ public class VilkårRestTjeneste {
 
     @Inject
     public VilkårRestTjeneste(BehandlingRepository behandlingRepository,
-                              VilkårTjeneste vilkårTjeneste,
-                              @Any Instance<VilkårUtleder> vilkårUtledere,
-                              @Any Instance<VilkårsPerioderTilVurderingTjeneste> vilkårsPerioderTilVurderingTjenester) {
+                              VilkårTjeneste vilkårTjeneste) {
         this.behandlingRepository = behandlingRepository;
         this.vilkårTjeneste = vilkårTjeneste;
-        this.vilkårUtledere = vilkårUtledere;
-        this.vilkårsPerioderTilVurderingTjenester = vilkårsPerioderTilVurderingTjenester;
     }
 
     @GET
@@ -100,53 +83,8 @@ public class VilkårRestTjeneste {
     private List<VilkårMedPerioderDto> getVilkårV3(BehandlingUuidDto behandlingUuid, boolean inkluderVilkårkjøring) {
         var behandling = behandlingRepository.hentBehandling(behandlingUuid.getBehandlingUuid());
         var vilkåreneOpt = vilkårTjeneste.hentHvisEksisterer(behandling.getId());
-        var dto = vilkåreneOpt.map(vilkårene -> {
-            var vilkårPeriodeMap = utledFaktiskeVilkårPerioder(behandling, vilkårene);
-            return VilkårDtoMapper.lagVilkarMedPeriodeDto(behandling, inkluderVilkårkjøring, vilkårene);
-        }).orElse(Collections.emptyList());
+        var dto = vilkåreneOpt.map(vilkårene -> VilkårDtoMapper.lagVilkarMedPeriodeDto(behandling, inkluderVilkårkjøring, vilkårene)).orElse(Collections.emptyList());
         return dto;
-    }
-
-    private Map<VilkårType, Set<DatoIntervallEntitet>> utledFaktiskeVilkårPerioder(Behandling behandling, Vilkårene vilkårene) {
-        Set<VilkårType> aktuelleVilkårTyper = finnAktuelleVilkårTyper(behandling, vilkårene);
-        Map<VilkårType, Set<DatoIntervallEntitet>> resultat = new EnumMap<>(VilkårType.class);
-        for (VilkårType vilkårType : aktuelleVilkårTyper) {
-            resultat.put(vilkårType, utledPeriodeTilVurdering(behandling, vilkårType));
-        }
-        return resultat;
-    }
-
-    private Set<VilkårType> finnAktuelleVilkårTyper(Behandling behandling, Vilkårene vilkårene) {
-        if (behandling.erAvsluttet()) {
-            return finnVilkårTyperPåPåBehandlingen(vilkårene);
-        } else {
-            Set<VilkårType> vilkår = EnumSet.noneOf(VilkårType.class);
-            vilkår.addAll(utledVilkårTyperForBehandlingen(behandling));
-            vilkår.addAll(finnVilkårTyperPåPåBehandlingen(vilkårene));
-            return vilkår;
-        }
-    }
-
-    private Set<VilkårType> utledVilkårTyperForBehandlingen(Behandling behandling) {
-        return getVilkårUtleder(behandling).utledVilkår(BehandlingReferanse.fra(behandling)).getAlleAvklarte();
-    }
-
-    private Set<VilkårType> finnVilkårTyperPåPåBehandlingen(Vilkårene vilkårene) {
-        return vilkårene.getVilkårene().stream().map(Vilkår::getVilkårType).collect(Collectors.toSet());
-    }
-
-    private NavigableSet<DatoIntervallEntitet> utledPeriodeTilVurdering(Behandling behandling, VilkårType vilkårType) {
-        return getPerioderTilVurderingTjeneste(behandling).utled(behandling.getId(), vilkårType);
-    }
-
-    private VilkårsPerioderTilVurderingTjeneste getPerioderTilVurderingTjeneste(Behandling behandling) {
-        return BehandlingTypeRef.Lookup.find(VilkårsPerioderTilVurderingTjeneste.class, vilkårsPerioderTilVurderingTjenester, behandling.getFagsakYtelseType(), behandling.getType())
-            .orElseThrow(() -> new UnsupportedOperationException("VilkårsPerioderTilVurderingTjeneste ikke implementert for ytelse [" + behandling.getFagsakYtelseType() + "], behandlingtype [" + behandling.getType() + "]"));
-    }
-
-    private VilkårUtleder getVilkårUtleder(Behandling behandling) {
-        return BehandlingTypeRef.Lookup.find(VilkårUtleder.class, vilkårUtledere, behandling.getFagsakYtelseType(), behandling.getType())
-            .orElseThrow(() -> new UnsupportedOperationException("VilkårUtleder ikke implementert for ytelse [" + behandling.getFagsakYtelseType() + "], behandlingtype [" + behandling.getType() + "]"));
     }
 
     @GET


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er ikkje relevant å vise vilkårsperiodene splittet opp på det som vurderes i denne behandlingen og det som vurderes i forrige for vilkår. Her ønsker vi alltid å vise alt som har blitt vurdert i alle behandlinger.