### PR TITLE
Mapper FagsakYtelsetype til YtelseType for RegisterInntektYtelseDTO

### DIFF
--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/kontroll/InntektKontrollOppgaveMapper.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/kontroll/InntektKontrollOppgaveMapper.java
@@ -5,6 +5,7 @@ import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektArbeidOgFrilansDTO;
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektDTO;
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektYtelseDTO;
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType;
 import no.nav.ung.kodeverk.arbeidsforhold.InntektspostType;
 import no.nav.ung.sak.domene.iay.modell.InntektArbeidYtelseGrunnlag;
 import no.nav.ung.sak.domene.iay.modell.Inntektspost;
@@ -30,10 +31,30 @@ public class InntektKontrollOppgaveMapper {
             .flatMap(inntekt -> inntekt.getAlleInntektsposter().stream()
                 .filter(ip -> ip.getInntektspostType().equals(InntektspostType.YTELSE))
                 .filter(ip -> ip.getPeriode().overlapper(periode))
-                .map(ip -> {
-                    var beløp = finnBeløpInnenforPeriode(periode, ip);
-                    return new RegisterInntektYtelseDTO(beløp.intValue(), ip.getInntektYtelseType().getYtelseType().getKode());
+                .map(inntektspost -> {
+                    var beløp = finnBeløpInnenforPeriode(periode, inntektspost);
+                    YtelseType ytelseType = maptilYtelseType(inntektspost);
+                    return new RegisterInntektYtelseDTO(beløp.intValue(), ytelseType);
                 })).toList();
+    }
+
+
+    private static YtelseType maptilYtelseType(Inntektspost ip) {
+        switch (ip.getInntektYtelseType().getYtelseType()) {
+            case SYKEPENGER -> {
+                return YtelseType.SYKEPENGER;
+            }
+            case OMSORGSPENGER, OMSORGSPENGER_AO, OMSORGSPENGER_KS, OMSORGSPENGER_MA -> {
+                return YtelseType.OMSORGSPENGER;
+            }
+            case PLEIEPENGER_SYKT_BARN -> {
+                return YtelseType.PLEIEPENGER_SYKT_BARN;
+            }
+            case PLEIEPENGER_NÆRSTÅENDE -> {
+                return YtelseType.PLEIEPENGER_LIVETS_SLUTTFASE;
+            }
+            default -> throw new IllegalStateException("Ikke støttet ytelsetype: " + ip.getInntektYtelseType().getYtelseType());
+        }
     }
 
     private static List<RegisterInntektArbeidOgFrilansDTO> finnArbeidOgFrilansInntekter(InntektArbeidYtelseGrunnlag grunnlag, DatoIntervallEntitet periode) {

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <pdfgen-core.version>1.1.43</pdfgen-core.version>
         <confluent.platform.version>7.9.0</confluent.platform.version>
         <mockito.version>5.17.0</mockito.version>
-        <ung-deltakelse-opplyser.version>1.3.0</ung-deltakelse-opplyser.version>
+        <ung-deltakelse-opplyser.version>1.5.0</ung-deltakelse-opplyser.version>
         <handlebars.version>4.4.0</handlebars.version>
         <validation-model-jakarta.version>1.26.5</validation-model-jakarta.version>
         <openhtmltopdf.version>1.1.26</openhtmltopdf.version>


### PR DESCRIPTION
### **Behov / Bakgrunn**

Idag sendes og presenteres det kodeverdi for ytelsetype, noe som ikke er veldig forståelig for deltaker.
Bakgrunn: https://jira.adeo.no/browse/TSFF-1481

### **Løsning**
Bumper ung-deltakelse-opplyser kontrakten og mapper fagsakYtelse på inntektspost til YtelseType.
