### PR TITLE
Bruke endepunkt i k9-oppdrag som skiller K9/UNG eksplisitt.

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
@@ -36,7 +36,8 @@ import java.util.Properties;
 import java.util.Set;
 
 
-@Deprecated//TODO denne publiserer melding til eksterne om vedtak fattet. Vurder om nødvendig for UNG etterhvert som detaljene for samhandling er landet
+// trengs p.t. for å opprette tilbakekrevinger, da ung-tilbake lytter på denne (men trenger ikke være public topic)
+// TODO denne publiserer melding til eksterne om vedtak fattet. Vurder om nødvendig for UNG etterhvert som detaljene for samhandling er landet
 @ApplicationScoped
 @ProsessTask(PubliserVedtattYtelseHendelseTask.TASKTYPE)
 @FagsakProsesstaskRekkefølge(gruppeSekvens = true)

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <dependency>
                 <groupId>no.nav.k9.oppdrag.kontrakt</groupId>
                 <artifactId>oppdrag-kontrakter</artifactId>
-                <version>2.2.6</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <groupId>no.nav.k9.abakus</groupId>


### PR DESCRIPTION
### **Behov / Bakgrunn**

Gjør at diagnostikk-endepunkt fungerer bedre, og at det er mindre konfigurering ved kjøring lokalt

### **Løsning**

Send med UNG som domene i kall til k9-oppdrag som ikke allerede har med ytelsetype

### **Andre endringer**

Justerte kommentar og de-deprekerte PubliserVedtattYtelseHendelseTask

### **Skjermbilder** (hvis relevant)
