### PR TITLE
FIX: Rydder perioder som er til vurdering i behandlingen før kjøring av inntektskontroll

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektSteg.java
@@ -85,7 +85,7 @@ public class KontrollerInntektSteg implements BehandlingSteg {
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         Long behandlingId = kontekst.getBehandlingId();
-        kontrollerteInntektperioderTjeneste.ryddPerioderFritattForKontroll(behandlingId);
+        kontrollerteInntektperioderTjeneste.ryddPerioderFritattForKontrollEllerTilVurderingIBehandlingen(behandlingId);
         var prosessTriggerTidslinje = prosessTriggerPeriodeUtleder.utledTidslinje(behandlingId);
         var rapporterteInntekterTidslinje = rapportertInntektMapper.mapAlleGjeldendeRegisterOgBrukersInntekter(behandlingId);
         var etterlysninger = etterlysningTjeneste.hentGjeldendeEtterlysninger(kontekst.getBehandlingId(), kontekst.getFagsakId(), EtterlysningType.UTTALELSE_KONTROLL_INNTEKT);

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/kontroll/KontrollerteInntektperioderTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/kontroll/KontrollerteInntektperioderTjeneste.java
@@ -6,10 +6,12 @@ import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateSegmentCombinator;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 import no.nav.ung.sak.behandlingslager.tilkjentytelse.KontrollertInntektPeriode;
 import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseRepository;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.perioder.ProsessTriggerPeriodeUtleder;
 import no.nav.ung.sak.ytelse.RapportertInntektOgKilde;
 import no.nav.ung.sak.ytelseperioder.MånedsvisTidslinjeUtleder;
 import org.slf4j.Logger;
@@ -31,12 +33,14 @@ public class KontrollerteInntektperioderTjeneste {
     private static final Logger LOG = LoggerFactory.getLogger(KontrollerteInntektperioderTjeneste.class);
     private final TilkjentYtelseRepository tilkjentYtelseRepository;
     private final MånedsvisTidslinjeUtleder ytelsesperiodeutleder;
+    private final ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder;
 
 
     @Inject
-    public KontrollerteInntektperioderTjeneste(TilkjentYtelseRepository tilkjentYtelseRepository, MånedsvisTidslinjeUtleder ytelsesperiodeutleder) {
+    public KontrollerteInntektperioderTjeneste(TilkjentYtelseRepository tilkjentYtelseRepository, MånedsvisTidslinjeUtleder ytelsesperiodeutleder, ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder) {
         this.tilkjentYtelseRepository = tilkjentYtelseRepository;
         this.ytelsesperiodeutleder = ytelsesperiodeutleder;
+        this.prosessTriggerPeriodeUtleder = prosessTriggerPeriodeUtleder;
     }
 
     public void opprettKontrollerteInntekterPerioderFraBruker(Long behandlingId,
@@ -61,7 +65,7 @@ public class KontrollerteInntektperioderTjeneste {
      *
      * @param behandlingId BehandlingId
      */
-    public void ryddPerioderFritattForKontroll(Long behandlingId) {
+    public void ryddPerioderFritattForKontrollEllerTilVurderingIBehandlingen(Long behandlingId) {
         final var kontrollertInntektPerioder = tilkjentYtelseRepository.hentKontrollertInntektPerioder(behandlingId);
         if (kontrollertInntektPerioder.isEmpty()) {
             return;
@@ -72,9 +76,11 @@ public class KontrollerteInntektperioderTjeneste {
         if (relevantForKontrollTidslinje.isEmpty()) {
             tilkjentYtelseRepository.lagre(behandlingId, new ArrayList<>());
         } else {
+            final var tidslinjeTilVurdering = prosessTriggerPeriodeUtleder.utledTidslinje(behandlingId).filterValue(it -> it.contains(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT)).mapValue(it -> true);
+            final var tidslinjeSomBeholdes = relevantForKontrollTidslinje.disjoint(tidslinjeTilVurdering);
             final var eksisterendePerioder = kontrollertInntektPerioder.get().getPerioder();
             final var perioderSomBeholdes = eksisterendePerioder.stream()
-                .filter(it -> !relevantForKontrollTidslinje.intersection(it.getPeriode().toLocalDateInterval()).isEmpty())
+                .filter(it -> !tidslinjeSomBeholdes.intersection(it.getPeriode().toLocalDateInterval()).isEmpty())
                 .toList();
             tilkjentYtelseRepository.lagre(behandlingId, perioderSomBeholdes);
         }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved revurdering av periode som tidligere har blitt kontrollert blir forrige vurdering stående, også ved aksjonspunkt. Dette fører til at feil data blir sendt til frontend for manuell kontroll.
