### PR TITLE
Publiser vedtakshendelser til ung-vedtakhendelse isdf teamforeldrepenger.familie-vedtakfattet-v1

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -128,8 +128,8 @@ spec:
       value: k9saksbehandling.ung-sak-aksjonspunkthendelse
     - name: KAFKA_DOKUMENTBESTILLING_AIVEN_TOPIC
       value: k9saksbehandling.k9-dokumenthendelse-v1
-    - name: KAFKA_FATTEVEDTAK_TOPIC
-      value: teamforeldrepenger.familie-vedtakfattet-v1
+    - name: KAFKA_FATTEVEDTAK_UNG_TOPIC
+      value: k9saksbehandling.ung-vedtakhendelse
     - name: KAFKA_STONADSTATISTIKK_TOPIC
       value: k9saksbehandling.aapen-ung-stonadstatistikk-v1
     - name: KAFKA_PRODUKSJONSSTYRING_TOPIC

--- a/deploy/kafka/ung-vedtakhendelse-dev.yml
+++ b/deploy/kafka/ung-vedtakhendelse-dev.yml
@@ -19,5 +19,5 @@ spec:
       application: ung-sak
       access: write
     - team: k9saksbehandling
-      application: k9-formidling-dokumentdata
+      application: ung-tilbake
       access: read

--- a/deploy/kafka/ung-vedtakhendelse-prod.yml
+++ b/deploy/kafka/ung-vedtakhendelse-prod.yml
@@ -19,5 +19,5 @@ spec:
       application: ung-sak
       access: write
     - team: k9saksbehandling
-      application: k9-formidling-dokumentdata
+      application: ung-tilbake
       access: read

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -126,8 +126,8 @@ spec:
       value: k9saksbehandling.ung-sak-aksjonspunkthendelse
     - name: KAFKA_DOKUMENTBESTILLING_AIVEN_TOPIC
       value: k9saksbehandling.k9-dokumenthendelse-v1
-    - name: KAFKA_FATTEVEDTAK_TOPIC
-      value: teamforeldrepenger.familie-vedtakfattet-v1
+    - name: KAFKA_FATTEVEDTAK_UNG_TOPIC
+      value: k9saksbehandling.ung-vedtakhendelse
     - name: KAFKA_STONADSTATISTIKK_TOPIC
       value: k9saksbehandling.aapen-ung-stonadstatistikk-v1
     - name: KAFKA_PRODUKSJONSSTYRING_TOPIC

--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
@@ -36,19 +36,17 @@ import java.util.Properties;
 import java.util.Set;
 
 
