### PR TITLE
FIX: Støtter flere autopunkter i samme steg

### DIFF
--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollFeil.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollFeil.java
@@ -6,6 +6,9 @@ import no.nav.k9.felles.feil.Feil;
 import no.nav.k9.felles.feil.FeilFactory;
 import no.nav.k9.felles.feil.deklarasjon.DeklarerteFeil;
 import no.nav.k9.felles.feil.deklarasjon.TekniskFeil;
+import no.nav.ung.kodeverk.behandling.BehandlingStegType;
+
+import java.util.Set;
 
 public interface BehandlingskontrollFeil extends DeklarerteFeil {
 
@@ -14,8 +17,6 @@ public interface BehandlingskontrollFeil extends DeklarerteFeil {
     @TekniskFeil(feilkode = "FP-143308", feilmelding = "BehandlingId %s er allerede avsluttet, kan ikke henlegges", logLevel = ERROR)
     Feil kanIkkeHenleggeAvsluttetBehandling(Long behandlingId);
 
-    @TekniskFeil(feilkode = "FP-105126", feilmelding = "BehandlingId %s har flere enn et aksjonspunkt, hvor aksjonspunktet fører til tilbakehopp ved gjenopptakelse. Kan ikke gjenopptas.", logLevel = ERROR)
-    Feil kanIkkeGjenopptaBehandlingFantFlereAksjonspunkterSomMedførerTilbakehopp(Long behandlingId);
-
-
+    @TekniskFeil(feilkode = "FP-105126", feilmelding = "BehandlingId %s har flere enn et aksjonspunkt, hvor aksjonspunktet fører til tilbakehopp ved gjenopptakelse til ulike steg. Kan ikke gjenopptas.", logLevel = ERROR)
+    Feil kanIkkeTilbakeføreBehandlingTilFlereSteg(Long id);
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
@@ -487,17 +487,18 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
             .filter(Aksjonspunkt::tilbakehoppVedGjenopptakelse)
             .collect(Collectors.toList());
 
-        if (aksjonspunkterSomMedførerTilbakehopp.size() > 1) {
-            throw BehandlingskontrollFeil.FACTORY.kanIkkeGjenopptaBehandlingFantFlereAksjonspunkterSomMedførerTilbakehopp(behandling.getId()).toException();
-        }
         if (erHenleggelse) {
             settAutopunkterTilAvbrutt(kontekst, behandling);
         } else {
             settAutopunkterTilUtført(kontekst, behandling);
         }
-        if (aksjonspunkterSomMedførerTilbakehopp.size() == 1) {
-            Aksjonspunkt ap = aksjonspunkterSomMedførerTilbakehopp.get(0);
-            BehandlingStegType behandlingStegFunnet = ap.getBehandlingStegFunnet();
+        if (!aksjonspunkterSomMedførerTilbakehopp.isEmpty()) {
+            final var unikeSteg = aksjonspunkterSomMedførerTilbakehopp.stream().map(Aksjonspunkt::getBehandlingStegFunnet)
+                .collect(Collectors.toSet());
+            if (unikeSteg.size() > 1) {
+                throw BehandlingskontrollFeil.FACTORY.kanIkkeTilbakeføreBehandlingTilFlereSteg(behandling.getId()).toException();
+            }
+            BehandlingStegType behandlingStegFunnet = unikeSteg.iterator().next();
             behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, behandlingStegFunnet);
             // I tilfelle tilbakehopp reåpner autopunkt - de skal reutledes av steget.
             settAutopunkterTilUtført(kontekst, behandling);

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/ung/sak/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.behandlingskontroll.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -9,6 +10,12 @@ import java.util.Objects;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.Venteårsak;
+import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
+import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.AksjonspunktKontrollRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingLås;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +48,7 @@ public class BehandlingskontrollTjenesteImplTest {
     private BehandlingskontrollTjenesteImpl kontrollTjeneste;
     private Behandling behandling;
     private BehandlingskontrollKontekst kontekst;
+    private AksjonspunktKontrollRepository aksjonspunktKontrollRepository;
 
     private BehandlingskontrollEventPublisererForTest eventPubliserer ;
     private BehandlingModellRepository behandlingModellRepository ;
@@ -59,7 +67,7 @@ public class BehandlingskontrollTjenesteImplTest {
     @SuppressWarnings("resource")
     @BeforeEach
     public void setup() {
-
+        aksjonspunktKontrollRepository = new AksjonspunktKontrollRepository();
         eventPubliserer = new BehandlingskontrollEventPublisererForTest();
         behandlingModellRepository = new BehandlingModellRepository();
         serviceProvider = new BehandlingskontrollServiceProvider(entityManager, behandlingModellRepository, eventPubliserer);
@@ -172,6 +180,33 @@ public class BehandlingskontrollTjenesteImplTest {
             BehandlingStegStatus.INNGANG);
 
     }
+
+    @Test
+    public void skal_ta_behandling_av_vent_dersom_flere_autopunkter_opprettet_i_samme_steg_og_alle_skal_hoppe_tilbake() {
+
+        // Arrange
+        manipulerInternBehandling.forceOppdaterBehandlingSteg(behandling, BehandlingStegType.VURDER_KOMPLETTHET, BehandlingStegStatus.UTGANG, BehandlingStegStatus.UTFØRT);
+
+        final var aksjonspunkt1 = aksjonspunktKontrollRepository.leggTilAksjonspunkt(behandling, AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_ETTERLYST_INNTEKTUTTALELSE, BehandlingStegType.VURDER_KOMPLETTHET);
+        final var fristTid = LocalDateTime.now().plusDays(1);
+        aksjonspunktKontrollRepository.setFrist(aksjonspunkt1, fristTid, Venteårsak.VENTER_PÅ_ETTERLYST_INNTEKT_UTTALELSE, null);
+
+        final var aksjonspunkt2 = aksjonspunktKontrollRepository.leggTilAksjonspunkt(behandling, AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_REVURDERING, BehandlingStegType.VURDER_KOMPLETTHET);
+        aksjonspunktKontrollRepository.setFrist(aksjonspunkt2, fristTid, Venteårsak.VENTER_BEKREFTELSE_ENDRET_UNGDOMSPROGRAMPERIODE, null);
+
+
+        final var behandlingLåsRepository = new BehandlingLåsRepository(entityManager);
+        final var behandlingLås = behandlingLåsRepository.taLås(behandling.getId());
+        Mockito.when(kontekst.getSkriveLås()).thenReturn(behandlingLås);
+
+        // Act
+        kontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
+
+        // Assert
+        assertThat(behandling.getBehandlingStegStatus()).isEqualTo(BehandlingStegStatus.INNGANG);
+        assertThat(behandling.getAktivtBehandlingSteg()).isEqualTo(BehandlingStegType.VURDER_KOMPLETTHET);
+    }
+
 
     @Test
     public void skal_kaste_exception_dersom_tilbakeføring_til_senere_steg() {


### PR DESCRIPTION
### **Behov / Bakgrunn**
I dag har vi to autopunkter med ulike venteårsaker som kan produseres fra kompletthetsteget. Dette for å se alle grunnene til at behandlingen står stille. Ved gjenopptagelse feiler det i dag fordi modellen ikke støtter flere autopunkter med tilbakehopp.