### PR TITLE
Legger til støtte for å publisere statistikk til Google BigQuery.

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/fagsak/Fagsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/fagsak/Fagsak.java
@@ -140,7 +140,7 @@ public class Fagsak extends BaseEntitet {
         oppdaterStatus(FagsakStatus.AVSLUTTET);
     }
 
-    void oppdaterStatus(FagsakStatus status) {
+    public void oppdaterStatus(FagsakStatus status) {
         this.setFagsakStatus(status);
     }
 

--- a/behandlingslager/testutil/src/main/java/no/nav/ung/sak/test/util/fagsak/FagsakBuilder.java
+++ b/behandlingslager/testutil/src/main/java/no/nav/ung/sak/test/util/fagsak/FagsakBuilder.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.test.util.fagsak;
 
 import java.time.LocalDate;
 
+import no.nav.ung.kodeverk.behandling.FagsakStatus;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.typer.AktørId;
@@ -18,6 +19,7 @@ public class FagsakBuilder {
 
     private FagsakYtelseType fagsakYtelseType;
     private AktørId aktørId = AktørId.dummy();
+    private FagsakStatus status;
 
     private FagsakBuilder(FagsakYtelseType fagsakYtelseType) {
         this.fagsakYtelseType = fagsakYtelseType;
@@ -57,12 +59,21 @@ public class FagsakBuilder {
         return this;
     }
 
+    public FagsakBuilder medStatus(FagsakStatus status) {
+        this.status = status;
+        return this;
+    }
+
     public Fagsak build() {
 
         if (fagsak != null) {
             return fagsak;
         } else {
             fagsak = Fagsak.opprettNy(fagsakYtelseType, aktørId, saksnummer, LocalDate.now(), null);
+
+            if (status != null) {
+                fagsak.oppdaterStatus(status);
+            }
             return fagsak;
         }
 

--- a/domenetjenester/datavarehus/pom.xml
+++ b/domenetjenester/datavarehus/pom.xml
@@ -13,8 +13,11 @@
 	<artifactId>datavarehus</artifactId>
 	<packaging>jar</packaging>
 	<name>ung-sak :: Domenetjenester - Datavarehus</name>
+    <properties>
+        <google-cloud-bigquery.version>2.52.0</google-cloud-bigquery.version>
+    </properties>
 
-	<dependencies>
+    <dependencies>
 		<dependency>
 			<groupId>no.nav.k9.felles.sikkerhet</groupId>
 			<artifactId>k9-felles-sikkerhet</artifactId>
@@ -45,6 +48,12 @@
 			<groupId>no.nav.k9.felles.integrasjon</groupId>
 			<artifactId>k9-sensu-klient</artifactId>
 		</dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquery</artifactId>
+            <version>${google-cloud-bigquery.version}</version>
+        </dependency>
 
 		<!-- Test avhengigheter -->
 		<dependency>

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/CombineLists.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/CombineLists.java
@@ -11,15 +11,15 @@ import java.util.TreeMap;
 import java.util.function.Function;
 
 /** Generer alle kombinasjoner av angitte input data. */
-class CombineLists<T> {
+public class CombineLists<T> {
 
     private Map<String, Collection<T>> namedVectors;
 
-    CombineLists(Map<String, Collection<T>> namedVectors) {
+    public CombineLists(Map<String, Collection<T>> namedVectors) {
         this.namedVectors = new TreeMap<>(namedVectors);
     }
 
-    List<Map<String, T>> toMap() {
+    public List<Map<String, T>> toMap() {
         return toMap(v -> v);
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/MetrikkUtils.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/MetrikkUtils.java
@@ -1,0 +1,93 @@
+package no.nav.ung.sak.metrikker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.k9.prosesstask.api.ProsessTaskFeil;
+import no.nav.ung.kodeverk.behandling.*;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktStatus;
+import no.nav.ung.kodeverk.dokument.Brevkode;
+import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public final class MetrikkUtils {
+    private MetrikkUtils() {}
+
+    private static ObjectMapper OM = new ObjectMapper();
+
+    public static final String UDEFINERT = "-";
+
+    public static final List<String> YTELSER = Stream.of(FagsakYtelseType.UNGDOMSYTELSE)
+        .map(FagsakYtelseType::getKode).toList();
+
+    public static final List<String> PROSESS_TASK_STATUSER = Stream.of(
+        no.nav.k9.prosesstask.api.ProsessTaskStatus.KLAR,
+        no.nav.k9.prosesstask.api.ProsessTaskStatus.FEILET,
+        no.nav.k9.prosesstask.api.ProsessTaskStatus.VENTER_SVAR
+    ).map(st -> st.getDbKode()).toList();
+
+    public static final List<String> AKSJONSPUNKTER = AksjonspunktDefinisjon.kodeMap().values().stream()
+        .filter(p -> !AksjonspunktDefinisjon.UNDEFINED.equals(p))
+        .map(AksjonspunktDefinisjon::getKode).toList();
+
+    public static final List<String> AKSJONSPUNKT_STATUSER = AksjonspunktStatus.kodeMap().values().stream()
+        .filter(p -> !AksjonspunktStatus.AVBRUTT.equals(p))
+        .map(AksjonspunktStatus::getKode).toList();
+
+    public static final List<String> BEHANDLING_RESULTAT_TYPER = List.copyOf(
+        BehandlingResultatType.kodeMap().keySet()
+    );
+    public static final List<String> BEHANDLING_STATUS = List.copyOf(
+        BehandlingStatus.kodeMap().keySet()
+    );
+    public static final List<String> FAGSAK_STATUS = List.copyOf(
+        FagsakStatus.kodeMap().keySet()
+    );
+
+    public static final List<String> BEHANDLING_TYPER = BehandlingType.kodeMap().values().stream()
+        .filter(p -> !BehandlingType.UDEFINERT.equals(p))
+        .map(BehandlingType::getKode).toList();
+
+    public static final List<String> AVSLAGSÅRSAKER = Avslagsårsak.kodeMap().values().stream()
+        .filter(p -> !Avslagsårsak.UDEFINERT.equals(p))
+        .map(Avslagsårsak::getKode).toList();
+
+    public static final List<String> BREVKODER = Brevkode.registrerteKoder().values().stream()
+        .filter(p -> !Brevkode.UDEFINERT.equals(p))
+        .map(k -> k.getKode()).toList();
+
+    public static final String PROSESS_TASK_VER = "v4";
+
+    public static String coalesce(String str, String defValue) {
+        return str != null ? str : defValue;
+    }
+
+    public static  <R> List<R> timeCall(Supplier<Collection<R>> supplier, String name, Logger log) {
+        long start = System.currentTimeMillis();
+        var result = new ArrayList<>(supplier.get());
+        long duration = System.currentTimeMillis() - start;
+        log.info("{} brukte {} ms", name, duration);
+        return result;
+    }
+
+    public static Optional<String> finnStacktraceStartFra(String sisteFeil, int maksLen) {
+        boolean guessItsJson = sisteFeil != null && sisteFeil.startsWith("{");
+        if (guessItsJson) {
+            try {
+                var feil = OM.readValue(sisteFeil, ProsessTaskFeil.class);
+                var strFeil = feil.getStackTrace();
+                return strFeil == null ? Optional.empty() : Optional.of(strFeil.substring(0, Math.min(maksLen, strFeil.length()))); // chop-chop
+            } catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("Ugyldig json: " + sisteFeil, e);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryDataset.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryDataset.java
@@ -1,0 +1,18 @@
+package no.nav.ung.sak.metrikker.bigquery;
+
+/**
+ * Sørg for at datasetName samsvarer med bigQueryDatasets.name i NAIS config.
+ */
+public enum BigQueryDataset {
+    UNG_SAK_STATISTIKK_DATASET("ung_sak_statistikk_dataset");
+
+    private final String datasetNavn;
+
+    BigQueryDataset(String datasetNavn) {
+        this.datasetNavn = datasetNavn;
+    }
+
+    public String getDatasetNavn() {
+        return datasetNavn;
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryKlient.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryKlient.java
@@ -1,0 +1,129 @@
+package no.nav.ung.sak.metrikker.bigquery;
+
+import com.google.cloud.bigquery.*;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Klient for å håndtere interaksjoner med Google BigQuery.
+ * Sørger for at nødvendige datasett eksisterer og håndterer innsetting av data i BigQuery-tabeller.
+ * Denne klassen er ansvarlig for å opprette tabeller hvis de ikke finnes,
+ * og for å forsikre at datasett eksisterer før data publiseres.
+ * <p>
+ * Data publiseres som JSON i et felt kalt "jsonData" i tabellene.
+ */
+@ApplicationScoped
+public class BigQueryKlient {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BigQueryKlient.class);
+
+    private static final BigQueryDataset[] BIG_QUERY_DATASET = BigQueryDataset.values();
+
+    private static final Field JSON_DATA_SCHEMA_FIELD = Field.of("jsonData", StandardSQLTypeName.JSON);
+    private static final Field TIMESTAMP_SCHEMA_FIELD = Field.of("timestamp", StandardSQLTypeName.DATETIME);
+
+    private final BigQuery bigQuery;
+
+    /**
+     * Konstruktør for BigQueryKlient som initialiserer BigQuery-tjenesten.
+     * Forsikrer at nødvendige BigQuery-datasett eksisterer ved oppstart.
+     */
+    @Inject
+    public BigQueryKlient() {
+        this.bigQuery = BigQueryOptions.getDefaultInstance().getService();
+        Arrays.stream(BIG_QUERY_DATASET).forEach(this::forsikreDatasetEksisterer);
+    }
+
+    /**
+     * Publiserer en rad med data til en spesifikk BigQuery-tabell.
+     *
+     * @param bigQueryDataset Datasettet som tabellen tilhører.
+     * @param bigQueryTable   Tabellen som data skal publiseres til. Dersom tabellen ikke finnes, vil den bli opprettet.
+     * @param rad             Dataen som skal publiseres, representert som en rad i BigQuery. Verdien av "jsonData" feltet må være en gyldig JSON-streng.
+     */
+    public void publish(BigQueryDataset bigQueryDataset, BigQueryTable bigQueryTable, InsertAllRequest.RowToInsert rad) {
+        String datasetNavn = bigQueryDataset.getDatasetNavn();
+        String tableNavn = bigQueryTable.getTableNavn();
+        Table eksisterendeTable = bigQuery.getTable(TableId.of(datasetNavn, tableNavn));
+
+        TableId tableId = hentTableId(eksisterendeTable, datasetNavn, tableNavn);
+
+        InsertAllResponse response = bigQuery.insertAll(
+            InsertAllRequest.newBuilder(tableId)
+                .setRows(List.of(rad))
+                .build());
+
+        håndterResponse(response);
+    }
+
+    /**
+     * Håndterer responsen fra BigQuery etter et forsøk på å sette inn data.
+     * Hvis det er feil i innsettingen, logges feilmeldingene og en RuntimeException kastes.
+     * @param response Responsen fra BigQuery etter innsetting av data.
+     */
+    private static void håndterResponse(InsertAllResponse response) {
+        if (response.hasErrors()) {
+            response.getInsertErrors()
+                .forEach((idx, errs) -> {
+                    errs.forEach(err -> log.error("BigQuery insert feilet for rad {}: {}", idx, err.getMessage()));
+                });
+            throw new RuntimeException("BigQuery insert feilet for noen rader: " + response.getInsertErrors().size());
+        }
+    }
+
+    /**
+     * Henter TableId for en BigQuery-tabell.
+     * Hvis tabellen allerede finnes, brukes den eksisterende tabellen.
+     * Hvis tabellen ikke finnes, opprettes en ny tabell med det angitte navnet og skjemaet.
+     *
+     * @param eksisterendeTable Eksisterende BigQuery-tabell, kan være null hvis tabellen ikke finnes.
+     * @param datasetNavn       Navnet på BigQuery-datasettet tabellen tilhører.
+     * @param tableNavn         Navnet på BigQuery-tabellen som skal opprettes eller brukes.
+     * @return TableId for den eksisterende eller nye tabellen.
+     */
+    private TableId hentTableId(Table eksisterendeTable, String datasetNavn, String tableNavn) {
+        TableId tableId;
+        if (eksisterendeTable != null) {
+            // Hvis tabellen allerede finnes, bruk den eksisterende tabellen
+            tableId = eksisterendeTable.getTableId();
+            log.info("Bruker eksisterende BigQuery-tabell: {}", tableId);
+        } else {
+            // Hvis tabellen ikke finnes, opprett en ny tabell
+            tableId = TableId.of(datasetNavn, tableNavn);
+
+            Schema schema = Schema.of(JSON_DATA_SCHEMA_FIELD, TIMESTAMP_SCHEMA_FIELD);
+            TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
+                .setSchema(schema)
+                .build();
+            TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+            bigQuery.create(tableInfo);
+            log.info("Opprettet ny BigQuery-tabell: {}", tableId);
+        }
+        return tableId;
+    }
+
+    /**
+     * Forsikrer at et BigQuery-datasett eksisterer.
+     *
+     * @param bigQueryDataset Navnet på BigQuery-datasettet som skal sjekkes.
+     * @throws RuntimeException hvis datasettet ikke eksisterer.
+     */
+    private void forsikreDatasetEksisterer(BigQueryDataset bigQueryDataset) {
+        String datasetNavn = bigQueryDataset.getDatasetNavn();
+        try {
+            Dataset dataset = bigQuery.getDataset(DatasetId.of(datasetNavn));
+            if (dataset != null) {
+                log.info("Forsikret at dataset {} eksisterer i BigQuery.", datasetNavn);
+            } else {
+                log.error("Dataset {} eksister ikke i BigQuery. Opprett en dataset i BigQuery før du publiserer data.", datasetNavn);
+                throw new RuntimeException("Dataset " + datasetNavn + " eksister ikke i BigQuery. Opprett dataset før publisering.");
+            }
+        } catch (BigQueryException e) {
+            log.error("Noe gikk galt ved forsøk på å hente dataset {}: {}", datasetNavn, e.getMessage(), e);
+            throw new RuntimeException("Kunne ikke hente dataset " + datasetNavn + " fra BigQuery.", e);
+        }
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryMetrikkTask.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryMetrikkTask.java
@@ -1,0 +1,71 @@
+package no.nav.ung.sak.metrikker.bigquery;
+
+import com.google.cloud.bigquery.InsertAllRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.k9.prosesstask.api.ProsessTask;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskHandler;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Task for publisering av metrikker til BigQuery.
+ * Denne tasken henter hyppig rapporterte metrikker fra BigQueryStatistikkRepository og publiserer dem til BigQuery.
+ * Det er satt opp en cron-jobb som kjører denne tasken hvert 5. minutt.
+ * Det er også satt en grense for maksimalt antall mislykkede kjøringer til 20.
+ */
+@ApplicationScoped
+@ProsessTask(value = BigQueryMetrikkTask.TASKTYPE, cronExpression = "0 */5 * * * *", maxFailedRuns = 20, firstDelay = 60)
+public class BigQueryMetrikkTask implements ProsessTaskHandler {
+
+    private static final int LOG_THRESHOLD = 5000;
+
+    static final String TASKTYPE = "bigquery.metrikk.task";
+
+    private static final Logger log = LoggerFactory.getLogger(BigQueryMetrikkTask.class);
+
+    private BigQueryKlient bigQueryKlient;
+
+    private BigQueryStatistikkRepository statistikkRepository;
+
+    BigQueryMetrikkTask() {
+        // for proxyd
+    }
+
+    @Inject
+    public BigQueryMetrikkTask(BigQueryKlient bigQueryKlient, BigQueryStatistikkRepository statistikkRepository) {
+        this.bigQueryKlient = bigQueryKlient;
+        this.statistikkRepository = statistikkRepository;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData data) {
+        long startTime = System.nanoTime();
+
+        try {
+            Map<BigQueryTable, JSONObject> metrikker = statistikkRepository.hentHyppigRapporterte();
+
+            publiserMetrikker(BigQueryDataset.UNG_SAK_STATISTIKK_DATASET, metrikker);
+
+        } finally {
+            var varighet = Duration.ofNanos(System.nanoTime() - startTime);
+            if (Duration.ofSeconds(20).minus(varighet).isNegative()) {
+                // bruker for lang tid på logging av metrikker.
+                log.warn("Generering av BigQuery metrikker tok : " + varighet);
+            }
+        }
+    }
+
+    private void publiserMetrikker(BigQueryDataset dataset, Map<BigQueryTable, JSONObject> metrikker) {
+        metrikker.forEach((bigQueryTable, data) -> bigQueryKlient.publish(dataset, bigQueryTable, tilRowInsert(data)));
+    }
+
+    private InsertAllRequest.RowToInsert tilRowInsert(JSONObject jsonObject) {
+        return InsertAllRequest.RowToInsert.of(jsonObject.toMap());
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryStatistikkRepository.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryStatistikkRepository.java
@@ -1,0 +1,103 @@
+package no.nav.ung.sak.metrikker.bigquery;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.util.Tuple;
+import no.nav.k9.prosesstask.api.ProsessTask;
+import no.nav.k9.prosesstask.api.ProsessTaskHandler;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Dependent
+public class BigQueryStatistikkRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(BigQueryStatistikkRepository.class);
+
+    private static final String OBSOLETE_KODE = FagsakYtelseType.OBSOLETE.getKode();
+
+    private final EntityManager entityManager;
+    private final Set<String> taskTyper;
+
+    @Inject
+    public BigQueryStatistikkRepository(
+            EntityManager entityManager,
+            @Any Instance<ProsessTaskHandler> handlers
+    ) {
+        this.entityManager = entityManager;
+        this.taskTyper = handlers.stream()
+                .map(bean -> extractClass(bean).getAnnotation(ProsessTask.class).value())
+                .collect(Collectors.toSet());
+    }
+
+    private Class<?> extractClass(ProsessTaskHandler handler) {
+        return handler.getClass();
+    }
+
+    public Map<BigQueryTable, JSONObject> hentHyppigRapporterte() {
+        LocalDate dag = LocalDate.now();
+        Map<BigQueryTable, JSONObject> hyppigRapporterte = new HashMap<>();
+
+        Tuple<BigQueryTable, JSONObject> fagsakStatusStatistikk = fagsakStatusStatistikk();
+        hyppigRapporterte.put(fagsakStatusStatistikk.getElement1(), fagsakStatusStatistikk.getElement2());
+
+        // TODO; behandlingStatusStatistikk
+        // TODO: behandlingResultatStatistikk
+        // TODO: prosessTaskStatistikk
+        // TODO: mottattDokumentMedKildesystemStatistikk
+        // TODO: aksjonspunktStatistikk
+        // TODO: aksjonspunktStatistikkDaglig
+        // TODO: avslagStatistikkDaglig
+        // TODO: avslagStatistikk
+        // TODO: prosessTaskFeilStatistikk
+
+        return hyppigRapporterte;
+    }
+
+    public Map<BigQueryTable, JSONObject> hentDagligRapporterte() {
+        // TODO: avslagStatistikk
+        throw new UnsupportedOperationException("TODO: avslagStatistikk");
+    }
+
+    Tuple<BigQueryTable, JSONObject> fagsakStatusStatistikk() {
+        BigQueryTable fagsakStatusTabell = BigQueryTable.FAGSAK_STATUS_TABELL_V1;
+        String metricName = fagsakStatusTabell.getTableNavn();
+
+        String sql = "SELECT jsonb_build_object(" +
+                ":metricName, jsonb_agg(row_to_json(subQuery))) AS result " +
+                "FROM (" +
+                "  SELECT f.fagsak_status, count(*) as antall " +
+                "  FROM fagsak f " +
+                "  WHERE f.ytelse_type <> :obsoleteKode " +
+                "  GROUP BY 1" +
+                "  ORDER BY 1" +
+                ") subQuery";
+
+        String jsonResultat = (String) entityManager
+                .createNativeQuery(sql)
+                .setParameter("metricName", metricName)
+                .setParameter("obsoleteKode", OBSOLETE_KODE)
+                .getSingleResult(); // Henter resultatet som ett JSON-objekt
+
+        return byggJsonObject(jsonResultat, fagsakStatusTabell);
+    }
+
+    private static Tuple<BigQueryTable, JSONObject> byggJsonObject(String jsonResultat, BigQueryTable bigQueryTable) {
+        if (jsonResultat != null) {
+            // Resultatet fra Postgres kommer som ett JSON-objekt
+            return new Tuple<>(bigQueryTable, new JSONObject(jsonResultat));
+        } else {
+            // Fallback hvis ingen rader eller resultat null
+            return new Tuple<>(bigQueryTable, new JSONObject().put(bigQueryTable.getTableNavn(), Collections.emptyList()));
+        }
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryTable.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/ung/sak/metrikker/bigquery/BigQueryTable.java
@@ -1,0 +1,15 @@
+package no.nav.ung.sak.metrikker.bigquery;
+
+public enum BigQueryTable {
+    FAGSAK_STATUS_TABELL_V1("fagsak_status_v1");
+
+    private final String tableNavn;
+
+    BigQueryTable(String tableNavn) {
+        this.tableNavn = tableNavn;
+    }
+
+    public String getTableNavn() {
+        return tableNavn;
+    }
+}

--- a/domenetjenester/datavarehus/src/test/java/no/nav/ung/sak/metrikker/CombineListsTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/ung/sak/metrikker/CombineListsTest.java
@@ -16,24 +16,24 @@ public class CombineListsTest {
     public void skal_kombinere_angitte_vektorer() throws Exception {
 
         var res = new CombineLists<>(Map.of(
-            YTELSE_TYPE, StatistikkRepository.YTELSER,
-            FAGSAK_STATUS, StatistikkRepository.FAGSAK_STATUS,
-            AVSLAG_ARSAK, StatistikkRepository.AVSLAGSÅRSAKER)).toMap();
+            YTELSE_TYPE, MetrikkUtils.YTELSER,
+            FAGSAK_STATUS, MetrikkUtils.FAGSAK_STATUS,
+            AVSLAG_ARSAK, MetrikkUtils.AVSLAGSÅRSAKER)).toMap();
 
         assertThat(res).isNotEmpty();
         var firstRow = res.get(0);
         assertThat(firstRow).hasSize(3);
         assertThat(firstRow.keySet()).containsOnly(YTELSE_TYPE, FAGSAK_STATUS, AVSLAG_ARSAK);
 
-        for (var yt : StatistikkRepository.YTELSER) {
+        for (var yt : MetrikkUtils.YTELSER) {
             assertThat(res).anyMatch(m -> m.get(YTELSE_TYPE).equals(yt));
         }
 
-        for (var av : StatistikkRepository.AVSLAGSÅRSAKER) {
+        for (var av : MetrikkUtils.AVSLAGSÅRSAKER) {
             assertThat(res).anyMatch(m -> m.get(AVSLAG_ARSAK).equals(av));
         }
 
-        for (var av : StatistikkRepository.FAGSAK_STATUS) {
+        for (var av : MetrikkUtils.FAGSAK_STATUS) {
             assertThat(res).anyMatch(m -> m.get(FAGSAK_STATUS).equals(av));
         }
     }

--- a/domenetjenester/datavarehus/src/test/java/no/nav/ung/sak/metrikker/StatistikkRepositoryTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/ung/sak/metrikker/StatistikkRepositoryTest.java
@@ -39,7 +39,7 @@ class StatistikkRepositoryTest {
     @Test
     void skal_kunne_hente_statistikk()  {
 
-        assertThat(statistikkRepository.prosessTaskStatistikk()).isNotEmpty().allMatch(v -> v.toString().contains("prosess_task_" + StatistikkRepository.PROSESS_TASK_VER));
+        assertThat(statistikkRepository.prosessTaskStatistikk()).isNotEmpty().allMatch(v -> v.toString().contains("prosess_task_" + MetrikkUtils.PROSESS_TASK_VER));
 
         assertThat(statistikkRepository.behandlingResultatStatistikk()).isNotEmpty().allMatch(v -> v.toString().contains("behandling_resultat_v1"));
 
@@ -50,7 +50,7 @@ class StatistikkRepositoryTest {
             .anyMatch(v -> v.toString().contains("behandling_status_v2"))
             .anyMatch(v -> v.toString().contains("fagsak_status_v2"))
             .anyMatch(v -> v.toString().contains("aksjonspunkt_per_ytelse_type_v3"))
-            .anyMatch(v -> v.toString().contains("prosess_task_" + StatistikkRepository.PROSESS_TASK_VER))
+            .anyMatch(v -> v.toString().contains("prosess_task_" + MetrikkUtils.PROSESS_TASK_VER))
             .noneMatch(v -> v.toString().contains("avslagStatistikk"));
     }
 
@@ -72,5 +72,4 @@ class StatistikkRepositoryTest {
             .anyMatch(v -> v.toString().contains("ytelse_type=" + ytelseType.getKode()) && v.toString().contains("aksjonspunkt=" + aksjonspunkt.getKode()) && v.toString().contains("totalt_antall=1"));
 
     }
-
 }

--- a/domenetjenester/datavarehus/src/test/java/no/nav/ung/sak/metrikker/bigquery/BigQueryStatistikkRepositoryTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/ung/sak/metrikker/bigquery/BigQueryStatistikkRepositoryTest.java
@@ -1,0 +1,118 @@
+package no.nav.ung.sak.metrikker.bigquery;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.k9.felles.util.Tuple;
+import no.nav.k9.prosesstask.api.ProsessTaskHandler;
+import no.nav.ung.kodeverk.behandling.FagsakStatus;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
+import org.assertj.core.api.MapAssert;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@ExtendWith(CdiAwareExtension.class)
+@ExtendWith(JpaExtension.class)
+class BigQueryStatistikkRepositoryTest {
+
+    @Inject
+    private EntityManager entityManager;
+
+    @Inject
+    private @Any Instance<ProsessTaskHandler> handlers;
+
+    @Inject
+    private FagsakRepository fagsakRepository;
+
+    private BigQueryStatistikkRepository statistikkRepository;
+
+    @BeforeEach
+    void setup() {
+        statistikkRepository = new BigQueryStatistikkRepository(entityManager, handlers);
+    }
+
+    @Test
+    void skal_kunne_hente_fagsak_status_statistikk() {
+        // Gitt eksisterende fagsaker med ulike status
+        lagreFagsaker(List.of(
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.OPPRETTET),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.OPPRETTET),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.UNDER_BEHANDLING),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.UNDER_BEHANDLING),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.UNDER_BEHANDLING),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.LØPENDE),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.LØPENDE),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.LØPENDE),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.LØPENDE),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.AVSLUTTET),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.AVSLUTTET),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.AVSLUTTET),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.AVSLUTTET),
+            byggFagsak(FagsakYtelseType.UNGDOMSYTELSE, FagsakStatus.AVSLUTTET),
+            byggFagsak(FagsakYtelseType.OBSOLETE, FagsakStatus.LØPENDE) // OBSOLETE fagsak for å teste at den ikke telles med
+        ));
+
+        // Når vi henter statistikken
+        Tuple<BigQueryTable, JSONObject> fagsakStatusStatistikk = statistikkRepository.fagsakStatusStatistikk();
+        assertThat(fagsakStatusStatistikk.getElement1()).isEqualTo(BigQueryTable.FAGSAK_STATUS_TABELL_V1);
+        JSONObject jsonObject = fagsakStatusStatistikk.getElement2();
+        System.out.println(jsonObject.toString(2));
+
+        String tabellNavn = "fagsak_status_v1";
+        String statusKolonne = "fagsak_status";
+        String antallKolonne = "antall";
+
+        // Så skal vi ha en JSON med riktig struktur og data
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.isEmpty()).isFalse();
+
+        // Sjekk at vi har de forventede statusene og antall
+        assertJsonInneholderTabellNavn(jsonObject, tabellNavn);
+        assertJsonInneholderAntallDataPunkter(jsonObject, tabellNavn, 4);
+
+        assertJsonInneholerEksaktData(jsonObject, tabellNavn,
+            Map.of(statusKolonne, FagsakStatus.OPPRETTET.getKode(), antallKolonne, 2),
+            Map.of(statusKolonne, FagsakStatus.UNDER_BEHANDLING.getKode(), antallKolonne, 3),
+            Map.of(statusKolonne, FagsakStatus.LØPENDE.getKode(), antallKolonne, 4),
+            Map.of(statusKolonne, FagsakStatus.AVSLUTTET.getKode(), antallKolonne, 5)
+        );
+    }
+
+    private static void assertJsonInneholerEksaktData(JSONObject jsonObject, String tabellNavn, Map<String, Object>... forventedeData) {
+        assertThat(jsonObject.getJSONArray(tabellNavn).toList()).containsExactlyInAnyOrder(forventedeData);
+    }
+
+    private static void assertJsonInneholderAntallDataPunkter(JSONObject jsonObject, String tabellNavn, int antall) {
+        assertThat(jsonObject.getJSONArray(tabellNavn).length()).isEqualTo(antall);
+    }
+
+    private static MapAssert<String, Object> assertJsonInneholderTabellNavn(JSONObject jsonObject, String tabellNavn) {
+        return assertThat(jsonObject.toMap()).containsKey(tabellNavn);
+    }
+
+    private Fagsak byggFagsak(FagsakYtelseType fagsakYtelseType, FagsakStatus status) {
+        return FagsakBuilder.nyFagsak(fagsakYtelseType).medStatus(status).build();
+    }
+
+    private void lagreFagsaker(List<Fagsak> fagsaker) {
+        fagsaker.forEach(
+            fagsak -> {
+                fagsakRepository.opprettNy(fagsak);
+                entityManager.flush();
+            }
+        );
+    }
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Sensu er ikke tilgjengelig i GCP, så metrikkene våres vil ikke være synlige noe sted.
Prometheus lagrer ikke data i mer enn 30 dager, så det ville ikke dekket vårt behov.

### **Løsning**
Integrerer mot Google BigQuery for å publisere statistikk data.
Løsningen pr. nå blir en POC for å utforske måten å publisere statistikken er tilstrekkelig.
Den bygger på at vi utformer spørringer mot Postgresql som returnerer JSON som respons.
Deretter blir denne JSON dataen publisert i sin helhet til BigQuery.

Det er både fordeler og ulemper med denne måten å gjøre det på .

Fordeler:
- Kjapt å publisere dataene.
- Trenger ikke å mappe responsen fra spørringen og definere datastruktur.

Ulemper:
- Kan potensielt bli et minneproblem om spørringen mot Postgresql retunerer store JSON data.


Eksempel på data som hentes ut fra Postgresql som JSON:
```json
{
  "fagsak_status": [
    {
      "antall": 23,
      "ytelse_type": "UNG",
      "fagsak_status": "AVSLU"
    },
    {
      "antall": 155,
      "ytelse_type": "UNG",
      "fagsak_status": "LOP"
    },
    {
      "antall": 199,
      "ytelse_type": "UNG",
      "fagsak_status": "UBEH"
    }
  ]
}
```

Relevant commit som provisjonerte Dataset til BigQuery: https://github.com/navikt/ung-sak/commit/b7faa21d6f4623cacf34b9e941e3ca476a22e16c

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
