### PR TITLE
TSFF-1699

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
@@ -14,6 +14,7 @@ import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.ung.sak.formidling.VedtaksbrevTjeneste;
+import no.nav.ung.sak.produksjonsstyring.totrinn.TotrinnTjeneste;
 import no.nav.ung.sak.økonomi.tilbakekreving.samkjøring.SjekkTilbakekrevingAksjonspunktUtleder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ class ForeslåVedtakTjeneste {
     private Instance<ForeslåVedtakManueltUtleder> foreslåVedtakManueltUtledere;
     private SjekkTilbakekrevingAksjonspunktUtleder sjekkMotTilbakekrevingTjeneste;
     private VedtaksbrevTjeneste vedtaksbrevTjeneste;
+    private TotrinnTjeneste totrinnTjeneste;
 
     protected ForeslåVedtakTjeneste() {
         // CDI proxy

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/vedtak/FatteVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/vedtak/FatteVedtakTjeneste.java
@@ -76,6 +76,7 @@ public class FatteVedtakTjeneste {
                 throw new IllegalStateException("Kunne ikke fatte vedtak. Hadde aksjonspunkt med status " + fatterVedtakAksjonspunkt.get().getStatus() + " og totrinnsvurderinger: " + totrinnaksjonspunktvurderinger);
             }
         } else {
+            totrinnTjeneste.deaktiverTotrinnaksjonspunktvurderinger(behandling);
             vedtakTjeneste.lagHistorikkinnslagFattVedtak(behandling);
         }
 

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/vedtak/FatteVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/vedtak/FatteVedtakTjeneste.java
@@ -57,7 +57,7 @@ public class FatteVedtakTjeneste {
             final var fatterVedtakAksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.FATTER_VEDTAK);
 
             // Dersom vi ikke har fatter vedtak aksjonspunkt eller allerede har opprettet aksjonspunkt og behandlingen er flagget som totrinnsbehandling returnerer vi med aksjonspunkt og går videre til steg-ut
-            if (fatterVedtakAksjonspunkt.isEmpty() || fatterVedtakAksjonspunkt.filter(Aksjonspunkt::erÅpentAksjonspunkt).isPresent()) {
+            if (fatterVedtakAksjonspunkt.filter(Aksjonspunkt::erUtført).isEmpty()) {
                 return BehandleStegResultat.utførtMedAksjonspunkter(List.of(AksjonspunktDefinisjon.FATTER_VEDTAK));
             }
 

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/vedtak/FatteVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/vedtak/FatteVedtakTjenesteTest.java
@@ -1,0 +1,217 @@
+package no.nav.ung.sak.domene.behandling.steg.vedtak;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.behandling.BehandlingResultatType;
+import no.nav.ung.kodeverk.behandling.BehandlingStatus;
+import no.nav.ung.kodeverk.behandling.BehandlingStegType;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.VurderÅrsak;
+import no.nav.ung.sak.behandlingskontroll.BehandlingskontrollKontekst;
+import no.nav.ung.sak.behandlingskontroll.transisjoner.FellesTransisjoner;
+import no.nav.ung.sak.behandlingskontroll.transisjoner.TransisjonIdentifikator;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.AksjonspunktKontrollRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingLåsRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.produksjonsstyring.totrinn.TotrinnTjeneste;
+import no.nav.ung.sak.produksjonsstyring.totrinn.Totrinnsvurdering;
+import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(CdiAwareExtension.class)
+@ExtendWith(JpaExtension.class)
+class FatteVedtakTjenesteTest {
+
+    @Inject
+    private FatteVedtakTjeneste fatteVedtakTjeneste;
+
+    @Inject
+    private EntityManager entityManager;
+    @Inject
+    private BehandlingLåsRepository behandlingLåsRepository;
+    @Inject
+    private BehandlingVedtakRepository behandlingVedtakRepository;
+    @Inject
+    private AksjonspunktKontrollRepository aksjonspunktKontrollRepository;
+    @Inject
+    private BehandlingRepository behandlingRepository;
+    @Inject
+    private TotrinnTjeneste totrinnTjeneste;
+
+    @Test
+    void skal_gå_videre_uten_aksjonspunkt_dersom_ingen_totrinn_på_behandling() {
+        // Arrange
+        var behandling = lagBehandlingUtenTotrinn();
+
+        // Act
+        var behandleStegResultat = fatteVedtakTjeneste.fattVedtak(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingLåsRepository.taLås(behandling.getId())), behandling);
+
+        // Assert
+        var aksjonspunktListe = behandleStegResultat.getAksjonspunktListe();
+
+        assertThat(aksjonspunktListe.size()).isEqualTo(0);
+
+        var behandlingVedtak = behandlingVedtakRepository.hentBehandlingVedtakForBehandlingId(behandling.getId());
+        assertThat(behandlingVedtak.isPresent()).isTrue();
+
+        var transisjon = behandleStegResultat.getTransisjon();
+        assertThat(transisjon).isEqualTo(FellesTransisjoner.UTFØRT);
+    }
+
+    @Test
+    void skal_utlede_fatte_vedtak_aksjonspunkt_for_behandling_med_totrinn_uten_aksjonspunkt() {
+        // Arrange
+        var behandling = lagTotrinnsbehandlingUtenFatteVedtak();
+
+        // Act
+        var behandleStegResultat = fatteVedtakTjeneste.fattVedtak(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingLåsRepository.taLås(behandling.getId())), behandling);
+
+        // Assert
+        var aksjonspunktListe = behandleStegResultat.getAksjonspunktListe();
+
+        assertThat(aksjonspunktListe.size()).isEqualTo(1);
+        assertThat(aksjonspunktListe.get(0)).isEqualTo(AksjonspunktDefinisjon.FATTER_VEDTAK);
+    }
+
+
+    @Test
+    void skal_utlede_fatte_vedtak_aksjonspunkt_for_behandling_med_totrinn_med_avbrutt_aksjonspunkt() {
+        // Arrange
+        var behandling = lagTotrinnsbehandlingMedAvbruttFatteVedtak();
+
+        // Act
+        var behandleStegResultat = fatteVedtakTjeneste.fattVedtak(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingLåsRepository.taLås(behandling.getId())), behandling);
+
+        // Assert
+        var aksjonspunktListe = behandleStegResultat.getAksjonspunktListe();
+
+        assertThat(aksjonspunktListe.size()).isEqualTo(1);
+        assertThat(aksjonspunktListe.get(0)).isEqualTo(AksjonspunktDefinisjon.FATTER_VEDTAK);
+    }
+
+    @Test
+    void skal_gå_videre_uten_aksjonspunkt_dersom_utført_med_godkjente_vurderinger() {
+        // Arrange
+        var behandling = lagTotrinnsbehandlingMedUtførtFatteVedtakOgGodkjentVurdering();
+
+        // Act
+        var behandleStegResultat = fatteVedtakTjeneste.fattVedtak(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingLåsRepository.taLås(behandling.getId())), behandling);
+
+        // Assert
+        var aksjonspunktListe = behandleStegResultat.getAksjonspunktListe();
+
+        assertThat(aksjonspunktListe.size()).isEqualTo(0);
+
+        var behandlingVedtak = behandlingVedtakRepository.hentBehandlingVedtakForBehandlingId(behandling.getId());
+        assertThat(behandlingVedtak.isPresent()).isTrue();
+
+        var transisjon = behandleStegResultat.getTransisjon();
+        assertThat(transisjon).isEqualTo(FellesTransisjoner.UTFØRT);
+    }
+
+    @Test
+    void skal_tilbakeføre_dersom_utført_med_ikke_godkjente_vurderinger() {
+        // Arrange
+        var behandling = lagTotrinnsbehandlingMedUtførtFatteVedtakUtenGodkjentVurdering();
+
+        // Act
+        var behandleStegResultat = fatteVedtakTjeneste.fattVedtak(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingLåsRepository.taLås(behandling.getId())), behandling);
+
+        // Assert
+        var aksjonspunktListe = behandleStegResultat.getAksjonspunktListe();
+        assertThat(aksjonspunktListe.size()).isEqualTo(1);
+        assertThat(aksjonspunktListe.get(0)).isEqualTo(AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
+
+        var behandlingVedtak = behandlingVedtakRepository.hentBehandlingVedtakForBehandlingId(behandling.getId());
+        assertThat(behandlingVedtak.isPresent()).isFalse();
+
+        var transisjon = behandleStegResultat.getTransisjon();
+        assertThat(transisjon).isEqualTo(FellesTransisjoner.TILBAKEFØRT_TIL_AKSJONSPUNKT);
+    }
+
+
+    private Behandling lagTotrinnsbehandlingUtenFatteVedtak() {
+        var testScenarioBuilder = TestScenarioBuilder.builderMedSøknad();
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.KONTROLLER_INNTEKT, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, BehandlingStegType.FORESLÅ_VEDTAK);
+        testScenarioBuilder.medBehandlingsresultat(BehandlingResultatType.INNVILGET).medBehandlingStatus(BehandlingStatus.FATTER_VEDTAK);
+        var behandling = testScenarioBuilder.lagre(entityManager);
+        behandling.setToTrinnsBehandling();
+        return behandling;
+    }
+
+
+    private Behandling lagTotrinnsbehandlingMedAvbruttFatteVedtak() {
+        var testScenarioBuilder = TestScenarioBuilder.builderMedSøknad();
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.KONTROLLER_INNTEKT, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, BehandlingStegType.FORESLÅ_VEDTAK);
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FATTER_VEDTAK, BehandlingStegType.FATTE_VEDTAK);
+        testScenarioBuilder.medBehandlingsresultat(BehandlingResultatType.INNVILGET).medBehandlingStatus(BehandlingStatus.FATTER_VEDTAK);
+        var behandling = testScenarioBuilder.lagre(entityManager);
+        behandling.setToTrinnsBehandling();
+        aksjonspunktKontrollRepository.setTilAvbrutt(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.FATTER_VEDTAK));
+        behandlingRepository.lagre(behandling, behandlingLåsRepository.taLås(behandling.getId()));
+        return behandling;
+    }
+
+    private Behandling lagTotrinnsbehandlingMedUtførtFatteVedtakOgGodkjentVurdering() {
+        var testScenarioBuilder = TestScenarioBuilder.builderMedSøknad();
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.KONTROLLER_INNTEKT, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, BehandlingStegType.FORESLÅ_VEDTAK);
+        testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FATTER_VEDTAK, BehandlingStegType.FATTE_VEDTAK);
+        testScenarioBuilder.medBehandlingsresultat(BehandlingResultatType.INNVILGET).medBehandlingStatus(BehandlingStatus.FATTER_VEDTAK);
+        var behandling = testScenarioBuilder.lagre(entityManager);
+        behandling.setToTrinnsBehandling();
+        aksjonspunktKontrollRepository.setTilUtført(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.FATTER_VEDTAK), "begrunnelse");
+
+        var totrinnvurderinBuilder = new Totrinnsvurdering.Builder(behandling, AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
+        totrinnTjeneste.settNyeTotrinnaksjonspunktvurderinger(behandling, List.of(
+            totrinnvurderinBuilder
+                .medGodkjent(true)
+                .medBegrunnelse("Godkjent")
+                .build()
+        ));
+
+        behandlingRepository.lagre(behandling, behandlingLåsRepository.taLås(behandling.getId()));
+        return behandling;
+    }
+
+        private Behandling lagTotrinnsbehandlingMedUtførtFatteVedtakUtenGodkjentVurdering() {
+            var testScenarioBuilder = TestScenarioBuilder.builderMedSøknad();
+            testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.KONTROLLER_INNTEKT, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
+            testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, BehandlingStegType.FORESLÅ_VEDTAK);
+            testScenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FATTER_VEDTAK, BehandlingStegType.FATTE_VEDTAK);
+            testScenarioBuilder.medBehandlingsresultat(BehandlingResultatType.INNVILGET).medBehandlingStatus(BehandlingStatus.FATTER_VEDTAK);
+            var behandling = testScenarioBuilder.lagre(entityManager);
+            behandling.setToTrinnsBehandling();
+            aksjonspunktKontrollRepository.setTilUtført(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.FATTER_VEDTAK), "begrunnelse");
+
+            var totrinnvurderinBuilder = new Totrinnsvurdering.Builder(behandling, AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
+            totrinnTjeneste.settNyeTotrinnaksjonspunktvurderinger(behandling, List.of(
+                totrinnvurderinBuilder
+                    .medGodkjent(false)
+                    .medVurderÅrsak(VurderÅrsak.FEIL_FAKTA)
+                    .medBegrunnelse("Godkjent")
+                    .build()
+            ));
+
+            behandlingRepository.lagre(behandling, behandlingLåsRepository.taLås(behandling.getId()));
+            return behandling;
+        }
+
+    private Behandling lagBehandlingUtenTotrinn() {
+        var testScenarioBuilder = TestScenarioBuilder.builderMedSøknad();
+        testScenarioBuilder.medBehandlingsresultat(BehandlingResultatType.INNVILGET).medBehandlingStatus(BehandlingStatus.FATTER_VEDTAK);
+        var behandling = testScenarioBuilder.lagre(entityManager);
+        return behandling;
+    }
+}

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/ung/sak/produksjonsstyring/totrinn/TotrinnTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/ung/sak/produksjonsstyring/totrinn/TotrinnTjeneste.java
@@ -32,9 +32,17 @@ public class TotrinnTjeneste {
         return totrinnRepository.hentTotrinnaksjonspunktvurderinger(behandling);
     }
 
