### PR TITLE
TSFF-1630-fortsette-fagsak-etter-brevfeil

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserver.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserver.java
@@ -4,7 +4,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import no.nav.k9.prosesstask.api.ProsessTaskData;
-import no.nav.k9.prosesstask.api.ProsessTaskGruppe;
 import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.ung.kodeverk.vedtak.IverksettingStatus;
 import no.nav.ung.sak.behandlingslager.behandling.vedtak.BehandlingVedtakEvent;
@@ -27,13 +26,12 @@ public class VedtakFattetEventObserver {
     public void observerBehandlingVedtak(@Observes BehandlingVedtakEvent event) {
         if (IverksettingStatus.IVERKSATT.equals(event.getVedtak().getIverksettingStatus())) {
            //TODO flytt til formidling pakke
-            var gruppe = new ProsessTaskGruppe(opprettTaskForBrevbestilling(event));
+            taskTjeneste.lagre(opprettTaskForBrevbestilling(event));
 
             if (erBehandlingAvRettTypeForAbakus(event)) {
-                gruppe.addNesteSekvensiell(opprettTaskForPubliseringAvVedtakMedYtelse(event));
+                taskTjeneste.lagre(opprettTaskForPubliseringAvVedtakMedYtelse(event));
             }
 
-            taskTjeneste.lagre(gruppe);
         }
     }
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserverTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/ung/sak/domene/vedtak/observer/VedtakFattetEventObserverTest.java
@@ -1,30 +1,7 @@
 package no.nav.ung.sak.domene.vedtak.observer;
 
-import static no.nav.ung.sak.domene.vedtak.observer.VedtakFattetEventObserver.BREVBESTILLING_TASKTYPE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Optional;
-
-import no.nav.ung.sak.ytelse.kontroll.ManglendeKontrollperioderTjeneste;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
 import no.nav.k9.prosesstask.api.ProsessTaskGruppe;
 import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.ung.kodeverk.vedtak.IverksettingStatus;
@@ -36,6 +13,23 @@ import no.nav.ung.sak.behandlingslager.behandling.vedtak.BehandlingVedtakEvent;
 import no.nav.ung.sak.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.typer.AktørId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static no.nav.ung.sak.domene.vedtak.observer.VedtakFattetEventObserver.BREVBESTILLING_TASKTYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(CdiAwareExtension.class)
 @ExtendWith(JpaExtension.class)
@@ -53,7 +47,7 @@ public class VedtakFattetEventObserverTest {
     private BehandlingVedtakRepository vedtakRepository;
 
     @Captor
-    ArgumentCaptor<ProsessTaskGruppe> prosessTaskGruppeCaptorCaptor;
+    ArgumentCaptor<ProsessTaskData> prosessTaskDataCaptorCaptor;
 
     VedtakFattetEventObserver vedtakFattetEventObserver;
 
@@ -67,10 +61,9 @@ public class VedtakFattetEventObserverTest {
         var behandlingVedtakEvent = lagVedtakEvent(IverksettingStatus.IVERKSATT, VedtakResultatType.INNVILGET);
         vedtakFattetEventObserver.observerBehandlingVedtak(behandlingVedtakEvent);
 
-        verify(prosessTaskRepository, times(1)).lagre(prosessTaskGruppeCaptorCaptor.capture());
-        assertThat(prosessTaskGruppeCaptorCaptor.getAllValues().stream().map(ProsessTaskGruppe::getTasks)
-            .flatMap(Collection::stream)
-            .map(it -> it.getTask().getTaskType()))
+        verify(prosessTaskRepository, times(2)).lagre(prosessTaskDataCaptorCaptor.capture());
+        assertThat(prosessTaskDataCaptorCaptor.getAllValues().stream()
+            .map(ProsessTaskData::getTaskType))
             .containsExactlyInAnyOrder(PubliserVedtattYtelseHendelseTask.TASKTYPE, BREVBESTILLING_TASKTYPE);
     }
 
@@ -87,10 +80,9 @@ public class VedtakFattetEventObserverTest {
         var behandlingVedtakEvent = lagVedtakEvent(IverksettingStatus.IVERKSATT, VedtakResultatType.AVSLAG);
         vedtakFattetEventObserver.observerBehandlingVedtak(behandlingVedtakEvent);
 
-        verify(prosessTaskRepository, times(1)).lagre(prosessTaskGruppeCaptorCaptor.capture());
-        assertThat(prosessTaskGruppeCaptorCaptor.getAllValues().stream().map(ProsessTaskGruppe::getTasks)
-            .flatMap(Collection::stream)
-            .map(it -> it.getTask().getTaskType()))
+        verify(prosessTaskRepository, times(2)).lagre(prosessTaskDataCaptorCaptor.capture());
+        assertThat(prosessTaskDataCaptorCaptor.getAllValues().stream()
+            .map(ProsessTaskData::getTaskType))
             .containsExactly(BREVBESTILLING_TASKTYPE, PubliserVedtattYtelseHendelseTask.TASKTYPE);
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Hvis brevutsendingen feiler så skal ikke videre behandling av fagsaken stoppe. 

### **Løsning**
fjerner sekvensiell gruppe på brevbestilling og publisering av vedtak task da de er uavhengig av hverandre. Dette gjør også at behandlingen går videre selv om brevtasken feiler.
