### PR TITLE
Setter behandlingsnummer for ungdomsytelsen på kall mot PDL.

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/beregning/barnetillegg/HentFødselOgDød.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/beregning/barnetillegg/HentFødselOgDød.java
@@ -2,17 +2,12 @@ package no.nav.ung.sak.domene.behandling.steg.beregning.barnetillegg;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-import no.nav.k9.felles.integrasjon.pdl.Doedsfall;
-import no.nav.k9.felles.integrasjon.pdl.DoedsfallResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.Foedselsdato;
-import no.nav.k9.felles.integrasjon.pdl.FoedselsdatoResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.HentPersonQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.PdlKlient;
-import no.nav.k9.felles.integrasjon.pdl.PersonResponseProjection;
+import no.nav.k9.felles.integrasjon.pdl.*;
 import no.nav.ung.sak.typer.AktørId;
 
 @Dependent
@@ -33,7 +28,7 @@ public class HentFødselOgDød {
             .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato())
             .doedsfall(new DoedsfallResponseProjection().doedsdato());
 
-        var personFraPdl = pdlKlient.hentPerson(query, projection);
+        var personFraPdl = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         var fødselsdato = personFraPdl.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)

--- a/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/PdlDødsfallFagsakTilVurderingUtleder.java
+++ b/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/PdlDødsfallFagsakTilVurderingUtleder.java
@@ -101,7 +101,7 @@ public class PdlDødsfallFagsakTilVurderingUtleder implements FagsakerTilVurderi
                     .relatertPersonsIdent()
                     .minRolleForPerson()
             );
-        return pdlKlient.hentPerson(query, projection);
+        return pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
     }
 
     private boolean deltarIProgramPåHendelsedato(Fagsak fagsak, LocalDate relevantDato, String hendelseId) {

--- a/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/PdlFødselshendelseFagsakTilVurderingUtleder.java
+++ b/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/PdlFødselshendelseFagsakTilVurderingUtleder.java
@@ -116,7 +116,7 @@ public class PdlFødselshendelseFagsakTilVurderingUtleder implements FagsakerTil
                     .relatertPersonsIdent()
                     .minRolleForPerson()
             );
-        return pdlKlient.hentPerson(query, projection);
+        return pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
     }
 
     private boolean deltarIProgramPåHendelsedato(Fagsak fagsak, LocalDate relevantDato, String hendelseId) {

--- a/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/pdl/PersonBasisTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/pdl/PersonBasisTjeneste.java
@@ -13,6 +13,7 @@ import no.nav.ung.sak.typer.PersonIdent;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 
 @ApplicationScoped
@@ -44,7 +45,7 @@ public class PersonBasisTjeneste {
             .kjoenn(new KjoennResponseProjection().kjoenn())
             .adressebeskyttelse(new AdressebeskyttelseResponseProjection().gradering());
 
-        var person = pdlKlient.hentPerson(query, projection);
+        var person = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         var fødselsdato = person.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)
@@ -90,7 +91,7 @@ public class PersonBasisTjeneste {
         var projection = new PersonResponseProjection()
             .navn(new NavnResponseProjection().forkortetNavn().fornavn().mellomnavn().etternavn())
             .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato());
-        var personFraPDL = pdlKlient.hentPerson(query, projection);
+        var personFraPDL = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         var fødselsdato = personFraPDL.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)

--- a/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/pdl/PersoninfoTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/pdl/PersoninfoTjeneste.java
@@ -84,7 +84,7 @@ public class PersoninfoTjeneste {
                     .minRolleForPerson()
             );
 
-        var personFraPdl = pdlKlient.hentPerson(query, projection);
+        var personFraPdl = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         var fødselsdato = personFraPdl.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)

