### PR TITLE
TSFF-1704: Justerer periode for aldersvilkåret slik at det kun vurderes første dag der ungdomsprogramvilkåret er innvilget

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/IngenVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/IngenVurdering.java
@@ -13,10 +13,5 @@ public class IngenVurdering implements KantIKantVurderer {
     public boolean erKantIKant(DatoIntervallEntitet periode1, DatoIntervallEntitet periode2) {
         return false;
     }
-
-    @Override
-    public boolean erKomprimerbar() {
-        return false;
-    }
 }
 

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/KantIKantVurderer.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/KantIKantVurderer.java
@@ -6,7 +6,4 @@ public interface KantIKantVurderer {
 
     boolean erKantIKant(DatoIntervallEntitet periode1, DatoIntervallEntitet periode2);
 
-    default boolean erKomprimerbar() {
-        return true;
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårBuilder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårBuilder.java
@@ -252,9 +252,7 @@ public class VilkårBuilder {
             justereUtfallVedTilbakestilling(periodeneSomFaltBort);
         }
         bygget = true;
-        if (kantIKantVurderer.erKomprimerbar()) {
-            vilkårTidslinje = vilkårTidslinje.compress();
-        }
+        vilkårTidslinje = vilkårTidslinje.compress();
         var vilkårsPerioderRaw = vilkårTidslinje
             .toSegments()
             .stream()
@@ -330,9 +328,7 @@ public class VilkårBuilder {
         var timeline = new LocalDateTimeline<>(vilkårPerioder.stream()
             .map(it -> new LocalDateSegment<>(it.getFom(), it.getTom(), new WrappedVilkårPeriode(it)))
             .collect(Collectors.toList()));
-        if (kantIKantVurderer.erKomprimerbar()) {
-            timeline = timeline.compress();
-        }
+        timeline = timeline.compress();
         return timeline.toSegments()
             .stream()
             .filter(it -> it.getValue() != null)

--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/ung/sak/inngangsvilkår/ungdomsprogram/AvhengigeVilkårJusterer.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/ung/sak/inngangsvilkår/ungdomsprogram/AvhengigeVilkårJusterer.java
@@ -1,0 +1,68 @@
+package no.nav.ung.sak.inngangsvilkår.ungdomsprogram;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.kodeverk.vilkår.VilkårType;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.*;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Set;
+
+/**
+ * Tjeneste for å justere avhengige vilkår når et vilkår vurderes.
+ * Dersom et vilkår vurderes som IKKE_OPPFYLT, fjernes de aktuelle periodene fra
+ * alle avhengige vilkår.
+ */
+@Dependent
+public class AvhengigeVilkårJusterer {
+
+    private final VilkårResultatRepository vilkårResultatRepository;
+
+    @Inject
+    public AvhengigeVilkårJusterer(VilkårResultatRepository vilkårResultatRepository) {
+        this.vilkårResultatRepository = vilkårResultatRepository;
+    }
+
+    /** Fjerner perioder fra avhengige vilkår der et definerende vilkår vurderes som avslått. Definerende vilkår er et vilkår som bestemmer hvilke perioder andre vilkår skal vurderes i. Det er kun innvilgede perioder for definerende vilkår som skal vurderes for avhengige vilkår.
+     * <p>
+     * For ungdomsytelsen er definerende vilkår ungdomsprogramvilkåret og avhengige vilkår er aldersvilkåret. Se også VilkårsPerioderTilVurde* For ungdomsytelsen er definerende vilkår ungdomsprogramvilkåret og avhengige vilkår er aldersvilkåret. Se også {@link no.nav.ung.sak.perioder.UngdomsytelseVilkårsperioderTilVurderingTjeneste#definerendeVilkår()}
+     *
+     * @param behandlingId Behandling ID for den behandlingen som skal justeres.
+     * @param perioderTilVurdering Perioder som vurderes for definerende vilkår
+     * @param avhengigeVilkår Vilkår som er avhengige av det definerende vilkår
+     * @param definerendeVilkår Vilkårtype for definerende vilkår som vurderes.
+     */
+    public void fjernAvslåttePerioderForAvhengigeVilkår(long behandlingId, NavigableSet<DatoIntervallEntitet> perioderTilVurdering, Set<VilkårType> avhengigeVilkår, VilkårType definerendeVilkår) {
+        var vilkårene = vilkårResultatRepository.hent(behandlingId);
+
+        // Finner avslåtte perioder for definerende vilkår som er vurdert i behandlingen
+        var avslåttePerioder = vilkårene.getVilkår(definerendeVilkår)
+            .stream().map(Vilkår::getPerioder)
+            .flatMap(List::stream)
+            .filter(p -> perioderTilVurdering.stream().anyMatch(tilVurdering -> tilVurdering.overlapper(p.getPeriode())) && p.getUtfall().equals(Utfall.IKKE_OPPFYLT))
+            .map(VilkårPeriode::getPeriode)
+            .toList();
+
+        if (avslåttePerioder.isEmpty()) {
+            return; // Ingenting å justere
+        }
+
+        // Justerer alle avhengige vilkår (fjerner perioder)
+        var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårene);
+
+        for (var type : avhengigeVilkår) {
+            var vilkårBuilder = vilkårResultatBuilder.hentBuilderFor(type);
+            for (DatoIntervallEntitet datoIntervallEntitet : avslåttePerioder) {
+                vilkårBuilder = vilkårBuilder.tilbakestill(datoIntervallEntitet);
+            }
+            vilkårResultatBuilder.leggTil(vilkårBuilder);
+        }
+
+        vilkårResultatRepository.lagre(behandlingId, vilkårResultatBuilder.build());
+    }
+
+}

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/ung/sak/inngangsvilkår/ungdomsprogram/AvhengigeVilkårJustererTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/ung/sak/inngangsvilkår/ungdomsprogram/AvhengigeVilkårJustererTest.java
@@ -1,0 +1,169 @@
+package no.nav.ung.sak.inngangsvilkår.ungdomsprogram;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.kodeverk.vilkår.VilkårType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.*;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(JpaExtension.class)
+@ExtendWith(CdiAwareExtension.class)
+class AvhengigeVilkårJustererTest {
+
+    @Inject
+    private EntityManager em;
+
+    @Inject
+    private VilkårResultatRepository vilkårResultatRepository;
+
+    private AvhengigeVilkårJusterer avhengigeVilkårJusterer;
+    private Behandling behandling;
+
+    @BeforeEach
+    void setUp() {
+
+        var scenarioBuilder = TestScenarioBuilder.builderMedSøknad();
+        behandling = scenarioBuilder.lagre(em);
+
+
+        avhengigeVilkårJusterer = new AvhengigeVilkårJusterer(vilkårResultatRepository);
+
+    }
+
+    @Test
+    void skal_ikke_justere_vilkår_dersom_ingen_perioder_avslått() {
+
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(10));
+        var resultatBuilder = new VilkårResultatBuilder();
+
+        var ungdomsprogramVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.UNGDOMSPROGRAMVILKÅRET);
+        lagPeriodeMedUtfall(ungdomsprogramVilkårBuilder, periode, Utfall.OPPFYLT);
+
+        var alderVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.ALDERSVILKÅR);
+        lagPeriodeMedUtfall(alderVilkårBuilder, periode, Utfall.IKKE_VURDERT);
+
+        resultatBuilder.leggTil(alderVilkårBuilder);
+        resultatBuilder.leggTil(ungdomsprogramVilkårBuilder);
+
+        vilkårResultatRepository.lagre(behandling.getId(), resultatBuilder.build());
+
+        avhengigeVilkårJusterer.fjernAvslåttePerioderForAvhengigeVilkår(behandling.getId(), new TreeSet<>(Set.of(periode)), Set.of(VilkårType.ALDERSVILKÅR), VilkårType.UNGDOMSPROGRAMVILKÅRET);
+
+
+        var nyttResultat = vilkårResultatRepository.hent(behandling.getId());
+        var avhengigVilkårResultat = nyttResultat.getVilkår(VilkårType.ALDERSVILKÅR).orElseThrow();
+        var perioderAvhengigVilkår = avhengigVilkårResultat.getPerioder();
+        assertThat(perioderAvhengigVilkår.size()).isEqualTo(1);
+        assertThat(perioderAvhengigVilkår.get(0).getUtfall()).isEqualTo(Utfall.IKKE_VURDERT);
+        assertThat(perioderAvhengigVilkår.get(0).getFom()).isEqualTo(periode.getFomDato());
+        assertThat(perioderAvhengigVilkår.get(0).getTom()).isEqualTo(periode.getTomDato());
+    }
+
+    @Test
+    void skal_ikke_justere_vilkår_dersom_ingen_perioder_til_vurdering() {
+
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(10));
+        var resultatBuilder = new VilkårResultatBuilder();
+
+        var ungdomsprogramVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.UNGDOMSPROGRAMVILKÅRET);
+        lagPeriodeMedUtfall(ungdomsprogramVilkårBuilder, periode, Utfall.OPPFYLT);
+
+        var alderVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.ALDERSVILKÅR);
+        lagPeriodeMedUtfall(alderVilkårBuilder, periode, Utfall.IKKE_VURDERT);
+
+        resultatBuilder.leggTil(alderVilkårBuilder);
+        resultatBuilder.leggTil(ungdomsprogramVilkårBuilder);
+
+        vilkårResultatRepository.lagre(behandling.getId(), resultatBuilder.build());
+
+        avhengigeVilkårJusterer.fjernAvslåttePerioderForAvhengigeVilkår(behandling.getId(), new TreeSet<>(Set.of()), Set.of(VilkårType.ALDERSVILKÅR), VilkårType.UNGDOMSPROGRAMVILKÅRET);
+
+
+        var nyttResultat = vilkårResultatRepository.hent(behandling.getId());
+        var avhengigVilkårResultat = nyttResultat.getVilkår(VilkårType.ALDERSVILKÅR).orElseThrow();
+        var perioderAvhengigVilkår = avhengigVilkårResultat.getPerioder();
+        assertThat(perioderAvhengigVilkår.size()).isEqualTo(1);
+        assertThat(perioderAvhengigVilkår.get(0).getUtfall()).isEqualTo(Utfall.IKKE_VURDERT);
+        assertThat(perioderAvhengigVilkår.get(0).getFom()).isEqualTo(periode.getFomDato());
+        assertThat(perioderAvhengigVilkår.get(0).getTom()).isEqualTo(periode.getTomDato());
+    }
+
+
+    @Test
+    void skal_fjerne_hele_vilkårsperiode_dersom_hele_perioden_er_avslått() {
+
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(10));
+        var resultatBuilder = new VilkårResultatBuilder();
+
+        var ungdomsprogramVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.UNGDOMSPROGRAMVILKÅRET);
+        lagPeriodeMedUtfall(ungdomsprogramVilkårBuilder, periode, Utfall.IKKE_OPPFYLT);
+
+        var alderVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.ALDERSVILKÅR);
+        lagPeriodeMedUtfall(alderVilkårBuilder, periode, Utfall.IKKE_VURDERT);
+
+        resultatBuilder.leggTil(alderVilkårBuilder);
+        resultatBuilder.leggTil(ungdomsprogramVilkårBuilder);
+
+        vilkårResultatRepository.lagre(behandling.getId(), resultatBuilder.build());
+
+        avhengigeVilkårJusterer.fjernAvslåttePerioderForAvhengigeVilkår(behandling.getId(), new TreeSet<>(Set.of(periode)), Set.of(VilkårType.ALDERSVILKÅR), VilkårType.UNGDOMSPROGRAMVILKÅRET);
+
+
+        var nyttResultat = vilkårResultatRepository.hent(behandling.getId());
+        var avhengigVilkårResultat = nyttResultat.getVilkår(VilkårType.ALDERSVILKÅR).orElseThrow();
+        var perioderAvhengigVilkår = avhengigVilkårResultat.getPerioder();
+        assertThat(perioderAvhengigVilkår.size()).isEqualTo(0);
+    }
+
+    @Test
+    void skal_fjerne_deler_av_vilkårsperiode_dersom_deler_av_perioden_er_avslått() {
+
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(10));
+        var resultatBuilder = new VilkårResultatBuilder();
+
+        var ungdomsprogramVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.UNGDOMSPROGRAMVILKÅRET);
+        var avslåttPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFomDato(), periode.getFomDato().plusDays(2));
+        lagPeriodeMedUtfall(ungdomsprogramVilkårBuilder, avslåttPeriode, Utfall.IKKE_OPPFYLT);
+        var innvilgetPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFomDato().plusDays(3), periode.getTomDato());
+        lagPeriodeMedUtfall(ungdomsprogramVilkårBuilder, innvilgetPeriode, Utfall.OPPFYLT);
+
+        var alderVilkårBuilder = resultatBuilder.hentBuilderFor(VilkårType.ALDERSVILKÅR);
+        lagPeriodeMedUtfall(alderVilkårBuilder, periode, Utfall.IKKE_VURDERT);
+
+        resultatBuilder.leggTil(alderVilkårBuilder);
+        resultatBuilder.leggTil(ungdomsprogramVilkårBuilder);
+
+        vilkårResultatRepository.lagre(behandling.getId(), resultatBuilder.build());
+
+        avhengigeVilkårJusterer.fjernAvslåttePerioderForAvhengigeVilkår(behandling.getId(), new TreeSet<>(Set.of(periode)), Set.of(VilkårType.ALDERSVILKÅR), VilkårType.UNGDOMSPROGRAMVILKÅRET);
+
+
+        var nyttResultat = vilkårResultatRepository.hent(behandling.getId());
+        var avhengigVilkårResultat = nyttResultat.getVilkår(VilkårType.ALDERSVILKÅR).orElseThrow();
+        var perioderAvhengigVilkår = avhengigVilkårResultat.getPerioder();
+        assertThat(perioderAvhengigVilkår.size()).isEqualTo(1);
+        assertThat(perioderAvhengigVilkår.get(0).getUtfall()).isEqualTo(Utfall.IKKE_VURDERT);
+        assertThat(perioderAvhengigVilkår.get(0).getFom()).isEqualTo(innvilgetPeriode.getFomDato());
+        assertThat(perioderAvhengigVilkår.get(0).getTom()).isEqualTo(innvilgetPeriode.getTomDato());
+    }
+
+    private static void lagPeriodeMedUtfall(VilkårBuilder ungdomsprogramVilkårBuilder, DatoIntervallEntitet periode, Utfall utfall) {
+        var periodeBuilder = ungdomsprogramVilkårBuilder.hentBuilderFor(periode);
+        periodeBuilder.medUtfall(utfall);
+        ungdomsprogramVilkårBuilder.leggTil(periodeBuilder);
+    }
+}

