### PR TITLE
Bruker service discovery url for ung-deltakelse-opplyser.

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -77,6 +77,7 @@ spec:
     outbound:
       rules:
         - application: sif-abac-pdp
+        - application: ung-deltakelse-opplyser
       external:
         - host: "dokarkiv-q2.dev-fss-pub.nais.io"
         - host: "k9-abakus.dev-fss-pub.nais.io"
@@ -173,7 +174,7 @@ spec:
     - name: ARBEID_OG_INNTEKT_BASE_URL
       value: https://arbeid-og-inntekt.nais.preprod.local
     - name: UNGDOMSPROGRAMREGISTER_URL
-      value: https://ung-deltakelse-opplyser.intern.dev.nav.no
+      value: http://ung-deltakelse-opplyser
     - name: UNGDOMSPROGRAMREGISTER_SCOPE
       value: api://dev-gcp.k9saksbehandling.ung-deltakelse-opplyser/.default
     - name: SIF_ABAC_PDP_SCOPE

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -77,6 +77,7 @@ spec:
     outbound:
       rules:
         - application : sif-abac-pdp
+        - application: ung-deltakelse-opplyser
       external:
         - host: "dokarkiv.prod-fss-pub.nais.io"
         - host: "k9-abakus.prod-fss-pub.nais.io"
@@ -173,7 +174,7 @@ spec:
     - name: ARBEID_OG_INNTEKT_BASE_URL
       value: https://arbeid-og-inntekt.nais.adeo.no
     - name: UNGDOMSPROGRAMREGISTER_URL
-      value: https://ung-deltakelse-opplyser.intern.nav.no
+      value: http://ung-deltakelse-opplyser
     - name: UNGDOMSPROGRAMREGISTER_SCOPE
       value: api://prod-gcp.k9saksbehandling.ung-deltakelse-opplyser/.default
     - name: SIF_ABAC_PDP_SCOPE


### PR DESCRIPTION
### **Behov / Bakgrunn**
[Zero-trust](https://doc.nais.io/workloads/explanations/zero-trust/?h=zero)

### **Løsning**
Bruker service discovery url for å enforce zero-trust på kall inne i clusteret samtidig som det reduserer latency da kallet ikke går ut av clusteret.

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
