### PR TITLE
Tsff 1709 utbetalingsinfo brev

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringProgramPeriodeInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringProgramPeriodeInnholdBygger.java
@@ -69,7 +69,7 @@ public class EndringProgramPeriodeInnholdBygger implements VedtaksbrevInnholdByg
 
     private EndretSluttDato lagEndretSluttdato(LocalDateSegment<Boolean> denneProgramperiode, LocalDateSegment<Boolean> forrigeProgramperiode) {
         var sluttDato = denneProgramperiode.getTom();
-        var opphørStartDato = PeriodeBeregner.nesteUkedag(sluttDato);
+        var opphørStartDato = sluttDato.plusDays(1);
         var harFlyttetBakover = sluttDato.isBefore(forrigeProgramperiode.getTom());
 
         var sisteUtbetalingsdato = PeriodeBeregner.utledFremtidigUtbetalingsdato(

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringProgramPeriodeInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringProgramPeriodeInnholdBygger.java
@@ -4,6 +4,8 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.konfigurasjon.env.Environment;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.ung.kodeverk.dokument.DokumentMalType;
 import no.nav.ung.kodeverk.formidling.TemplateType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -15,16 +17,23 @@ import no.nav.ung.sak.formidling.vedtak.DetaljertResultat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
+
 @Dependent
 public class EndringProgramPeriodeInnholdBygger implements VedtaksbrevInnholdBygger {
 
     private static final Logger LOG = LoggerFactory.getLogger(EndringProgramPeriodeInnholdBygger.class);
 
     private final UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository;
+    private final LocalDate overrideDagensDatoForTest;
 
     @Inject
-    public EndringProgramPeriodeInnholdBygger(UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository) {
+    public EndringProgramPeriodeInnholdBygger(
+        UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository,
+        @KonfigVerdi(value = "BREV_DAGENS_DATO_TEST", required = false) LocalDate overrideDagensDatoForTest) {
         this.ungdomsprogramPeriodeRepository = ungdomsprogramPeriodeRepository;
+        this.overrideDagensDatoForTest = overrideDagensDatoForTest;
     }
 
 
@@ -58,10 +67,21 @@ public class EndringProgramPeriodeInnholdBygger implements VedtaksbrevInnholdByg
             ));
     }
 
-    private static EndretSluttDato lagEndretSluttdato(LocalDateSegment<Boolean> denneProgramperiode, LocalDateSegment<Boolean> forrigeProgramperiode) {
-        var opphørStartDato = PeriodeUtils.nesteUkedag(denneProgramperiode.getTom());
-        var harFlyttetBakover = denneProgramperiode.getTom().isBefore(forrigeProgramperiode.getTom());
-        return new EndretSluttDato(denneProgramperiode.getTom(), forrigeProgramperiode.getTom(), opphørStartDato, harFlyttetBakover);
+    private EndretSluttDato lagEndretSluttdato(LocalDateSegment<Boolean> denneProgramperiode, LocalDateSegment<Boolean> forrigeProgramperiode) {
+        var sluttDato = denneProgramperiode.getTom();
+        var opphørStartDato = PeriodeBeregner.nesteUkedag(sluttDato);
+        var harFlyttetBakover = sluttDato.isBefore(forrigeProgramperiode.getTom());
+
+        var sisteUtbetalingsdato = PeriodeBeregner.utledFremtidigUtbetalingsdato(
+            sluttDato, bestemInneværendeMåned());
+
+        return new EndretSluttDato(sluttDato, forrigeProgramperiode.getTom(), opphørStartDato, harFlyttetBakover, sisteUtbetalingsdato);
+    }
+
+    private YearMonth bestemInneværendeMåned() {
+        return Environment.current().isLocal() && overrideDagensDatoForTest != null ?
+            YearMonth.from(overrideDagensDatoForTest)
+            : YearMonth.now();
     }
 
     private LocalDateTimeline<Boolean> hentProgramperiodeTidslinje(Long behandlingid) {

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
@@ -3,6 +3,8 @@ package no.nav.ung.sak.formidling.innhold;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.konfigurasjon.env.Environment;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.ung.kodeverk.dokument.DokumentMalType;
 import no.nav.ung.kodeverk.formidling.TemplateType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -12,33 +14,56 @@ import no.nav.ung.sak.formidling.vedtak.DetaljertResultatType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
+import java.time.LocalDate;
+import java.time.YearMonth;
 
 @Dependent
 public class OpphørInnholdBygger implements VedtaksbrevInnholdBygger {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpphørInnholdBygger.class);
+    private final LocalDate overrideDagensDatoForTest;
 
     @Inject
-    public OpphørInnholdBygger() {
+    public OpphørInnholdBygger(@KonfigVerdi(value = "BREV_DAGENS_DATO_TEST", required = false) LocalDate overrideDagensDatoForTest) {
+        this.overrideDagensDatoForTest = overrideDagensDatoForTest;
     }
 
 
     @Override
     public TemplateInnholdResultat bygg(Behandling behandling, LocalDateTimeline<DetaljertResultat> resultatTidslinje) {
-        var opphørsDato = resultatTidslinje.filterValue(it -> it.resultatInfo().stream()
+        var opphørStartdato = resultatTidslinje.filterValue(it -> it.resultatInfo().stream()
                 .anyMatch(r -> r.detaljertResultatType() == DetaljertResultatType.ENDRING_SLUTTDATO))
             .getMinLocalDate();
 
-        var utbetalingsMånedÅr = opphørsDato.withDayOfMonth(1).plusMonths(1)
-            .format(DateTimeFormatter.ofPattern("MMMM yyyy", Locale.forLanguageTag("no-NO")));
+        var sisteUtbetalingsdato = utledFremtidigUtbetalingsdato(
+            PeriodeUtils.forrigeUkedag(opphørStartdato),
+            bestemInneværendeMåned());
 
         return new TemplateInnholdResultat(DokumentMalType.ENDRING_DOK, TemplateType.OPPHØR,
             new OpphørDto(
-                opphørsDato,
-                utbetalingsMånedÅr
+                opphørStartdato,
+                sisteUtbetalingsdato
             ));
+    }
+
+    private YearMonth bestemInneværendeMåned() {
+        return Environment.current().isLocal() && overrideDagensDatoForTest != null ?
+            YearMonth.from(overrideDagensDatoForTest)
+            : YearMonth.now();
+    }
+
+    /**
+     * Utleder fremtidig utbetalingsdato basert på sluttdato.
+     * For siste måned i ungdomsprogrammet kontrolleres ikke inntekt
+     * Oppdrag utbetaler siste måneden første virkedag i påfølgende måned.
+     * Hvis sluttdato var forrige måned så utbetales det neste virkedag.
+     * Nevner da ikke noe dato
+     */
+    private static LocalDate utledFremtidigUtbetalingsdato(LocalDate sluttdato, YearMonth denneMåneden) {
+        YearMonth sluttMåned = YearMonth.from(sluttdato);
+
+        return sluttMåned.isBefore(denneMåneden) ? null
+            : sluttMåned.plusMonths(1).atDay(10);
     }
 
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
@@ -36,7 +36,7 @@ public class OpphørInnholdBygger implements VedtaksbrevInnholdBygger {
             .getMinLocalDate();
 
         var sisteUtbetalingsdato = PeriodeBeregner.utledFremtidigUtbetalingsdato(
-            PeriodeBeregner.forrigeUkedag(opphørStartdato),
+            opphørStartdato.minusDays(1),
             bestemInneværendeMåned());
 
         return new TemplateInnholdResultat(DokumentMalType.ENDRING_DOK, TemplateType.OPPHØR,

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
@@ -35,8 +35,8 @@ public class OpphørInnholdBygger implements VedtaksbrevInnholdBygger {
                 .anyMatch(r -> r.detaljertResultatType() == DetaljertResultatType.ENDRING_SLUTTDATO))
             .getMinLocalDate();
 
-        var sisteUtbetalingsdato = utledFremtidigUtbetalingsdato(
-            PeriodeUtils.forrigeUkedag(opphørStartdato),
+        var sisteUtbetalingsdato = PeriodeBeregner.utledFremtidigUtbetalingsdato(
+            PeriodeBeregner.forrigeUkedag(opphørStartdato),
             bestemInneværendeMåned());
 
         return new TemplateInnholdResultat(DokumentMalType.ENDRING_DOK, TemplateType.OPPHØR,
@@ -50,20 +50,6 @@ public class OpphørInnholdBygger implements VedtaksbrevInnholdBygger {
         return Environment.current().isLocal() && overrideDagensDatoForTest != null ?
             YearMonth.from(overrideDagensDatoForTest)
             : YearMonth.now();
-    }
-
-    /**
-     * Utleder fremtidig utbetalingsdato basert på sluttdato.
-     * For siste måned i ungdomsprogrammet kontrolleres ikke inntekt
-     * Oppdrag utbetaler siste måneden første virkedag i påfølgende måned.
-     * Hvis sluttdato var forrige måned så utbetales det neste virkedag.
-     * Nevner da ikke noe dato
-     */
-    private static LocalDate utledFremtidigUtbetalingsdato(LocalDate sluttdato, YearMonth denneMåneden) {
-        YearMonth sluttMåned = YearMonth.from(sluttdato);
-
-        return sluttMåned.isBefore(denneMåneden) ? null
-            : sluttMåned.plusMonths(1).atDay(10);
     }
 
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/PeriodeBeregner.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/PeriodeBeregner.java
@@ -1,29 +1,9 @@
 package no.nav.ung.sak.formidling.innhold;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
 
 public class PeriodeBeregner {
-    public static LocalDate nesteUkedag(LocalDate date) {
-        LocalDate nesteDag = date.plusDays(1);
-        if (nesteDag.getDayOfWeek() == DayOfWeek.SATURDAY) {
-            return nesteDag.plusDays(2);
-        } else if (nesteDag.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            return nesteDag.plusDays(1);
-        }
-        return nesteDag;
-    }
-
-    public static LocalDate forrigeUkedag(LocalDate date) {
-        LocalDate forrigeDag = date.minusDays(1);
-        if (forrigeDag.getDayOfWeek() == DayOfWeek.SATURDAY) {
-            return forrigeDag.minusDays(1);
-        } else if (forrigeDag.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            return forrigeDag.minusDays(2);
-        }
-        return forrigeDag;
-    }
 
     /**
      * Utleder fremtidig utbetalingsdato basert på sluttdato.

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/PeriodeBeregner.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/PeriodeBeregner.java
@@ -2,8 +2,9 @@ package no.nav.ung.sak.formidling.innhold;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.YearMonth;
 
-public class PeriodeUtils {
+public class PeriodeBeregner {
     public static LocalDate nesteUkedag(LocalDate date) {
         LocalDate nesteDag = date.plusDays(1);
         if (nesteDag.getDayOfWeek() == DayOfWeek.SATURDAY) {
@@ -22,5 +23,19 @@ public class PeriodeUtils {
             return forrigeDag.minusDays(2);
         }
         return forrigeDag;
+    }
+
+    /**
+     * Utleder fremtidig utbetalingsdato basert på sluttdato.
+     * For siste måned i ungdomsprogrammet kontrolleres ikke inntekt
+     * Oppdrag utbetaler siste måneden første virkedag i påfølgende måned.
+     * Hvis sluttdato var forrige måned så utbetales det neste virkedag.
+     * Nevner da ikke noe dato
+     */
+    static LocalDate utledFremtidigUtbetalingsdato(LocalDate sluttdato, YearMonth denneMåneden) {
+        YearMonth sluttMåned = YearMonth.from(sluttdato);
+
+        return sluttMåned.isBefore(denneMåneden) ? null
+            : sluttMåned.plusMonths(1).atDay(10);
     }
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/PeriodeUtils.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/PeriodeUtils.java
@@ -13,4 +13,14 @@ public class PeriodeUtils {
         }
         return nesteDag;
     }
+
+    public static LocalDate forrigeUkedag(LocalDate date) {
+        LocalDate forrigeDag = date.minusDays(1);
+        if (forrigeDag.getDayOfWeek() == DayOfWeek.SATURDAY) {
+            return forrigeDag.minusDays(1);
+        } else if (forrigeDag.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            return forrigeDag.minusDays(2);
+        }
+        return forrigeDag;
+    }
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/InnvilgelseDto.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/InnvilgelseDto.java
@@ -17,7 +17,7 @@ public record InnvilgelseDto(
     SatsOgBeregningDto satsOgBeregning,
     String ikkeStøttetBrevTekst,
     boolean etterbetaling,
-    boolean ingenSatsEndringHendelser)
+    boolean ingenSatsEndringHendelser, LocalDate sisteUtbetalingsdato)
     implements TemplateInnholdDto {
 
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/OpphørDto.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/OpphørDto.java
@@ -4,5 +4,5 @@ import java.time.LocalDate;
 
 public record OpphørDto(
     LocalDate opphørsdato,
-    String utbetalingsMånedÅr) implements TemplateInnholdDto {
+    LocalDate sisteUtbetalingsdato) implements TemplateInnholdDto {
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/endring/programperiode/EndretSluttDato.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/template/dto/endring/programperiode/EndretSluttDato.java
@@ -6,5 +6,6 @@ public record EndretSluttDato(
     LocalDate endretTil,
     LocalDate endretFra,
     LocalDate opphørStartDato,
-    boolean harFlyttetBakover) {
+    boolean harFlyttetBakover,
+    LocalDate sisteUtbetalingsdato) {
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/DetaljertResultatInfo.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/DetaljertResultatInfo.java
@@ -12,6 +12,6 @@ public record DetaljertResultatInfo(DetaljertResultatType detaljertResultatType,
 
     public String utledForklaring() {
         var typeTekst = detaljertResultatType.name() + " - " + detaljertResultatType.getNavn();
-        return forklaring != null ? typeTekst + ". Forklaring: " + forklaring : typeTekst;
+        return forklaring != null && !forklaring.isBlank() ? typeTekst + ". Forklaring: " + forklaring : typeTekst;
     }
 }

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_programperiode.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/endring_programperiode.hbs
@@ -16,13 +16,12 @@
                 Du fikk tidligere melding om at du skulle få penger til og med {{endretFra}},
                 men den datoen gjelder ikke lenger fordi du sluttet i ungdomsprogrammet {{endretTil}}.
             </p>
+            {{#if sisteUtbetalingsdato}}
+                <p>Den siste utbetalingen får du før den {{sisteUtbetalingsdato}}.</p>
+            {{/if}}
         {{/with}}
 
-        {{#if muligTilbakekreving}}
-            <p>Fordi du har fått en ny dato, kan det hende at du har fått mer penger enn du har rett på.
-                Da må du i så fall betale disse pengene tilbake.</p>
-            <p>Du får et nytt brev av oss hvis det skulle skje.</p>
-        {{/if}}
+
 
         <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
     {{/felles/seksjon/hoved}}

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/innvilgelse.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/innvilgelse.hbs
@@ -34,7 +34,7 @@
             {{else}}
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet.
             {{/if}}
-''            {{#if sisteUtbetalingsdato}}
+            {{#if sisteUtbetalingsdato}}
                 Den siste utbetalingen får du før den {{sisteUtbetalingsdato}}.
             {{/if}}
             Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt.

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/innvilgelse.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/innvilgelse.hbs
@@ -34,6 +34,9 @@
             {{else}}
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet.
             {{/if}}
+''            {{#if sisteUtbetalingsdato}}
+                Den siste utbetalingen får du før den {{sisteUtbetalingsdato}}.
+            {{/if}}
             Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt.
         </p>
 
@@ -45,8 +48,9 @@
         <h2>Hvorfor får du penger?</h2>
         <p>Du får penger fordi du er med i ungdomsprogrammet. Pengene gir deg en inntekt mens du deltar i
             ungdomsprogrammet.</p>
-        <p>Pengene får du så lenge du er i ungdomsprogrammet, men du kan som hovedregel ikke få det i
-            mer enn ett år.</p>
+        <p>Pengene får du så lenge du er i ungdomsprogrammet
+            {{~#unless ytelseTom~}}, men du kan som hovedregel ikke få det i mer enn ett år{{/unless}}.
+        </p>
 
         <p>Vedtaket er gjort etter arbeidsmarkedsloven § 12, 3. ledd og forskrift om xxx § xx.</p>
 

--- a/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/opphør.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsytelse/opphør.hbs
@@ -4,9 +4,10 @@
         <h1>Du får ikke lenger ungdomsprogramytelse</h1>
 
         <p>Fra {{opphørsdato}} får du ikke lenger penger gjennom ungdomsytelsen. Det er fordi du ikke lenger er med i ungdomsprogrammet.</p>
-        <p>
-            Den siste utbetalingen får du i {{utbetalingsMånedÅr}}, før den 10. i måneden.
-        </p>
+        {{#if sisteUtbetalingsdato}}
+            <p>Den siste utbetalingen får du før den {{sisteUtbetalingsdato}}.</p>
+        {{/if}}
+
         <p>Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx.</p>
     {{/felles/seksjon/hoved}}
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevScenarioer.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevScenarioer.java
@@ -480,6 +480,42 @@ public class BrevScenarioer {
     }
 
     /**
+     *
+     *  Innvilget med sluttdato
+     *
+     */
+    public static UngTestScenario innvilget19årMedSluttdato(LocalDate startdato, LocalDate sluttdato) {
+        var p = new LocalDateInterval(startdato, startdato.plusYears(1));
+        var fagsakPeriode = new LocalDateInterval(startdato, startdato.plusWeeks(52).minusDays(1));
+        var programperiode = new LocalDateInterval(startdato, sluttdato);
+        var satser = new LocalDateTimeline<>(p, lavSatsBuilder(startdato).build());
+
+        return new UngTestScenario(
+            DEFAULT_NAVN,
+            List.of(new UngdomsprogramPeriode(programperiode.getFomDato(), programperiode.getTomDato())),
+            satser,
+            uttaksPerioder(programperiode),
+            tilkjentYtelsePerioder(satser, programperiode),
+            new LocalDateTimeline<>(fagsakPeriode, Utfall.OPPFYLT),
+            new LocalDateTimeline<>(List.of(
+                new LocalDateSegment<>(programperiode, Utfall.OPPFYLT),
+                new LocalDateSegment<>(sluttdato.plusDays(1), fagsakPeriode.getTomDato(), Utfall.IKKE_OPPFYLT)
+            )
+
+            ),
+            startdato.minusYears(19).plusDays(42),
+            List.of(startdato),
+            Set.of(
+                new Trigger(BehandlingÅrsakType.NY_SØKT_PROGRAM_PERIODE, DatoIntervallEntitet.fra(startdato, sluttdato)),
+                new Trigger(BehandlingÅrsakType.UTTALELSE_FRA_BRUKER, DatoIntervallEntitet.fra(startdato, sluttdato)),
+                new Trigger(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM, DatoIntervallEntitet.fra(startdato, sluttdato))
+            ),
+            null,
+            Collections.emptyList(),
+            null);
+    }
+
+    /**
      * Har allerede opphørt, endrer opphørsdato
      */
     public static UngTestScenario endringSluttdato(LocalDate nySluttdato, LocalDateInterval opprinneligProgramPeriode) {

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/BrevScenarioer.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/BrevScenarioer.java
@@ -507,8 +507,7 @@ public class BrevScenarioer {
             List.of(startdato),
             Set.of(
                 new Trigger(BehandlingÅrsakType.NY_SØKT_PROGRAM_PERIODE, DatoIntervallEntitet.fra(startdato, sluttdato)),
-                new Trigger(BehandlingÅrsakType.UTTALELSE_FRA_BRUKER, DatoIntervallEntitet.fra(startdato, sluttdato)),
-                new Trigger(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM, DatoIntervallEntitet.fra(startdato, sluttdato))
+                new Trigger(BehandlingÅrsakType.UTTALELSE_FRA_BRUKER, DatoIntervallEntitet.fra(startdato, sluttdato))
             ),
             null,
             Collections.emptyList(),

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/EndringOpphørTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/EndringOpphørTest.java
@@ -7,8 +7,6 @@ import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.formidling.innhold.OpphørInnholdBygger;
 import no.nav.ung.sak.formidling.innhold.VedtaksbrevInnholdBygger;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
-import no.nav.ung.sak.test.util.behandling.UngTestScenario;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -19,28 +17,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class EndringOpphørTest extends AbstractVedtaksbrevInnholdByggerTest {
 
-   EndringOpphørTest() {
+    private final LocalDate DAGENS_DATO = LocalDate.of(2025, 8, 15);
+
+
+    EndringOpphørTest() {
         super(1, "Du får ikke lenger ungdomsprogramytelse");
     }
 
 
-    @DisplayName("Opphørsbrev")
     @Test
     void standardOpphørsbrev() {
         LocalDate sluttdato = LocalDate.of(2025, 8, 15);
-        var forrigeBehandlingGrunnlag = BrevScenarioer.innvilget19år(LocalDate.of(2024, 12, 1));
-        var ungTestGrunnlag = BrevScenarioer.endringOpphør(forrigeBehandlingGrunnlag.programPerioder().getFirst().getPeriode().toLocalDateInterval(), sluttdato);
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             """
                 Du får ikke lenger ungdomsprogramytelse \
                 Fra 16. august 2025 får du ikke lenger penger gjennom ungdomsytelsen. \
                 Det er fordi du ikke lenger er med i ungdomsprogrammet. \
-                Den siste utbetalingen får du i september 2025, før den 10. i måneden. \
+                Den siste utbetalingen får du før den 10. september 2025. \
                 Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
                 """);
 
 
-        var behandling = lagOpphørscenario(ungTestGrunnlag, forrigeBehandlingGrunnlag);
+        var behandling = lagOpphørsbehandling(sluttdato);
 
         GenerertBrev generertBrev = genererVedtaksbrev(behandling.getId());
         assertThat(generertBrev.templateType()).isEqualTo(TemplateType.OPPHØR);
@@ -55,18 +53,47 @@ class EndringOpphørTest extends AbstractVedtaksbrevInnholdByggerTest {
 
     }
 
-    private Behandling lagOpphørscenario(UngTestScenario ungTestscenario, UngTestScenario forrigeBehandlingScenario) {
+
+    @Test
+    void opphør_tilbake_i_tid() {
+        LocalDate sluttdato = LocalDate.of(2025, 6, 15);
+        var behandling = lagOpphørsbehandling(sluttdato);
+
+        var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
+            """
+                Du får ikke lenger ungdomsprogramytelse \
+                Fra 16. juni 2025 får du ikke lenger penger gjennom ungdomsytelsen. \
+                Det er fordi du ikke lenger er med i ungdomsprogrammet. \
+                Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
+                """);
+
+        GenerertBrev generertBrev = genererVedtaksbrev(behandling.getId());
+        assertThat(generertBrev.templateType()).isEqualTo(TemplateType.OPPHØR);
+
+        var brevtekst = generertBrev.dokument().html();
+
+        assertThatHtml(brevtekst)
+            .asPlainTextIsEqualTo(forventet)
+            .containsHtmlSubSequenceOnce(
+                "<h1>Du får ikke lenger ungdomsprogramytelse</h1>"
+            );
+
+    }
+
+    private Behandling lagOpphørsbehandling(LocalDate sluttdato) {
+        var forrigeBehandlingGrunnlag = BrevScenarioer.innvilget19år(LocalDate.of(2025, 1, 1));
+        var ungTestGrunnlag = BrevScenarioer.endringOpphør(forrigeBehandlingGrunnlag.programPerioder().getFirst().getPeriode().toLocalDateInterval(), sluttdato);
+
         TestScenarioBuilder builder = TestScenarioBuilder.builderMedSøknad()
-                .medBehandlingType(BehandlingType.REVURDERING)
-                .medUngTestGrunnlag(forrigeBehandlingScenario)
-                ;
+            .medBehandlingType(BehandlingType.REVURDERING)
+            .medUngTestGrunnlag(forrigeBehandlingGrunnlag);
         var originalBehandling = builder.buildOgLagreMedUng(ungTestRepositories);
         originalBehandling.setBehandlingResultatType(BehandlingResultatType.INNVILGET);
         originalBehandling.avsluttBehandling();
 
         builder
             .medBehandlingType(BehandlingType.REVURDERING)
-            .medUngTestGrunnlag(ungTestscenario)
+            .medUngTestGrunnlag(ungTestGrunnlag)
             .medOriginalBehandling(originalBehandling, null);
 
         var behandling = builder.buildOgLagreNyUngBehandlingPåEksisterendeSak(ungTestRepositories);
@@ -82,15 +109,13 @@ class EndringOpphørTest extends AbstractVedtaksbrevInnholdByggerTest {
 
     @Override
     protected VedtaksbrevInnholdBygger lagVedtaksbrevInnholdBygger() {
-        return new OpphørInnholdBygger();
+        return new OpphørInnholdBygger(DAGENS_DATO);
     }
 
     @Override
     protected Behandling lagScenarioForFellesTester() {
         LocalDate sluttdato = LocalDate.of(2025, 8, 15);
-        var forrigeBehandlingGrunnlag = BrevScenarioer.innvilget19år(LocalDate.of(2024, 12, 1));
-        var ungTestGrunnlag = BrevScenarioer.endringOpphør(forrigeBehandlingGrunnlag.programPerioder().getFirst().getPeriode().toLocalDateInterval(), sluttdato);
-        return lagOpphørscenario(ungTestGrunnlag, forrigeBehandlingGrunnlag);
+        return lagOpphørsbehandling(sluttdato);
     }
 }
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/EndringProgramPeriodeTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/EndringProgramPeriodeTest.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class EndringProgramPeriodeTest extends AbstractVedtaksbrevInnholdByggerTest {
 
-   EndringProgramPeriodeTest() {
+    private final LocalDate DAGENS_DATO = LocalDate.of(2025, 8, 15);
+
+
+    EndringProgramPeriodeTest() {
         super(1,
             "Vi har endret ungdomsprogramytelsen din");
     }
@@ -38,6 +41,7 @@ class EndringProgramPeriodeTest extends AbstractVedtaksbrevInnholdByggerTest {
               Fra 25. august 2025 får du ikke penger fordi du ikke lenger er med i ungdomsprogrammet. \
               Du fikk tidligere melding om at du skulle få penger til og med 15. august 2025, \
               men den datoen gjelder ikke lenger fordi du sluttet i ungdomsprogrammet 22. august 2025. \
+              Den siste utbetalingen får du før den 10. september 2025. \
               Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
               """);
 
@@ -151,7 +155,7 @@ class EndringProgramPeriodeTest extends AbstractVedtaksbrevInnholdByggerTest {
 
     @Override
     protected VedtaksbrevInnholdBygger lagVedtaksbrevInnholdBygger() {
-        return new EndringProgramPeriodeInnholdBygger(ungTestRepositories.ungdomsprogramPeriodeRepository());
+        return new EndringProgramPeriodeInnholdBygger(ungTestRepositories.ungdomsprogramPeriodeRepository(), DAGENS_DATO);
     }
 
     @Override

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/EndringProgramPeriodeTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/EndringProgramPeriodeTest.java
@@ -39,7 +39,7 @@ class EndringProgramPeriodeTest extends AbstractVedtaksbrevInnholdByggerTest {
       var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
           """
               Vi har endret ungdomsprogramytelsen din \
-              Fra 25. august 2025 får du ikke penger fordi du ikke lenger er med i ungdomsprogrammet. \
+              Fra 23. august 2025 får du ikke penger fordi du ikke lenger er med i ungdomsprogrammet. \
               Du fikk tidligere melding om at du skulle få penger til og med 15. august 2025, \
               men den datoen gjelder ikke lenger fordi du sluttet i ungdomsprogrammet 22. august 2025. \
               Den siste utbetalingen får du før den 10. september 2025. \

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/EndringProgramPeriodeTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/EndringProgramPeriodeTest.java
@@ -9,6 +9,7 @@ import no.nav.ung.sak.formidling.innhold.EndringProgramPeriodeInnholdBygger;
 import no.nav.ung.sak.formidling.innhold.VedtaksbrevInnholdBygger;
 import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.test.util.behandling.UngTestScenario;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -58,17 +59,18 @@ class EndringProgramPeriodeTest extends AbstractVedtaksbrevInnholdByggerTest {
   }
 
   @Test
+  @DisplayName("Flytter sluttdato bakover til forrige måned")
   void flytteSluttdato_bakover() {
-      var nySluttdato = LocalDate.of(2025, 8, 1);
+      var nySluttdato = LocalDate.of(2025, 7, 31);
       var opprinneligSluttdato = LocalDate.of(2025, 8, 15);
       var behandling = lagScenarioForSluttdato(opprinneligSluttdato, nySluttdato);
 
       var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
           """
               Vi har endret ungdomsprogramytelsen din \
-              Fra 4. august 2025 får du ikke lenger penger fordi du ikke lenger er med i ungdomsprogrammet. \
+              Fra 1. august 2025 får du ikke lenger penger fordi du ikke lenger er med i ungdomsprogrammet. \
               Du fikk tidligere melding om at du skulle få penger til og med 15. august 2025, \
-              men den datoen gjelder ikke lenger fordi du sluttet i ungdomsprogrammet 1. august 2025. \
+              men den datoen gjelder ikke lenger fordi du sluttet i ungdomsprogrammet 31. juli 2025. \
               Vedtaket er gjort etter arbeidsmarkedsloven § xx og forskrift om xxx § xx. \
               """);
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
@@ -68,6 +68,47 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
 
     }
 
+    @DisplayName("Førstegangsbehandling med opphør")
+    @Test
+    void medOpphør() {
+        LocalDate fom = LocalDate.of(2025, 8, 1);
+        LocalDate sluttdato = LocalDate.of(2025, 12, 12);
+        var ungTestGrunnlag = BrevScenarioer.innvilget19årMedSluttdato(fom, sluttdato);
+
+        var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
+            """
+                Du får ungdomsprogramytelse \
+                Fra 1. august 2025 til 12. desember 2025 får du ungdomsprogramytelse på 681 kroner per dag, utenom lørdag og søndag. \
+                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
+                Den siste utbetalingen får du før den 10. januar 2026. \
+                Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
+                Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
+                """ + hvorforFårDuPleiepengerAvsnittForOpphør() + """
+                Hvordan regner vi oss fram til hvor mye penger du får? \
+                Når Nav regner ut hvor mye penger du har rett på, bruker vi en bestemt sum som heter grunnbeløpet. \
+                Grunnbeløpet er bestemt av Stortinget, og det øker hvert år. \
+                Nå er grunnbeløpet på 130 160 kroner. \
+                Når du er under 25 år, bruker vi grunnbeløpet ganger 2/3 av 2,041. \
+                Det blir 177 105 kroner i året. \
+                Denne summen deler vi på 260 dager, fordi du ikke får penger for lørdager og søndager. \
+                Det vil si at du har rett på 681 kroner per dag. \
+                """ + meldFraTilOssHvisDuHarEndringerAvsnitt()
+        );
+
+        var behandling = lagScenario(ungTestGrunnlag);
+
+        GenerertBrev generertBrev = genererVedtaksbrev(behandling.getId());
+
+        var brevtekst = generertBrev.dokument().html();
+
+        assertThatHtml(brevtekst)
+            .asPlainTextIsEqualTo(forventet)
+            .containsHtmlSubSequenceOnce(
+                "<h1>Du får ungdomsprogramytelse</h1>"
+            );
+    }
+
     @Test
     void høySats() {
         LocalDate fom = LocalDate.of(2025, 8, 1);
@@ -116,9 +157,10 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
                 Fra 1. august 2025 til 15. februar 2026 får du ungdomsprogramytelse på 1 022 kroner per dag, utenom lørdag og søndag. \
                 Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
+                Den siste utbetalingen får du før den 10. mars 2026.
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
-                """ + hvorforFårDuPleiepengerAvsnitt() + """
+                """ + hvorforFårDuPleiepengerAvsnittForOpphør() + """
                 Hvordan regner vi oss fram til hvor mye penger du får? \
                 Når Nav regner ut hvor mye penger du har rett på, bruker vi en bestemt sum som heter grunnbeløpet. \
                 Grunnbeløpet er bestemt av Stortinget, og det øker hvert år. \
@@ -290,6 +332,16 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
             Du får penger fordi du er med i ungdomsprogrammet. \
             Pengene gir deg en inntekt mens du deltar i ungdomsprogrammet. \
             Pengene får du så lenge du er i ungdomsprogrammet, men du kan som hovedregel ikke få det i mer enn ett år. \
+            Vedtaket er gjort etter arbeidsmarkedsloven § 12, 3. ledd og forskrift om xxx § xx. \
+            """;
+    }
+
+    private static String hvorforFårDuPleiepengerAvsnittForOpphør() {
+        return """
+            Hvorfor får du penger? \
+            Du får penger fordi du er med i ungdomsprogrammet. \
+            Pengene gir deg en inntekt mens du deltar i ungdomsprogrammet. \
+            Pengene får du så lenge du er i ungdomsprogrammet. \
             Vedtaket er gjort etter arbeidsmarkedsloven § 12, 3. ledd og forskrift om xxx § xx. \
             """;
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
@@ -157,7 +157,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
                 Fra 1. august 2025 til 15. februar 2026 får du ungdomsprogramytelse på 1 022 kroner per dag, utenom lørdag og søndag. \
                 Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
-                Den siste utbetalingen får du før den 10. mars 2026.
+                Den siste utbetalingen får du før den 10. mars 2026. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
                 """ + hvorforFårDuPleiepengerAvsnittForOpphør() + """


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved opphør i førstegangsbehandling så skal sluttdato nevnes. 
Vi trenger å fortelle om siste utbetalingsdato ved opphør. 

### **Løsning**
Utvider førstegangsinnvilgelse til å også håndtere opphør. 
Forteller om siste utbetalingsdato basert på følgende:
For siste måned i ungdomsprogrammet kontrolleres ikke inntekt. Oppdrag utbetaler siste måneden første virkedag i påfølgende måned. 
Hvis sluttdato var forrige måned så utbetales det neste virkedag. Nevner da ikke noe dato.