--- a/domenetjenester/perioder/src/main/java/no/nav/ung/sak/perioder/UngdomsytelseVilkårsperioderTilVurderingTjeneste.java
+++ b/domenetjenester/perioder/src/main/java/no/nav/ung/sak/perioder/UngdomsytelseVilkårsperioderTilVurderingTjeneste.java
@@ -3,6 +3,7 @@ package no.nav.ung.sak.perioder;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.kodeverk.vilkår.Utfall;
 import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandling.BehandlingReferanse;
 import no.nav.ung.sak.behandlingskontroll.BehandlingTypeRef;
@@ -77,7 +78,10 @@ public class UngdomsytelseVilkårsperioderTilVurderingTjeneste implements Vilkå
                 .stream()
                 .flatMap(Collection::stream)
                 .map(VilkårPeriode::getPeriode)
-                .filter(p -> perioder.stream().anyMatch(p::overlapper))
+                .filter(p -> perioder.stream().anyMatch(endringPeriode ->
+                    endringPeriode.overlapper(p) ||
+                    p.inkluderer(endringPeriode.getFomDato().minusDays(1)) ||
+                    p.inkluderer(endringPeriode.getTomDato().plusDays(1)))) // Vurderer perioder som grenser til endringsperiode for å håndtere scenario der vi splitter aldersvilkåret pga endring i ungdomsprogramperiode
                 .collect(Collectors.toCollection(TreeSet::new));
         }
         return TidslinjeUtil.tilDatoIntervallEntiteter(ungdomsprogramPeriodeTjeneste.finnPeriodeTidslinje(behandlingId));


### PR DESCRIPTION
### **Behov / Bakgrunn**
Aldersvilkåret skal vurderes fra første dag i ungdomsprogrammet og vi må derfor ta hensyn til endringer i programperiode som skal endre periode for når aldersvilkåret skal vurderes.

### **Løsning**
Oppretter en ny klasse for justering av avhengige vilkår (aldersvilkåret) basert på definerende vilkår (ungdomsprogramvilkåret) og fjerner perioder som er avslått for ungdomsprogramvilkåret
