### PR TITLE
Aktiverer bigquery publisering i prod.

### DIFF
--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -217,6 +217,8 @@ spec:
       value: "true"
     - name: PUBLISER_PRODUKSJONSSTYRING_HENDELSE
       value: "false"
+    - name: BIGQUERY_ENABLED
+      value: "true"
 
     # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å kunne legge til et datasett i datamarkedplassen må man koble til et dataset i prod.

### **Løsning**

### **Andre endringer**

### **Skjermbilder** (hvis relevant)

<img width="1453" height="904" alt="image" src="https://github.com/user-attachments/assets/dcc63921-5263-49dd-bc6b-cf3340d3684c" />