--- a/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/pdl/TilknytningTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/ung/sak/domene/person/pdl/TilknytningTjeneste.java
@@ -6,23 +6,16 @@ import static no.nav.ung.kodeverk.person.Diskresjonskode.KODE6;
 import static no.nav.ung.kodeverk.person.Diskresjonskode.KODE7;
 import static no.nav.k9.felles.integrasjon.pdl.AdressebeskyttelseGradering.UGRADERT;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import no.nav.k9.felles.integrasjon.pdl.*;
 import no.nav.ung.kodeverk.person.Diskresjonskode;
 import no.nav.ung.sak.behandlingslager.aktør.GeografiskTilknytning;
 import no.nav.ung.sak.typer.AktørId;
-import no.nav.k9.felles.integrasjon.pdl.Adressebeskyttelse;
-import no.nav.k9.felles.integrasjon.pdl.AdressebeskyttelseGradering;
-import no.nav.k9.felles.integrasjon.pdl.AdressebeskyttelseResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.GeografiskTilknytningResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.GtType;
-import no.nav.k9.felles.integrasjon.pdl.HentGeografiskTilknytningQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.HentPersonQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.PersonResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.PdlKlient;
 
 @ApplicationScoped
 public class TilknytningTjeneste {
@@ -75,7 +68,7 @@ public class TilknytningTjeneste {
             .gtType().gtBydel().gtKommune().gtLand();
 
         var diskresjon = hentDiskresjonskode(aktørId);
-        var tilknytning = getTilknytning(pdlKlient.hentGT(queryGT, projectionGT));
+        var tilknytning = getTilknytning(pdlKlient.hentGT(queryGT, projectionGT, List.of(Behandlingsnummer.UNGDOMSYTELSEN)));
         return new GeografiskTilknytning(tilknytning, diskresjon);
     }
 
@@ -84,7 +77,7 @@ public class TilknytningTjeneste {
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
             .adressebeskyttelse(new AdressebeskyttelseResponseProjection().gradering());
-        var person = pdlKlient.hentPerson(query, projection);
+        var person = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         return diskresjonskodeFor(person.getAdressebeskyttelse().stream());
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/PdlKlientFake.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/PdlKlientFake.java
@@ -3,24 +3,11 @@ package no.nav.ung.sak.formidling;
 import java.util.List;
 
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLOperationRequest;
+import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLRequest;
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLResponseProjection;
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLResult;
 
-import no.nav.k9.felles.integrasjon.pdl.GeografiskTilknytning;
-import no.nav.k9.felles.integrasjon.pdl.GeografiskTilknytningResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.HentGeografiskTilknytningQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.HentIdenterBolkQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.HentIdenterBolkResult;
-import no.nav.k9.felles.integrasjon.pdl.HentIdenterBolkResultResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.HentIdenterQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.HentPersonQueryRequest;
-import no.nav.k9.felles.integrasjon.pdl.IdentGruppe;
-import no.nav.k9.felles.integrasjon.pdl.IdentInformasjon;
-import no.nav.k9.felles.integrasjon.pdl.Identliste;
-import no.nav.k9.felles.integrasjon.pdl.IdentlisteResponseProjection;
-import no.nav.k9.felles.integrasjon.pdl.Pdl;
-import no.nav.k9.felles.integrasjon.pdl.Person;
-import no.nav.k9.felles.integrasjon.pdl.PersonResponseProjection;
+import no.nav.k9.felles.integrasjon.pdl.*;
 import no.nav.ung.sak.test.util.aktør.FiktiveFnr;
 
 public record PdlKlientFake(String fnr) implements Pdl {
@@ -51,12 +38,32 @@ public record PdlKlientFake(String fnr) implements Pdl {
     }
 
     @Override
+    public Person hentPerson(HentPersonQueryRequest q, PersonResponseProjection p, List<Behandlingsnummer> behandlingsnummere) {
+        return null;
+    }
+
+    @Override
     public Person hentPerson(HentPersonQueryRequest q, PersonResponseProjection p, boolean ignoreNotFound) {
         return null;
     }
 
     @Override
+    public Person hentPerson(HentPersonQueryRequest q, PersonResponseProjection p, boolean ignoreNotFound, List<Behandlingsnummer> behandlingsnummere) {
+        return null;
+    }
+
+    @Override
     public GeografiskTilknytning hentGT(HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p) {
+        return null;
+    }
+
+    @Override
+    public GeografiskTilknytning hentGT(HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p, List<Behandlingsnummer> behandlingsnummere) {
+        return null;
+    }
+
+    @Override
+    public <T extends GraphQLResult<?>> T query(GraphQLRequest req, Class<T> clazz, List<Behandlingsnummer> behandlingsnummer) {
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <felles.version>4.4.16</felles.version>
+        <felles.version>4.5.0</felles.version>
         <swagger.version>2.2.30</swagger.version>
         <junit.version>5.12.2</junit.version>
         <k9format.version>12.0.0</k9format.version>

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/personopplysning/debug/DebugPersoninfoTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/personopplysning/debug/DebugPersoninfoTjeneste.java
@@ -89,12 +89,12 @@ public class DebugPersoninfoTjeneste {
             );
 
 
-        var personFraPdl = pdlKlient.hentPerson(query, projection);
+        var personFraPdl = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         dumpinnhold.add("pdl-kjerneinfo-query for " + aktørId.getAktørId() + ": " + PdlKallDump.toJson(query));
         dumpinnhold.add("pdl-kjerneinfo-projection for " + aktørId.getAktørId() + ": " + PdlKallDump.toJson(projection));
 
-        var person = pdlKlient.hentPerson(query, projection);
+        var person = pdlKlient.hentPerson(query, projection, List.of(Behandlingsnummer.UNGDOMSYTELSEN));
 
         dumpinnhold.add("pdl-kjerneinfo-svar for " + aktørId.getAktørId() + ": " + PdlKallDump.toJson(person));
 

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/AppPdpKlient.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/AppPdpKlient.java
@@ -4,10 +4,7 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-import no.nav.k9.felles.sikkerhet.abac.Decision;
-import no.nav.k9.felles.sikkerhet.abac.PdpKlient;
-import no.nav.k9.felles.sikkerhet.abac.PdpRequest;
-import no.nav.k9.felles.sikkerhet.abac.Tilgangsbeslutning;
+import no.nav.k9.felles.sikkerhet.abac.*;
 import no.nav.sif.abac.kontrakt.abac.dto.SaksinformasjonOgPersonerTilgangskontrollInputDto;
 
 import java.util.Set;
@@ -28,8 +25,12 @@ public class AppPdpKlient implements PdpKlient {
     public Tilgangsbeslutning forespørTilgang(PdpRequest pdpRequest) {
         SaksinformasjonOgPersonerTilgangskontrollInputDto tilgangskontrollInput = PdpRequestMapper.map(pdpRequest);
         Decision decision = sifAbacPdpRestKlient.sjekkTilgangForInnloggetBruker(tilgangskontrollInput);
-        return new Tilgangsbeslutning(decision == Decision.Permit, Set.of(), pdpRequest);
+        return new Tilgangsbeslutning(
+            decision == Decision.Permit,
+            Set.of(),
+            pdpRequest,
+            TilgangType.INTERNBRUKER // TODO: Bruker riktig tilgangstype?
+        );
     }
-
 }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å kunne utføre tilgangskontroll på personopplysninger vi etterspør fra PDL er det viktig at vi sender med korrekt behandlingsnummer.

Idag sendes det en liste med alle behandlingsnummere til PDL uansett fagsakytelse, noe som går imot sin hensikt.

### **Løsning**
Bumper k9-felles med støtte for å kunne sette `Behandlingsnummer` i pdl-kall.

### **Andre endringer**
Måtte sette `TilgangType` i `AppPdpKlient`. Usikker på om `TilgangType.INTERNBRUKER` er riktig.
