### PR TITLE
FIX: Flytter opprettelse av revurdering fra iverksetting til vedtak observer

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/iverksettevedtak/IverksetteVedtakStegYtelseTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/iverksettevedtak/IverksetteVedtakStegYtelseTest.java
@@ -28,7 +28,6 @@ import no.nav.ung.sak.hendelse.stønadstatistikk.StønadstatistikkService;
 import no.nav.ung.sak.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
 import no.nav.ung.sak.test.util.UnitTestLookupInstanceImpl;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
-import no.nav.ung.sak.ytelse.kontroll.ManglendeKontrollperioderTjeneste;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,9 +74,6 @@ public class IverksetteVedtakStegYtelseTest {
     @Mock
     private StønadstatistikkService stønadstatistikkService;
 
-    @Mock
-    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
-
     private IverksetteVedtakSteg iverksetteVedtakSteg;
 
     @BeforeEach
@@ -90,7 +86,7 @@ public class IverksetteVedtakStegYtelseTest {
         historikkRepository = repositoryProvider.getHistorikkinnslagRepository();
 
 
-        opprettProsessTaskIverksett = new UnitTestLookupInstanceImpl<>(new UngdomsytelseOpprettProsessTaskIverksett(prosessTaskRepository, stønadstatistikkService, manglendeKontrollperioderTjeneste));
+        opprettProsessTaskIverksett = new UnitTestLookupInstanceImpl<>(new UngdomsytelseOpprettProsessTaskIverksett(prosessTaskRepository, stønadstatistikkService));
         iverksetteVedtakSteg = new IverksetteVedtakSteg(repositoryProvider,
             opprettProsessTaskIverksett,
             vurderBehandlingerUnderIverksettelse);

--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/iverksett/UngdomsytelseOpprettProsessTaskIverksett.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/iverksett/UngdomsytelseOpprettProsessTaskIverksett.java
@@ -19,7 +19,6 @@ import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakProsessTaskRepository;
 import no.nav.ung.sak.domene.vedtak.intern.AvsluttBehandlingTask;
 import no.nav.ung.sak.hendelse.stønadstatistikk.StønadstatistikkService;
-import no.nav.ung.sak.ytelse.kontroll.ManglendeKontrollperioderTjeneste;
 import no.nav.ung.sak.økonomi.SendØkonomiOppdragTask;
 
 @ApplicationScoped
@@ -28,7 +27,6 @@ public class UngdomsytelseOpprettProsessTaskIverksett implements OpprettProsessT
 
     protected FagsakProsessTaskRepository fagsakProsessTaskRepository;
     private StønadstatistikkService stønadstatistikkService;
-    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
 
     protected UngdomsytelseOpprettProsessTaskIverksett() {
         // for CDI proxy
@@ -36,10 +34,9 @@ public class UngdomsytelseOpprettProsessTaskIverksett implements OpprettProsessT
 
     @Inject
     public UngdomsytelseOpprettProsessTaskIverksett(FagsakProsessTaskRepository fagsakProsessTaskRepository,
-                                                    StønadstatistikkService stønadstatistikkService, ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste) {
+                                                    StønadstatistikkService stønadstatistikkService) {
         this.fagsakProsessTaskRepository = fagsakProsessTaskRepository;
         this.stønadstatistikkService = stønadstatistikkService;
-        this.manglendeKontrollperioderTjeneste = manglendeKontrollperioderTjeneste;
     }
 
     @Override
@@ -61,7 +58,6 @@ public class UngdomsytelseOpprettProsessTaskIverksett implements OpprettProsessT
 
         taskData.addNesteParallell(parallelle);
         taskData.addNesteSekvensiell(ProsessTaskData.forProsessTask(AvsluttBehandlingTask.class));
-        manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(behandling.getId()).ifPresent(taskData::addNesteSekvensiell);
         taskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
 
         taskData.setCallIdFraEksisterende();

--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserver.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserver.java
@@ -9,19 +9,22 @@ import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.ung.kodeverk.vedtak.IverksettingStatus;
 import no.nav.ung.sak.behandlingslager.behandling.vedtak.BehandlingVedtakEvent;
 import no.nav.ung.sak.formidling.bestilling.BrevbestillingTask;
+import no.nav.ung.sak.ytelse.kontroll.ManglendeKontrollperioderTjeneste;
 
 @ApplicationScoped
 public class VedtakFattetEventObserver {
 
     public static final String BREVBESTILLING_TASKTYPE = "formidling.brevbestilling";
     private ProsessTaskTjeneste taskTjeneste;
+    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
 
     public VedtakFattetEventObserver() {
     }
 
     @Inject
-    public VedtakFattetEventObserver(ProsessTaskTjeneste taskTjeneste) {
+    public VedtakFattetEventObserver(ProsessTaskTjeneste taskTjeneste, ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste) {
         this.taskTjeneste = taskTjeneste;
+        this.manglendeKontrollperioderTjeneste = manglendeKontrollperioderTjeneste;
     }
 
     public void observerBehandlingVedtak(@Observes BehandlingVedtakEvent event) {
@@ -32,6 +35,10 @@ public class VedtakFattetEventObserver {
             if (erBehandlingAvRettTypeForAbakus(event)) {
                 gruppe.addNesteSekvensiell(opprettTaskForPubliseringAvVedtakMedYtelse(event));
             }
+
+            manglendeKontrollperioderTjeneste.lagProsesstaskForRevurderingGrunnetManglendeKontrollAvInntekt(event.getBehandlingId())
+                .ifPresent(gruppe::addNesteParallell);
+
             taskTjeneste.lagre(gruppe);
         }
     }

--- a/domenetjenester/vedtak/src/test/java/no/nav/ung/sak/domene/vedtak/fp/OpprettProsessTaskIverksettTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/ung/sak/domene/vedtak/fp/OpprettProsessTaskIverksettTest.java
@@ -20,7 +20,6 @@ import no.nav.ung.sak.hendelse.stønadstatistikk.StønadstatistikkService;
 import no.nav.ung.sak.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
 import no.nav.ung.sak.produksjonsstyring.oppgavebehandling.task.AvsluttOppgaveTask;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
-import no.nav.ung.sak.ytelse.kontroll.ManglendeKontrollperioderTjeneste;
 import no.nav.ung.sak.økonomi.SendØkonomiOppdragTask;
 import no.nav.ung.sak.økonomi.task.VurderOppgaveTilbakekrevingTask;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,9 +61,6 @@ public class OpprettProsessTaskIverksettTest {
     @Mock
     private StønadstatistikkService stønadstatistikkService;
 
-    @Mock
-    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
-
     private Behandling behandling;
     private OpprettProsessTaskIverksett opprettProsessTaskIverksett;
 
@@ -75,7 +71,7 @@ public class OpprettProsessTaskIverksettTest {
 
         var scenario = TestScenarioBuilder.builderMedSøknad();
         behandling = scenario.lagMocked();
-        opprettProsessTaskIverksett = new UngdomsytelseOpprettProsessTaskIverksett(fagsakProsessTaskRepository, stønadstatistikkService, manglendeKontrollperioderTjeneste);
+        opprettProsessTaskIverksett = new UngdomsytelseOpprettProsessTaskIverksett(fagsakProsessTaskRepository, stønadstatistikkService);
     }
 
     @Test

--- a/domenetjenester/vedtak/src/test/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserverTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserverTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 
+import no.nav.ung.sak.ytelse.kontroll.ManglendeKontrollperioderTjeneste;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,9 @@ public class VedtakFattetEventObserverTest {
     @Mock
     private BehandlingVedtakRepository vedtakRepository;
 
+    @Mock
+    private ManglendeKontrollperioderTjeneste manglendeKontrollperioderTjeneste;
+
     @Captor
     ArgumentCaptor<ProsessTaskGruppe> prosessTaskGruppeCaptorCaptor;
 
@@ -58,7 +62,7 @@ public class VedtakFattetEventObserverTest {
 
     @BeforeEach
     public void setup() {
-        vedtakFattetEventObserver = new VedtakFattetEventObserver(prosessTaskRepository);
+        vedtakFattetEventObserver = new VedtakFattetEventObserver(prosessTaskRepository, manglendeKontrollperioderTjeneste);
     }
 
     @Test


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å unngå at vranglås av tasker flyttes revurderingtasken til vedtak status observer. Der opprettes revurdering først etter at behandling er iverksatt.