-// trengs p.t. for å opprette tilbakekrevinger, da ung-tilbake lytter på denne (men trenger ikke være public topic)
-// TODO denne publiserer melding til eksterne om vedtak fattet. Vurder om nødvendig for UNG etterhvert som detaljene for samhandling er landet
+// ung-tilbake lytter på denne for å opprette tilbakekrevingsbehandlinger ved behov
 @ApplicationScoped
 @ProsessTask(PubliserVedtattYtelseHendelseTask.TASKTYPE)
 @FagsakProsesstaskRekkefølge(gruppeSekvens = true)
 public class PubliserVedtattYtelseHendelseTask extends BehandlingProsessTask {
 
     public static final String TASKTYPE = "vedtak.publiserHendelse";
-    private static final Logger log = LoggerFactory.getLogger(VurderOmVedtakPåvirkerAndreSakerTask.class);
+    private static final Logger log = LoggerFactory.getLogger(PubliserVedtattYtelseHendelseTask.class);
 
     private BehandlingRepository behandlingRepository;
     private VedtattYtelseTjeneste vedtakTjeneste;
-    private boolean skalPublisereTilFamilieVedtakFattet;
     private GenerellKafkaProducer producer;
     private Validator validator;
 
@@ -65,19 +63,17 @@ public class PubliserVedtattYtelseHendelseTask extends BehandlingProsessTask {
         VedtattYtelseTjeneste vedtakTjeneste,
         ProsessTaskTjeneste taskTjeneste,
         @Any Instance<InformasjonselementerUtleder> informasjonselementer,
-        @KonfigVerdi("kafka.fattevedtak.topic") String topic,
+        @KonfigVerdi(value = "kafka.fattevedtak.ung.topic", defaultVerdi = "k9saksbehandling.ung-vedtakhendelse") String topic,
         @KonfigVerdi(value = "KAFKA_BROKERS") String kafkaBrokers,
         @KonfigVerdi(value = "KAFKA_TRUSTSTORE_PATH", required = false) String trustStorePath,
         @KonfigVerdi(value = "KAFKA_CREDSTORE_PASSWORD", required = false) String trustStorePassword,
         @KonfigVerdi(value = "KAFKA_KEYSTORE_PATH", required = false) String keyStoreLocation,
-        @KonfigVerdi(value = "KAFKA_CREDSTORE_PASSWORD", required = false) String keyStorePassword,
-        @KonfigVerdi(value = "PUBLISER_VEDTAK_FAMILIE", defaultVerdi = "false") boolean skalPublisereTilFamilieVedtakFattet
+        @KonfigVerdi(value = "KAFKA_CREDSTORE_PASSWORD", required = false) String keyStorePassword
     ) {
         this.taskTjeneste = taskTjeneste;
         this.informasjonselementer = informasjonselementer;
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.vedtakTjeneste = vedtakTjeneste;
-        this.skalPublisereTilFamilieVedtakFattet = skalPublisereTilFamilieVedtakFattet;
 
         boolean kjørerIMiljø = Environment.current().isProd() || Environment.current().isDev();
         if (kjørerIMiljø) {
@@ -134,11 +130,8 @@ public class PubliserVedtattYtelseHendelseTask extends BehandlingProsessTask {
                 log.info("Mottatt ytelse-vedtatt hendelse med ytelse='{}' saksnummer='{}', sjekker behovet for revurdering", fagsakYtelseType, behandling.getFagsak().getSaksnummer());
                 opprettTaskForVurderingAvPåvirkedeSaker(payload);
                 String key = behandling.getFagsak().getSaksnummer().getVerdi();
-                if (skalPublisereTilFamilieVedtakFattet) {
-                    RecordMetadata recordMetadata = producer.sendJsonMedNøkkel(key, payload);
-                    log.info("Sendte melding til  {} partition {} offset {}", recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset());
-
-                }
+                RecordMetadata recordMetadata = producer.sendJsonMedNøkkel(key, payload);
+                log.info("Sendte melding til  {} partition {} offset {}", recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset());
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>no.nav.k9.abakus</groupId>
                 <artifactId>abakus-kontrakt</artifactId>
-                <version>1.3.0</version>
+                <version>1.4.0</version>
             </dependency>
 
             <dependency>

--- a/web/app-vtp.properties
+++ b/web/app-vtp.properties
@@ -73,8 +73,7 @@ kafka.aksjonspunkthendelse.topic=ung-sak-aksjonspunkthendelse
 kafka.aksjonspunkthendelse.aiven.topic=k9saksbehandling.ung-sak-aksjonspunkthendelse
 kafka.dokumentbestilling.aiven.topic=k9saksbehandling.k9-dokumenthendelse-v1
 kafka.infotrygdfeed.topic=privat-k9-infotrygdFeedHendelse
-kafka.fattevedtak.topic=teamforeldrepenger.familie-vedtakfattet-v1
-kafka.fattevedtak.lesfrastart=true
+kafka.fattevedtak.ung.topic=k9saksbehandling.ung-vedtakhendelse
 hendelse.person.leesah.topic=aapen-person-pdl-leesah-v1-vtp
 kafka.journal.topic=teamdokumenthandtering.aapen-dok-journalfoering-q1
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Hendelsene er nødvendige for å automatisk opprette tilbakekrevingsbehandlinger.

Foreldrepenger ønsker ikke at vi publisere UNG-vedtak til eamforeldrepenger.familie-vedtakfattet-v1

### **Løsning**

Bytte til å bruke eget topic

### **Andre endringer**

Oppdaterte abakus-kontrakt for å få med støtte for UNG

### **Skjermbilder** (hvis relevant)
