### PR TITLE
Utelater "navn" property i LegacyKodeverdiSomObjektSerializer.

### DIFF
--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/LegacyKodeverdiSomObjektSerializer.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/LegacyKodeverdiSomObjektSerializer.java
@@ -28,9 +28,6 @@ public class LegacyKodeverdiSomObjektSerializer extends StdSerializer<Kodeverdi>
         } else {
             gen.writeStartObject();
             gen.writeStringField("kode", value.getKode());
-            if (value.getNavn() != null) {
-                gen.writeStringField("navn", value.getNavn());
-            }
             gen.writeStringField("kodeverk", value.getKodeverk());
             gen.writeEndObject();
         }


### PR DESCRIPTION
### **Behov / Bakgrunn**

navn har stort sett vore markert med @JsonIgnore før, så dette bevarer eksisterande oppførsel, som også konverterKodeverkTilKode.ts i frontend baserer seg på (den teller antal properties i kodeverk objekt).

### **Løsning**

Utelater "navn" property i LegacyKodeverdiSomObjektSerializer.