### PR TITLE
TSFF-1463: Starter inntektkontroll den sjette i måneden. Gjør kun kontroll og setter på vent dersom vi har kontrollårsak.

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.k9.prosesstask.api.ProsessTaskData;
 import no.nav.k9.prosesstask.api.ProsessTaskGruppe;
 import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
@@ -59,7 +60,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     private EtterlysningTjeneste etterlysningTjeneste;
     private InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste;
     private ProsessTaskTjeneste prosessTaskTjeneste;
-
+    private Integer rapporteringsfristDagIMåned;
 
 
     @Inject
@@ -70,7 +71,8 @@ public class KontrollerInntektSteg implements BehandlingSteg {
                                  EtterlysningRepository etterlysningRepository,
                                  EtterlysningTjeneste etterlysningTjeneste,
                                  InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste,
-                                 ProsessTaskTjeneste prosessTaskTjeneste) {
+                                 ProsessTaskTjeneste prosessTaskTjeneste,
+                                 @KonfigVerdi(value = "RAPPORTERINGSFRIST_DAG_I_MAANED", defaultVerdi = "5") Integer rapporteringsfristDagIMåned) {
         this.prosessTriggerPeriodeUtleder = prosessTriggerPeriodeUtleder;
         this.rapportertInntektMapper = rapportertInntektMapper;
         this.kontrollerteInntektperioderTjeneste = kontrollerteInntektperioderTjeneste;
@@ -79,6 +81,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
         this.etterlysningTjeneste = etterlysningTjeneste;
         this.inntektArbeidYtelseTjeneste = inntektArbeidYtelseTjeneste;
         this.prosessTaskTjeneste = prosessTaskTjeneste;
+        this.rapporteringsfristDagIMåned = rapporteringsfristDagIMåned;
     }
 
     public KontrollerInntektSteg() {
@@ -100,7 +103,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
 
         var registerinntekterForEtterlysninger = rapportertInntektMapper.finnRegisterinntekterForEtterlysninger(behandlingId, etterlysningsperioder);
 
-        var kontrollResultat = new KontrollerInntektTjeneste(AKSEPTERT_DIFFERANSE).utførKontroll(prosessTriggerTidslinje, rapporterteInntekterTidslinje, registerinntekterForEtterlysninger);
+        var kontrollResultat = new KontrollerInntektTjeneste(AKSEPTERT_DIFFERANSE, rapporteringsfristDagIMåned).utførKontroll(prosessTriggerTidslinje, rapporterteInntekterTidslinje, registerinntekterForEtterlysninger);
 
         log.info("Kontrollresultat ble {}", kontrollResultat.toSegments());
         håndterPeriodisertKontrollresultat(kontekst, kontrollResultat, etterlysninger);

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjeneste.java
@@ -7,17 +7,22 @@ import no.nav.ung.sak.ytelse.EtterlysningOgRegisterinntekt;
 import no.nav.ung.sak.ytelse.RapporterteInntekter;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Set;
 
+import static no.nav.ung.kodeverk.uttak.Tid.TIDENES_BEGYNNELSE;
 import static no.nav.ung.sak.domene.behandling.steg.registerinntektkontroll.FinnKontrollresultatForIkkeGodkjentUttalelse.finnKontrollresultatForIkkeGodkjentUttalelse;
 
 public class KontrollerInntektTjeneste {
 
     private final BigDecimal akseptertDifferanse;
+    private final Integer rapporteringsfristDagIMåned;
 
-    public KontrollerInntektTjeneste(BigDecimal akseptertDifferanse) {
+    public KontrollerInntektTjeneste(BigDecimal akseptertDifferanse, Integer rapporteringsfristDagIMåned) {
         this.akseptertDifferanse = akseptertDifferanse;
+        this.rapporteringsfristDagIMåned = rapporteringsfristDagIMåned;
     }
 
     public LocalDateTimeline<Kontrollresultat> utførKontroll(
@@ -25,15 +30,15 @@ public class KontrollerInntektTjeneste {
         LocalDateTimeline<RapporterteInntekter> gjeldendeRapporterteInntekter,
         LocalDateTimeline<EtterlysningOgRegisterinntekt> etterlysningTidslinje) {
 
-
         var resultatTidslinje = new LocalDateTimeline<Kontrollresultat>(List.of());
 
-
         // Sjekker først om vi har relevante årsaker
-        final var tidslinjeRelevanteÅrsaker = prosessTriggerTidslinje.filterValue(it -> it.contains(BehandlingÅrsakType.RE_RAPPORTERING_INNTEKT) || it.contains(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT));
-        final var harIkkePassertRapporteringsfrist = tidslinjeRelevanteÅrsaker.filterValue(it -> !it.contains(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT));
+        final var tidslinjeRelevanteÅrsaker = prosessTriggerTidslinje.filterValue(it -> it.contains(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT));
 
-        // Dersom vi ikkje har passert rapporteringsfrist (ikkje har kontroll-årsak) så skal vi vente til rapporteringsfrist
+        final var tidslinjePassertFrist = finnTidslinjePassertFrist();
+        final var harIkkePassertRapporteringsfrist = tidslinjeRelevanteÅrsaker.disjoint(tidslinjePassertFrist);
+
+        // Dersom vi ikkje har passert rapporteringsfrist så skal vi vente til rapporteringsfrist
         resultatTidslinje = resultatTidslinje.crossJoin(harIkkePassertRapporteringsfrist.mapValue(it -> Kontrollresultat.utenInntektresultat(KontrollResultatType.SETT_PÅ_VENT_TIL_RAPPORTERINGSFRIST)));
 
 
@@ -54,6 +59,15 @@ public class KontrollerInntektTjeneste {
         }
         return resultatTidslinje;
 
+    }
+
+    private LocalDateTimeline<Boolean> finnTidslinjePassertFrist() {
+        final var sisteDagForPassertFrist = LocalDate.now().getDayOfMonth() <= rapporteringsfristDagIMåned ?
+            LocalDate.now().minusMonths(2).with(TemporalAdjusters.lastDayOfMonth())
+            : LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+
+        final var tidslinjePassertFrist = new LocalDateTimeline<>(TIDENES_BEGYNNELSE, sisteDagForPassertFrist, true);
+        return tidslinjePassertFrist;
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjenesteTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Set;
 
@@ -23,12 +24,30 @@ class KontrollerInntektTjenesteTest {
 
     public static final BigDecimal AKSEPTERT_DIFFERANSE = BigDecimal.valueOf(1000);
 
+
+    @Test
+    void skal_returnere_tom_tidslinje_dersom_ingen_kontrollårsak() {
+        // Arrange
+        final var fom = LocalDate.now().plusMonths(1).withDayOfMonth(1);
+        final var tom = LocalDate.now().plusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForInntektRapportering(fom, tom);
+        final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinje(fom, tom);
+        LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
+
+        // Act
+        var resultat = utfør(prosessTriggerTidslinje, gjeldendeRapporterteInntekter, ikkeGodkjentUttalelseTidslinje);
+
+        // Assert
+        assertEquals(LocalDateTimeline.empty(), resultat);
+    }
+
+
     @Test
     void skal_sette_på_vent_til_rapporteringsfrist() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
-        LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForInntektRapportering(fom, tom);
+        final var fom = LocalDate.now().plusMonths(1).withDayOfMonth(1);
+        final var tom = LocalDate.now().plusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForInntektRapporteringOgKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinje(fom, tom);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
 
@@ -42,8 +61,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_opprette_aksjonspunkt_dersom_brukes_har_gitt_uttalelse_og_registerinntekt_er_lik() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         final var bruker = 10;
         final var register = 10_000;
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForInntektRapporteringOgKontroll(fom, tom);
@@ -61,8 +80,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_sette_på_vent_på_nytt_dersom_bruker_har_gitt_uttalelse_og_registerinntekt_er_ulik() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         final var bruker = 10;
         final var register = 10_000;
         final var registerFraUttalelse = 9999;
@@ -81,8 +100,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_bruke_brukers_inntekt_dersom_diff_mellom_rapportert_inntekt_fra_register_og_bruker_er_mindre_enn_akseptert_grense() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 10_000, 10_001);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -97,8 +116,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_bruke_brukers_inntekt_dersom_ingen_rapportert_inntekt_fra_register_eller_bruker() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = ingenRapporterteInntekter(fom, tom);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -113,8 +132,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_opprette_oppgave_dersom_diff_mellom_rapportert_inntekt_fra_register_og_bruker_er_større_enn_akseptert_grense() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 10_000, 11_001);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -129,8 +148,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_opprette_oppgave_dersom_det_finnes_ytelse_som_er_større_enn_akseptert_grense() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 0, 1001, 0);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -145,8 +164,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_bruke_brukers_inntekt_dersom_det_finnes_ytelse_som_er_lik_akseptert_grense() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 0, 1000, 0);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -161,8 +180,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_bruke_brukers_godkjente_inntekt_dersom_bruker_har_godkjent_ytelse_og_inntekt_fra_register() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 0, 1001, 0);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = new LocalDateTimeline<>(
@@ -180,8 +199,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_bruke_brukers_godkjente_inntekt_dersom_bruker_tidligere_har_rapportert_inntekt_og_har_godkjent_gjeldende_ytelse_og_inntekt_fra_register() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 2000, 10_000, 500);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = new LocalDateTimeline<>(
@@ -202,8 +221,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_opprette_oppgave_med_ny_frist_dersom_diff_mellom_rapportert_inntekt_fra_register_og_bruker_er_større_enn_akseptert_grense_og_det_finnes_eksisterende_ikke_bekreftet_oppgave_med_ulik_registerinntekt() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 10_000, 11_001);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> uttalelseTidslinje = new LocalDateTimeline<>(fom, tom,
@@ -219,8 +238,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_opprette_aksjonspunkt_dersom_ingen_inntekt_i_register_og_rapportert_inntekt_fra_bruker() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 0, 11_001);
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -235,8 +254,8 @@ class KontrollerInntektTjenesteTest {
     @Test
     void skal_gå_videre_med_brukers_inntekt_dersom_ingen_inntekt_i_register_eller_rapportert_fra_bruker() {
         // Arrange
-        final var fom = LocalDate.now().minusDays(10);
-        final var tom = LocalDate.now().plusDays(10);
+        final var fom = LocalDate.of(2025,3,1);
+        final var tom = LocalDate.of(2025,3,31);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = new LocalDateTimeline<RapporterteInntekter>(Set.of());
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = LocalDateTimeline.empty();
@@ -249,7 +268,7 @@ class KontrollerInntektTjenesteTest {
     }
 
     private LocalDateTimeline<KontrollResultatType> utfør(LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje, LocalDateTimeline<RapporterteInntekter> gjeldendeRapporterteInntekter, LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje) {
-        return new KontrollerInntektTjeneste(AKSEPTERT_DIFFERANSE).utførKontroll(prosessTriggerTidslinje, gjeldendeRapporterteInntekter, ikkeGodkjentUttalelseTidslinje)
+        return new KontrollerInntektTjeneste(AKSEPTERT_DIFFERANSE, 5).utførKontroll(prosessTriggerTidslinje, gjeldendeRapporterteInntekter, ikkeGodkjentUttalelseTidslinje)
             .mapValue(Kontrollresultat::type);
     }
 

--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -266,7 +266,7 @@ spec:
     - name: REVURDERING_ENDRET_PERIODE_VENTEFRIST
       value: "PT15M"
     - name: RAPPORTERINGSFRIST_DAG_I_MAANED
-      value: "6"
+      value: "5"
 
 
       # Audit logging

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -252,7 +252,7 @@ spec:
     - name: INNSENDING_HENDELSER_FORSINKELSE
       value: "PT1H"
     - name: RAPPORTERINGSFRIST_DAG_I_MAANED
-      value: "6"
+      value: "5"
 
     # Audit logging
     - name: AUDITLOGGER_ENABLED

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
@@ -42,7 +42,7 @@ import no.nav.ung.sak.vilkår.VilkårTjeneste;
  * Kjører hver dag kl 07:15.
  */
 @ApplicationScoped
-@ProsessTask(value = OpprettRevurderingForInntektskontrollBatchTask.TASKNAME, cronExpression = "0 0 7 7 * *", maxFailedRuns = 1)
+@ProsessTask(value = OpprettRevurderingForInntektskontrollBatchTask.TASKNAME, cronExpression = "0 0 7 6 * *", maxFailedRuns = 1)
 public class OpprettRevurderingForInntektskontrollBatchTask implements ProsessTaskHandler {
 
     public static final String TASKNAME = "batch.opprettRevurderingForInntektskontrollBatch";


### PR DESCRIPTION
### **Behov / Bakgrunn**
Rapporteringsfrist i a-ordningen er den femte og dermed kan vi starter kontroll av inntekt den sjette i måneden.

Vi ønsker også å tillate å lagre ned rapportert inntekt på saken uten at vi lar behandlingen stå på vent i påvente av at vi oppretter årsak for inntektkontroll.

### **Løsning**
Endrer start fra 7. dag i måneden til 6. dag i måneden.

Tidslinjen som vi ser på som relevant for kontroll er kun den som inneholder årsak for kontroll (dette må endres dersom vi lar bruker rapportere inn inntekt etter at fristen har blitt passert).