### PR TITLE
FIX: Håndterer endret startdato fra det som bruker fikk opplyst i søknaden

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/startdato/UngdomsytelseSøktStartdato.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/startdato/UngdomsytelseSøktStartdato.java
@@ -46,10 +46,6 @@ public class UngdomsytelseSøktStartdato extends BaseEntitet implements SøktPer
         this.journalpostId = journalpostId;
     }
 
-    public UngdomsytelseSøktStartdato(LocalDate startdato) {
-        this.startdato = startdato;
-    }
-
     public UngdomsytelseSøktStartdato(UngdomsytelseSøktStartdato it) {
         this.journalpostId = it.getJournalpostId();
         this.startdato = it.getStartdato();

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/BeregnYtelseStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/beregnytelse/BeregnYtelseStegTest.java
@@ -10,6 +10,7 @@ import no.nav.ung.kodeverk.ungdomsytelse.sats.UngdomsytelseSatsType;
 import no.nav.ung.sak.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
@@ -64,7 +65,7 @@ class BeregnYtelseStegTest {
         ungdomsprogramPeriodeRepository = new UngdomsprogramPeriodeRepository(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
         final var månedsvisTidslinjeUtleder = new MånedsvisTidslinjeUtleder(
-            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository),
+            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, new UngdomsytelseStartdatoRepository(entityManager)),
             behandlingRepository);
         beregnYtelseSteg = new BeregnYtelseSteg(ungdomsytelseGrunnlagRepository,
             tilkjentYtelseRepository,

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/ManglendeKontrollperioderTjenesteTest.java
@@ -63,7 +63,7 @@ class ManglendeKontrollperioderTjenesteTest {
 
     @BeforeEach
     void setUp() {
-        final var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository);
+        final var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, ungdomsytelseStartdatoRepository);
         final var ungdomsytelseSøknadsperiodeTjeneste = new UngdomsytelseSøknadsperiodeTjeneste(ungdomsytelseStartdatoRepository, ungdomsprogramPeriodeTjeneste, behandlingRepository);
         prosessTriggerPeriodeUtleder = new ProsessTriggerPeriodeUtleder(prosessTriggereRepository, ungdomsytelseSøknadsperiodeTjeneste);
         ytelsesperiodeutleder = new MånedsvisTidslinjeUtleder(ungdomsprogramPeriodeTjeneste, behandlingRepository);

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/ungdomsprogramkontroll/ProgramperiodeendringEtterlysningTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/ungdomsprogramkontroll/ProgramperiodeendringEtterlysningTjenesteTest.java
@@ -13,6 +13,8 @@ import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseSøktStartdato;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
@@ -49,6 +51,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     private UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository;
     @Inject
     private EtterlysningRepository etterlysningRepository;
+    @Inject
+    private UngdomsytelseStartdatoRepository ungdomsytelseStartdatoRepository;
 
     @Inject
     private EntityManager entityManager;
@@ -62,7 +66,7 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void setUp() {
         scenario = TestScenarioBuilder.builderMedSøknad();
         behandling = scenario.medBehandlingÅrsak(BehandlingÅrsakType.RE_HENDELSE_ENDRET_STARTDATO_UNGDOMSPROGRAM).lagre(entityManager);
-        final var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository);
+        final var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, ungdomsytelseStartdatoRepository);
         mottatteDokumentRepository = new MottatteDokumentRepository(entityManager);
         programperiodeendringEtterlysningTjeneste = new ProgramperiodeendringEtterlysningTjeneste(
             ungdomsprogramPeriodeTjeneste,
@@ -92,7 +96,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void skal_ikke_opprette_etterlysning_for_endret_startdato_uten_endring() {
 
         final var fom = LocalDate.now();
-        final var tom = fom.plusDays(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
 
         // act
@@ -105,7 +110,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     @Test
     void skal_opprette_etterlysning_for_endret_startdato_endring() {
         final var fom = LocalDate.now();
-        final var tom = fom.plusDays(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
 
 
@@ -126,11 +132,54 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     }
 
     @Test
+    void skal_opprette_etterlysning_for_endret_startdato_endring_fra_oppgitt_i_søknad() {
+        final var fom = LocalDate.now();
+        final var tom = TIDENES_ENDE;
+        var fomFraSøknad = fom.minusDays(10);
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fomFraSøknad, new JournalpostId("1L"))));
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
+        final var ungdomsprogramPeriodeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
+
+        // act
+        programperiodeendringEtterlysningTjeneste.opprettEtterlysningerForProgramperiodeEndring(BehandlingReferanse.fra(behandling));
+
+        final var etterlysninger = etterlysningRepository.hentEtterlysninger(behandling.getId());
+        assertThat(etterlysninger.size()).isEqualTo(1);
+        final var etterlysning = etterlysninger.get(0);
+        assertThat(etterlysning.getPeriode()).isEqualTo(DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom));
+        assertThat(etterlysning.getStatus()).isEqualTo(EtterlysningStatus.OPPRETTET);
+        assertThat(etterlysning.getType()).isEqualTo(EtterlysningType.UTTALELSE_ENDRET_STARTDATO);
+        assertThat(etterlysning.getGrunnlagsreferanse()).isEqualTo(ungdomsprogramPeriodeGrunnlag.getGrunnlagsreferanse());
+    }
+
+    @Test
+    void skal_opprette_etterlysning_for_sluttdato_satt_i_førstegangsbehandling() {
+        final var fom = LocalDate.now();
+        final var tom = fom.plusWeeks(1);
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
+        final var ungdomsprogramPeriodeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
+
+        // act
+        programperiodeendringEtterlysningTjeneste.opprettEtterlysningerForProgramperiodeEndring(BehandlingReferanse.fra(behandling));
+
+        final var etterlysninger = etterlysningRepository.hentEtterlysninger(behandling.getId());
+        assertThat(etterlysninger.size()).isEqualTo(1);
+        final var etterlysning = etterlysninger.get(0);
+        assertThat(etterlysning.getPeriode()).isEqualTo(DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom));
+        assertThat(etterlysning.getStatus()).isEqualTo(EtterlysningStatus.OPPRETTET);
+        assertThat(etterlysning.getType()).isEqualTo(EtterlysningType.UTTALELSE_ENDRET_SLUTTDATO);
+        assertThat(etterlysning.getGrunnlagsreferanse()).isEqualTo(ungdomsprogramPeriodeGrunnlag.getGrunnlagsreferanse());
+    }
+
+
+    @Test
     void skal_opprette_etterlysning_for_endret_sluttdato() {
         var scenario = TestScenarioBuilder.builderMedSøknad();
         behandling = scenario.medBehandlingÅrsak(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM).lagre(entityManager);
 
         final var fom = LocalDate.now();
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, TIDENES_ENDE)));
 
 
@@ -156,7 +205,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void skal_ikke_opprette_ny_etterlysning_for_endret_startdato_dersom_ventende_etterlysning_er_gyldig() {
 
         final var fom = LocalDate.now();
-        final var tom = fom.plusDays(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
         final var ungdomsprogramPeriodeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
 
@@ -179,7 +229,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void skal_opprette_ny_etterlysning_for_endret_startdato_dersom_ventende_etterlysning_ikke_er_gyldig() {
 
         final var gammelFom = LocalDate.now();
-        final var tom = gammelFom.plusYears(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(gammelFom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(
             new UngdomsprogramPeriode(gammelFom, tom)
         ));
@@ -215,7 +266,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void skal_ikke_opprette_ny_etterlysning_for_endret_startdato_med_endret_grunnlagsreferanse_dersom_ventende_etterlysning_er_gyldig() {
 
         final var fom = LocalDate.now();
-        final var tom = fom.plusDays(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
 
         final var ungdomsprogramPeriodeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
@@ -241,7 +293,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void skal_ikke_opprette_ny_etterlysning_dersom_etterlysning_med_mottatt_svar_er_gyldig() {
 
         final var fom = LocalDate.now();
-        final var tom = fom.plusDays(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)));
         final var ungdomsprogramPeriodeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
 
@@ -264,7 +317,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     void skal_opprette_ny_etterlysning_dersom_etterlysning_med_mottatt_svar_ikke_er_gyldig() {
 
         final var gammelFom = LocalDate.now();
-        final var tom = gammelFom.plusYears(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(gammelFom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(gammelFom, tom)));
         final var ungdomsprogramPeriodeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
 
@@ -293,7 +347,8 @@ class ProgramperiodeendringEtterlysningTjenesteTest {
     @Test
     void skal_opprette_ny_etterlysning_dersom_siste_etterlysning_med_mottatt_svar_ikke_er_gyldig_og_har_mottatt_svar_for_samme_endring_tidligere() {
         final var opprinneligFom = LocalDate.now().plusMonths(1);
-        final var tom = opprinneligFom.plusYears(1);
+        final var tom = TIDENES_ENDE;
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(opprinneligFom, new JournalpostId("1L"))));
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(opprinneligFom, tom)));
         final var ungdomsprogramPeriodeGrunnlag1 = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId()).orElseThrow();
         opprettEtterlysningMedMottattSvar(ungdomsprogramPeriodeGrunnlag1, opprinneligFom, tom, EtterlysningType.UTTALELSE_ENDRET_STARTDATO);

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/ProsessModell.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/ung/sak/behandlingskontroll/ProsessModell.java
@@ -28,6 +28,7 @@ public class ProsessModell {
             .medSteg(BehandlingStegType.FORESLÅ_BEHANDLINGSRESULTAT)
             .medSteg(BehandlingStegType.UNGDOMSYTELSE_BEREGNING, StartpunktType.BEREGNING)
             .medSteg(BehandlingStegType.VURDER_UTTAK)
+            .medSteg(BehandlingStegType.VURDER_KOMPLETTHET)
             .medSteg(BehandlingStegType.BEREGN_YTELSE)
             .medSteg(BehandlingStegType.SIMULER_OPPDRAG)
             .medSteg(BehandlingStegType.FORESLÅ_VEDTAK)

--- a/domenetjenester/hendelsemottak/src/test/java/no/nav/ung/sak/hendelsemottak/tjenester/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
+++ b/domenetjenester/hendelsemottak/src/test/java/no/nav/ung/sak/hendelsemottak/tjenester/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.ungdomsprogram.UngdomsprogramPeriodeTjeneste;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,7 +54,7 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtlederTest {
     void setUp() {
         var fagsakRepository = new FagsakRepository(entityManager);
         this.utleder = new UngdomsprogramOpphørFagsakTilVurderingUtleder(
-            new BehandlingRepository(entityManager), new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository), new FinnFagsakerForAktørTjeneste(entityManager, fagsakRepository));
+            new BehandlingRepository(entityManager), new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, new UngdomsytelseStartdatoRepository(entityManager)), new FinnFagsakerForAktørTjeneste(entityManager, fagsakRepository));
         scenarioBuilder = TestScenarioBuilder.builderMedSøknad(FagsakYtelseType.UNGDOMSYTELSE)
             .medBruker(BRUKER_AKTØR_ID);
     }

--- a/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/FagsakperiodeUtlederTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/ung/sak/mottak/dokumentmottak/FagsakperiodeUtlederTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.ungdomsprogram.forbruktedager.FagsakperiodeUtleder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ class FagsakperiodeUtlederTest {
     @BeforeEach
     void setUp() {
         ungdomsprogramPeriodeRepository = new UngdomsprogramPeriodeRepository(entityManager);
-        ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository);
+        ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, new UngdomsytelseStartdatoRepository(entityManager));
         fagsakperiodeUtleder = new FagsakperiodeUtleder(ungdomsprogramPeriodeTjeneste);
     }
 

--- a/domenetjenester/perioder/src/test/java/no/nav/ung/sak/perioder/UngdomsytelseSøknadsperiodeTjenesteTest.java
+++ b/domenetjenester/perioder/src/test/java/no/nav/ung/sak/perioder/UngdomsytelseSøknadsperiodeTjenesteTest.java
@@ -47,7 +47,7 @@ class UngdomsytelseSøknadsperiodeTjenesteTest {
         søknadsperiodeRepository = new UngdomsytelseStartdatoRepository(em);
         behandlingRepository = new BehandlingRepository(em);
         ungdomsytelseSøknadsperiodeTjeneste = new UngdomsytelseSøknadsperiodeTjeneste(søknadsperiodeRepository,
-            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository),
+            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, new UngdomsytelseStartdatoRepository(em)),
             behandlingRepository
             );
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/AbstractVedtaksbrevInnholdByggerTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/AbstractVedtaksbrevInnholdByggerTest.java
@@ -72,7 +72,7 @@ abstract class AbstractVedtaksbrevInnholdByggerTest {
         var repositoryProvider = ungTestRepositories.repositoryProvider();
 
         UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository = ungTestRepositories.ungdomsprogramPeriodeRepository();
-        UngdomsprogramPeriodeTjeneste ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository);
+        UngdomsprogramPeriodeTjeneste ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, ungTestRepositories.ungdomsytelseStartdatoRepository());
 
         BehandlingRepository behandlingRepository = repositoryProvider.getBehandlingRepository();
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevGenerererTjenesteTest.java
@@ -56,8 +56,8 @@ class BrevGenerererTjenesteTest {
 
         FørstegangsInnvilgelseInnholdBygger førstegangsInnvilgelseInnholdBygger = new FørstegangsInnvilgelseInnholdBygger(
             ungTestRepositories.ungdomsytelseGrunnlagRepository(),
-            new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository())
-            , ungTestRepositories.tilkjentYtelseRepository(), false, null);
+            new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository(), ungTestRepositories.ungdomsytelseStartdatoRepository()),
+            ungTestRepositories.tilkjentYtelseRepository(), false, null);
         BrevGenerererTjeneste brevGenerererTjeneste = new BrevGenerererTjenesteImpl(
             repositoryProvider.getBehandlingRepository(),
             new AktørTjeneste(pdlKlient),
@@ -67,7 +67,7 @@ class BrevGenerererTjenesteTest {
                 repositoryProvider.getBehandlingRepository(),
                 new UnitTestLookupInstanceImpl<>(førstegangsInnvilgelseInnholdBygger),
                 new DetaljertResultatUtlederFake(
-                ungTestGrunnlag.ungdomsprogramvilkår().mapValue(it -> DetaljertResultat.of(DetaljertResultatInfo.of(DetaljertResultatType.INNVILGELSE_UTBETALING_NY_PERIODE), Collections.emptySet(), Collections.emptySet(), Collections.emptySet()))),
+                    ungTestGrunnlag.ungdomsprogramvilkår().mapValue(it -> DetaljertResultat.of(DetaljertResultatInfo.of(DetaljertResultatType.INNVILGELSE_UTBETALING_NY_PERIODE), Collections.emptySet(), Collections.emptySet(), Collections.emptySet()))),
                 ungTestRepositories.ungdomsprogramPeriodeRepository()),
             ungTestRepositories.vedtaksbrevValgRepository(), new ManuellVedtaksbrevInnholdBygger(ungTestRepositories.vedtaksbrevValgRepository()));
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/FormidlingTjenesteTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/FormidlingTjenesteTest.java
@@ -70,7 +70,7 @@ class FormidlingTjenesteTest {
         var repositoryProvider = ungTestRepositories.repositoryProvider();
         var tilkjentYtelseRepository = ungTestRepositories.tilkjentYtelseRepository();
 
-        var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository());
+        var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository(), ungTestRepositories.ungdomsytelseStartdatoRepository());
 
         var endringInnholdBygger = new EndringRapportertInntektInnholdBygger(tilkjentYtelseRepository);
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
@@ -313,7 +313,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
 
     @Override
     protected VedtaksbrevInnholdBygger lagVedtaksbrevInnholdBygger() {
-        var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository());
+        var ungdomsprogramPeriodeTjeneste = new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository(), ungTestRepositories.ungdomsytelseStartdatoRepository());
 
         return  new FørstegangsInnvilgelseInnholdBygger(
             ungTestRepositories.ungdomsytelseGrunnlagRepository(),

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/VedtaksbrevReglerTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/VedtaksbrevReglerTest.java
@@ -140,7 +140,7 @@ class VedtaksbrevReglerTest {
         var detaljertResultatUtleder = new DetaljertResultatUtlederImpl(
             new ProsessTriggerPeriodeUtleder(ungTestRepositories.prosessTriggereRepository(),
                 new UngdomsytelseSøknadsperiodeTjeneste(ungTestRepositories.ungdomsytelseStartdatoRepository(),
-                    new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository()),
+                    new UngdomsprogramPeriodeTjeneste(ungTestRepositories.ungdomsprogramPeriodeRepository(), ungTestRepositories.ungdomsytelseStartdatoRepository()),
                     behandlingRepository)),
             ungTestRepositories.tilkjentYtelseRepository(),
             repositoryProvider.getVilkårResultatRepository());

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/kontroll/FastsettInntektOppdatererTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/kontroll/FastsettInntektOppdatererTest.java
@@ -84,11 +84,12 @@ class FastsettInntektOppdatererTest {
         ungdomsprogramPeriodeRepository = new UngdomsprogramPeriodeRepository(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
         prosesstriggerRepo = new ProsessTriggereRepository(entityManager);
+        var ungdomsytelseStartdatoRepository = new UngdomsytelseStartdatoRepository(entityManager);
         final var månedsvisTidslinjeUtleder = new MånedsvisTidslinjeUtleder(
-            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository),
+            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, ungdomsytelseStartdatoRepository),
             behandlingRepository);
         prosessTriggerPeriodeUtleder = new ProsessTriggerPeriodeUtleder(prosesstriggerRepo,
-            new UngdomsytelseSøknadsperiodeTjeneste(new UngdomsytelseStartdatoRepository(entityManager), new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository), behandlingRepository));
+            new UngdomsytelseSøknadsperiodeTjeneste(ungdomsytelseStartdatoRepository, new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, ungdomsytelseStartdatoRepository), behandlingRepository));
         kontrollerteInntektperioderTjeneste = new KontrollerteInntektperioderTjeneste(tilkjentYtelseRepository, månedsvisTidslinjeUtleder, prosessTriggerPeriodeUtleder);
         final var rapportertInntektMapper = new RapportertInntektMapper(inntektArbeidYtelseTjeneste, månedsvisTidslinjeUtleder);
         oppdaterer = new FastsettInntektOppdaterer(

--- a/web/src/test/java/no/nav/ung/sak/web/app/ungdomsytelse/UngdomsytelseRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/ungdomsytelse/UngdomsytelseRestTjenesteTest.java
@@ -6,6 +6,7 @@ import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
 import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelsePeriode;
@@ -52,9 +53,9 @@ class UngdomsytelseRestTjenesteTest {
         ungdomsytelseRestTjeneste = new UngdomsytelseRestTjeneste(
             behandlingRepository,
             ungdomsytelseGrunnlagRepository,
-            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository),
+            new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, new UngdomsytelseStartdatoRepository(entityManager)),
             tilkjentYtelseRepository,
-            new MånedsvisTidslinjeUtleder(new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository), behandlingRepository)
+            new MånedsvisTidslinjeUtleder(new UngdomsprogramPeriodeTjeneste(ungdomsprogramPeriodeRepository, new UngdomsytelseStartdatoRepository(entityManager)), behandlingRepository)
         );
 
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
I tilfeller der innsending av søknad feiler/tar lang tid, og endringer i programperioden kommer inn i mellomtiden, vil den innhentede perioden i ung-sak ikke nødvendigvis stemme overens med det bruker fikk presentert i søknadsdialogen. For å bedre håndtere en slik situasjon opprettes det oppgave der startdato fra register differ med startdato som bruker fikk presentert i søknadsdialogen.

Siden vi per nå ikke tar inn sluttdato via søknad har vi ingen måte å vite hva bruker fikk presentert da hen søkte. For å bøte på dette oppretter vi alltid oppgave om å bekrefte sluttdato dersom denne er satt i førstegangsbehandling.
