### PR TITLE
Revert "Setter planlagte tasker for behandling til ferdig ved avsluttet behandling (#447)"

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/intern/AvsluttBehandling.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/intern/AvsluttBehandling.java
@@ -2,8 +2,6 @@ package no.nav.ung.sak.domene.vedtak.intern;
 
 import java.util.Optional;
 
-import no.nav.k9.prosesstask.api.ProsessTaskStatus;
-import no.nav.ung.sak.etterlysning.SettEtterlysningTilUtløptDersomVenterTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,14 +85,6 @@ public class AvsluttBehandling {
             log.info("Fortsetter iverksetting av ventende behandling: {}", ventendeBehandling.getId()); //$NON-NLS-1$
             opprettTaskForProsesserBehandling(ventendeBehandling);
         });
-
-        settPlanlagteFagsakProsesstaskerForBehandlingTilFerdig();
-
-    }
-
-    private void settPlanlagteFagsakProsesstaskerForBehandlingTilFerdig() {
-        var taskSomSkalSettesTilFerdig = taskTjeneste.finnAlle(SettEtterlysningTilUtløptDersomVenterTask.TASKTYPE, ProsessTaskStatus.KLAR);
-        taskSomSkalSettesTilFerdig.forEach(pt -> taskTjeneste.setProsessTaskFerdig(pt.getId(), ProsessTaskStatus.KLAR));
     }
 
     private void opprettTaskForProsesserBehandling(Behandling behandling) {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det gav problemer pga skrivelås. Taskene gjer ingen skade, så vi kan trygt reverte denne.