### PR TITLE
Diverse småfiks for historikk v2.

### DIFF
--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/historikk/HistorikkinnslagType.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/historikk/HistorikkinnslagType.java
@@ -163,4 +163,10 @@ public enum HistorikkinnslagType implements Kodeverdi {
     public String getMal() {
         return mal;
     }
+
+    /* For å få korrekt openapi spesifikasjon med kode verdi istadenfor name() verdi */
+    @Override
+    public String toString() {
+        return this.getKode();
+    }
 }

--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/historikk/HistorikkinnslagType.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/historikk/HistorikkinnslagType.java
@@ -48,7 +48,7 @@ public enum HistorikkinnslagType implements Kodeverdi {
     // Mal Type 2
     VEDTAK_FATTET("VEDTAK_FATTET", "Vedtak fattet", HistorikkinnslagMal.MAL_TYPE_2),
     UENDRET_UTFALL("UENDRET_UTFALL", "Uendret utfall", HistorikkinnslagMal.MAL_TYPE_2),
-    TILBAKEKREVING_VIDEREBEHANDLING("TILBAKEKR_VIDEREBEHANDLING", "Metode for å håndtere tilbakekreving av feilutbetailng er valgt.", HistorikkinnslagMal.MAL_TYPE_2),
+    TILBAKEKREVING_VIDEREBEHANDLING("TILBAKEKR_VIDEREBEHANDLING", "Metode for å håndtere tilbakekreving av feilutbetaling er valgt.", HistorikkinnslagMal.MAL_TYPE_2),
     REGISTRER_OM_VERGE("REGISTRER_OM_VERGE", "Registrering av opplysninger om verge/fullmektig/søker under 18 år", HistorikkinnslagMal.MAL_TYPE_2),
     FORSLAG_VEDTAK_UTEN_TOTRINN("FORSLAG_VEDTAK_UTEN_TOTRINN", "Vedtak foreslått", HistorikkinnslagMal.MAL_TYPE_2),
     FORSLAG_VEDTAK("FORSLAG_VEDTAK", "Vedtak foreslått og sendt til beslutter", HistorikkinnslagMal.MAL_TYPE_2),


### PR DESCRIPTION
Fikser diverse småfeil nødvendig for historikk v2:

- Fikser skrivefeil på navn på HistorikkinnslagType.TILBAKEKREVING_VIDEREBEHANDLING. Sidan denne blir synleg i v2 historikk.
- toString på HistorikkinnslagType enum, så openapi spesifikasjon blir rett.