### PR TITLE
Oppdater openapi-spec-utils til versjon 1.5.0

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>no.nav.openapi.spec.utils</groupId>
             <artifactId>openapi-spec-utils</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- CDI -->

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -4296,25 +4296,8 @@
             "type" : "integer"
           },
           "måned" : {
-            "properties" : {
-              "leapYear" : {
-                "type" : "boolean"
-              },
-              "month" : {
-                "enum" : [ "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER" ],
-                "x-enum-varnames" : [ "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER" ],
-                "type" : "string"
-              },
-              "monthValue" : {
-                "format" : "int32",
-                "type" : "integer"
-              },
-              "year" : {
-                "format" : "int32",
-                "type" : "integer"
-              }
-            },
-            "type" : "object"
+            "format" : "year-month",
+            "type" : "string"
           },
           "rapportertInntekt" : {
             "type" : "number"


### PR DESCRIPTION
### **Behov / Bakgrunn**

openapi spesifikasjon for YearMonth type vart feil.

### **Løsning**

Oppdaterer til ny versjon av openapi-spec-utils som genererer korrekt type for YearMonth type.