+    /** Deaktiverer alle totrinnsvurderinger for en behandling.
+     * @param behandling
+     */
+    public void deaktiverTotrinnaksjonspunktvurderinger(Behandling behandling) {
+        totrinnRepository.lagreOgFlush(behandling, List.of());
+    }
+
     public void settNyeTotrinnaksjonspunktvurderinger(Behandling behandling, List<Totrinnsvurdering> vurderinger) {
         totrinnRepository.lagreOgFlush(behandling, vurderinger);
     }
+
 
     public void lagreNyttTotrinnresultat(Behandling behandling, Totrinnresultatgrunnlag totrinnresultatgrunnlag) {
         totrinnRepository.lagreOgFlush(behandling, totrinnresultatgrunnlag);

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåVedtakOppdatererTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåVedtakOppdatererTjeneste.java
@@ -41,7 +41,6 @@ public class ForeslåVedtakOppdatererTjeneste {
 
         if (AksjonspunktDefinisjon.FORESLÅ_VEDTAK.equals(aksjonspunktDefinisjon)) {
             opprettToTrinnsgrunnlag.settNyttTotrinnsgrunnlag(behandling);
-            totrinnTjeneste.settNyeTotrinnaksjonspunktvurderinger(behandling, List.of());
         }
         opprettHistorikkinnslag(behandling);
     }

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåVedtakOppdatererTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåVedtakOppdatererTjeneste.java
@@ -14,19 +14,24 @@ import no.nav.ung.sak.behandlingslager.behandling.historikk.HistorikkinnslagRepo
 import no.nav.ung.sak.domene.vedtak.VedtakTjeneste;
 import no.nav.ung.sak.historikk.HistorikkTjenesteAdapter;
 import no.nav.ung.sak.kontrakt.vedtak.VedtaksbrevOverstyringDto;
+import no.nav.ung.sak.produksjonsstyring.totrinn.TotrinnTjeneste;
+
+import java.util.List;
 
 @Dependent
 public class ForeslåVedtakOppdatererTjeneste {
     private HistorikkinnslagRepository historikkinnslagRepository;
     private OpprettToTrinnsgrunnlag opprettToTrinnsgrunnlag;
+    private TotrinnTjeneste totrinnTjeneste;
     private VedtakTjeneste vedtakTjeneste;
 
     @Inject
     public ForeslåVedtakOppdatererTjeneste(HistorikkinnslagRepository historikkinnslagRepository,
-                                           OpprettToTrinnsgrunnlag opprettToTrinnsgrunnlag,
+                                           OpprettToTrinnsgrunnlag opprettToTrinnsgrunnlag, TotrinnTjeneste totrinnTjeneste,
                                            VedtakTjeneste vedtakTjeneste) {
         this.historikkinnslagRepository = historikkinnslagRepository;
         this.opprettToTrinnsgrunnlag = opprettToTrinnsgrunnlag;
+        this.totrinnTjeneste = totrinnTjeneste;
         this.vedtakTjeneste = vedtakTjeneste;
     }
 
@@ -36,6 +41,7 @@ public class ForeslåVedtakOppdatererTjeneste {
 
         if (AksjonspunktDefinisjon.FORESLÅ_VEDTAK.equals(aksjonspunktDefinisjon)) {
             opprettToTrinnsgrunnlag.settNyttTotrinnsgrunnlag(behandling);
+            totrinnTjeneste.settNyeTotrinnaksjonspunktvurderinger(behandling, List.of());
         }
         opprettHistorikkinnslag(behandling);
     }

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktOppdatererTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktOppdatererTest.java
@@ -15,11 +15,11 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.domene.vedtak.VedtakTjeneste;
 import no.nav.ung.sak.domene.vedtak.impl.FatterVedtakAksjonspunkt;
-import no.nav.ung.sak.historikk.HistorikkTjenesteAdapter;
 import no.nav.ung.sak.kontrakt.vedtak.AksjonspunktGodkjenningDto;
 import no.nav.ung.sak.kontrakt.vedtak.FatterVedtakAksjonspunktDto;
 import no.nav.ung.sak.kontrakt.vedtak.ForeslaVedtakAksjonspunktDto;
 import no.nav.ung.sak.produksjonsstyring.totrinn.TotrinnRepository;
+import no.nav.ung.sak.produksjonsstyring.totrinn.TotrinnTjeneste;
 import no.nav.ung.sak.produksjonsstyring.totrinn.Totrinnsvurdering;
 import no.nav.ung.sak.produksjonsstyring.totrinn.VurderÅrsakTotrinnsvurdering;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
@@ -81,6 +81,7 @@ public class AksjonspunktOppdatererTest {
         var vedtaksbrevHåndterer = new ForeslåVedtakOppdatererTjeneste(
             mock(HistorikkinnslagRepository.class),
             opprettTotrinnsgrunnlag,
+            new TotrinnTjeneste(new TotrinnRepository(entityManager)),
             vedtakTjeneste);
 
         var foreslaVedtakAksjonspunktOppdaterer = new ForeslåVedtakAksjonspunktOppdaterer(vedtaksbrevHåndterer);


### PR DESCRIPTION
### **Behov / Bakgrunn**
Når en behandling returneres til saksbehandler flyttes den tilbake til første ikke godkjente aksjonspunkt basert på vurderinger gjort av beslutter. Ved tilbakeføring settes også status på aksjonspunktet til avbrutt. Neste kjøring av steget vil derfor ha fatte vedtak aksjonspunkt i tilstand avbrutt. I disse tilfellene skal vi returnere aksjonspunkt for fatter vedtak.
