### PR TITLE
Endre kode verdi på UngdomsytelseSatsType.

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/sats/SatsEndringRepository.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/sats/SatsEndringRepository.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.persistence.Tuple;
+import no.nav.ung.kodeverk.ungdomsytelse.sats.UngdomsytelseSatsType;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 
 import java.sql.Date;
@@ -36,7 +37,7 @@ public class SatsEndringRepository {
 
         String periodeMedHøySats = "(SELECT 1 FROM UNG_GR ungdomsgrunnlag " +
             "       INNER JOIN UNG_SATS_PERIODE satsperiode ON ungdomsgrunnlag.ung_sats_perioder_id = satsperiode.ung_sats_perioder_id " +
-            "       WHERE sats_type = 'HOY' AND ungdomsgrunnlag.behandling_id = b.id)";
+            "       WHERE sats_type = '"+ UngdomsytelseSatsType.HØY.getKode() +"' AND ungdomsgrunnlag.behandling_id = b.id)";
 
         String reTriggerBeregningHøySats = "(SELECT 1 FROM BEHANDLING_ARSAK behandling_årsak WHERE behandling_årsak.behandling_id = b.id AND behandling_årsak.behandling_arsak_type = 'RE_TRIGGER_BEREGNING_HØY_SATS')";
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/sats/SatsEndringRepositoryTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/sats/SatsEndringRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import java.time.LocalDate;
 import java.util.Map;
 
+import no.nav.ung.kodeverk.ungdomsytelse.sats.UngdomsytelseSatsType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -138,7 +139,7 @@ class SatsEndringRepositoryTest {
 
             .executeUpdate();
 
-        entityManager.createNativeQuery("INSERT INTO UNG_SATS_PERIODE (id, ung_sats_perioder_id, periode, dagsats, grunnbeløp, grunnbeløp_faktor, sats_type, antall_barn, dagsats_barnetillegg) VALUES (1, :satsPerioderId, '[2021-01-01,2021-12-31]', 1000, 1000, 1, 'HOY', 0, 0)")
+        entityManager.createNativeQuery("INSERT INTO UNG_SATS_PERIODE (id, ung_sats_perioder_id, periode, dagsats, grunnbeløp, grunnbeløp_faktor, sats_type, antall_barn, dagsats_barnetillegg) VALUES (1, :satsPerioderId, '[2021-01-01,2021-12-31]', 1000, 1000, 1, '"+ UngdomsytelseSatsType.HØY.getKode() +"', 0, 0)")
             .setParameter("satsPerioderId", satsPerioderId)
             .executeUpdate();
 

--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/ungdomsytelse/sats/UngdomsytelseSatsType.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/ungdomsytelse/sats/UngdomsytelseSatsType.java
@@ -3,12 +3,13 @@ package no.nav.ung.kodeverk.ungdomsytelse.sats;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import no.nav.ung.kodeverk.api.Kodeverdi;
 
 public enum UngdomsytelseSatsType implements Kodeverdi {
 
     LAV("LAV", "Lav"),
-    HØY("HOY", "Høy");
+    HØY("HØY", "Høy");
 
     private static final Map<String, UngdomsytelseSatsType> KODER = new LinkedHashMap<>();
 
@@ -41,6 +42,7 @@ public enum UngdomsytelseSatsType implements Kodeverdi {
 
 
     @Override
+    @JsonValue
     public String getKode() {
         return kode;
     }

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_038__endre_kode_ungdomsytelse_sats_type.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_038__endre_kode_ungdomsytelse_sats_type.sql
@@ -1,0 +1,1 @@
+update ung_sats_periode set sats_type = 'HØY' where sats_type = 'HOY';


### PR DESCRIPTION
### **Behov / Bakgrunn**

UngdomsytelseSatsType enum hadde kode verdi ulik name() verdi, og ingen `@JsonValue` annotasjon på kode property. Var dermed inkonsistent i forhold til vanleg definisjon av Kodeverdi enum. Serialisering ville bli anna verdi enn kode.

## Endring

Endre kode verdi til å vere  samme som namn på enum, og setter @JsonValue på kode property slik at denne blir konsistent med andre Kodeverdi enums.