### PR TITLE
Overfør til k9-oppdrag som ungdsomytelse isdf FRISINN

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/tilkjentytelse/MapperForYtelseType.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/tilkjentytelse/MapperForYtelseType.java
@@ -35,12 +35,6 @@ class MapperForYtelseType {
                     + " siden det ikke finnes tilsvarende i " + YtelseType.class.getName());
             }
         }
-
-        if (Environment.current().isDev()){
-            //FIXME fjern
-            //midlertidig mapping i dev for å kunne teste simulering
-            map.put(FagsakYtelseType.UNGDOMSYTELSE, YtelseType.FRISINN);
-        }
         return map;
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Vi har kjørt oversending til k9-oppdrag i dev som FRISINN for å kunne teste simulering. Nå er oppsett for ungdomsytelsen på plass i oppdragsystemet, så bytter til riktig kode.
