### PR TITLE
Mer eksplisitt håndtering av ukjent behandling/fagsak i PdpRequestBuilder

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/Behandling.java
@@ -70,6 +70,7 @@ import no.nav.ung.sak.typer.AktørId;
 @SqlResultSetMappings(value = {
     @SqlResultSetMapping(name = "PipDataResult", classes = {
         @ConstructorResult(targetClass = PipBehandlingsData.class, columns = {
+            @ColumnResult(name = "behandlingUuid"),
             @ColumnResult(name = "behandligStatus"),
             @ColumnResult(name = "ansvarligSaksbehandler"),
             @ColumnResult(name = "fagsakId"),

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipBehandlingsData.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipBehandlingsData.java
@@ -2,21 +2,32 @@ package no.nav.ung.sak.behandlingslager.pip;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 public class PipBehandlingsData {
+    private UUID behandlingUuid;
     private String behandligStatus;
     private String fagsakStatus;
     private String ansvarligSaksbehandler;
     private Long fagsakId;
     private String saksnummer;
 
-    public PipBehandlingsData(String behandligStatus, String ansvarligSaksbehandler, Number fagsakId,
-            String fagsakStatus, String saksnummer) {
+    public PipBehandlingsData(UUID behandlingUuid, String behandligStatus, String ansvarligSaksbehandler, Number fagsakId,
+                              String fagsakStatus, String saksnummer) {
+        this.behandlingUuid = behandlingUuid;
         this.behandligStatus = behandligStatus;
         this.saksnummer = saksnummer;
         this.fagsakId = fagsakId.longValue();
         this.fagsakStatus = fagsakStatus;
         this.ansvarligSaksbehandler = ansvarligSaksbehandler;
+    }
+
+    public UUID getBehandlingUuid() {
+        return behandlingUuid;
+    }
+
+    public void setBehandlingUuid(UUID behandlingUuid) {
+        this.behandlingUuid = behandlingUuid;
     }
 
     public String getBehandligStatus() {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
@@ -34,15 +34,17 @@ public class PipRepository {
     public Optional<PipBehandlingsData> hentDataForBehandling(Long behandlingId) {
         Objects.requireNonNull(behandlingId, "behandlingId"); // NOSONAR
 
-        String sql = "SELECT " +
-            "b.behandling_status behandligStatus, " +
-            "b.ansvarlig_saksbehandler ansvarligSaksbehandler, " +
-            "f.id fagsakId, " +
-            "f.fagsak_status fagsakStatus, " +
-            "f.saksnummer " +
-            "FROM BEHANDLING b " +
-            "JOIN FAGSAK f ON b.fagsak_id = f.id " +
-            "WHERE b.id = :behandlingId";
+        String sql = """
+            SELECT
+               b.uuid behandlingUuid,
+               b.behandling_status behandligStatus,
+               b.ansvarlig_saksbehandler ansvarligSaksbehandler,
+               f.id fagsakId,
+               f.fagsak_status fagsakStatus,
+               f.saksnummer
+             FROM BEHANDLING b
+             JOIN FAGSAK f ON b.fagsak_id = f.id
+             WHERE b.id = :behandlingId""";
 
         Query query = entityManager.createNativeQuery(sql, "PipDataResult");
         query.setParameter("behandlingId", behandlingId);
@@ -88,66 +90,44 @@ public class PipRepository {
         }
     }
 
-    public Set<AktørId> hentAktørIdKnyttetTilFagsaker(Collection<Long> fagsakIder) {
-        Objects.requireNonNull(fagsakIder, SAKSNUMMER);
-        if (fagsakIder.isEmpty()) {
+    public Set<AktørId> hentAktørIdKnyttetTilFagsaker(Collection<Saksnummer> saksnumre) {
+        Objects.requireNonNull(saksnumre, SAKSNUMMER);
+        if (saksnumre.isEmpty()) {
             return Collections.emptySet();
         }
         String sql = """
-            SELECT por.AKTOER_ID From Fagsak fag
+            SELECT por.AKTOER_ID
+             From Fagsak fag
              INNER JOIN BEHANDLING beh ON fag.ID = beh.FAGSAK_ID
              INNER JOIN GR_PERSONOPPLYSNING grp ON grp.behandling_id = beh.ID
              INNER JOIN PO_INFORMASJON poi ON grp.registrert_informasjon_id = poi.ID
              INNER JOIN PO_PERSONOPPLYSNING por ON poi.ID = por.po_informasjon_id
-             WHERE fag.id in (:fagsakIder) AND grp.aktiv = TRUE
+             WHERE fag.saksnummer in (:saksnumre) AND grp.aktiv = TRUE
              UNION ALL
-             SELECT fag.bruker_aktoer_id FROM Fagsak fag
-             WHERE fag.id in (:fagsakIder) AND fag.bruker_aktoer_id IS NOT NULL
+             SELECT fag.bruker_aktoer_id
+             FROM Fagsak fag
+             WHERE fag.saksnummer in (:saksnumre) AND fag.bruker_aktoer_id IS NOT NULL
              """;
 
         Query query = entityManager.createNativeQuery(sql);
-        query.setParameter("fagsakIder", fagsakIder);
+        query.setParameter("saksnumre", saksnumre.stream().map(Saksnummer::getVerdi).collect(Collectors.toSet()));
 
         @SuppressWarnings("unchecked")
         List<String> aktørIdList = query.getResultList();
         return aktørIdList.stream().map(AktørId::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
-
-    public Set<AktørId> hentAktørIdKnyttetTilSaksnummer(Saksnummer saksnummer) {
-        Objects.requireNonNull(saksnummer, SAKSNUMMER);
-
-        String sql = """
-            SELECT por.AKTOER_ID From Fagsak fag
-             INNER JOIN BEHANDLING beh ON fag.ID = beh.FAGSAK_ID
-             INNER JOIN GR_PERSONOPPLYSNING grp ON grp.behandling_id = beh.ID
-             INNER JOIN PO_INFORMASJON poi ON grp.registrert_informasjon_id = poi.ID
-             INNER JOIN PO_PERSONOPPLYSNING por ON poi.ID = por.po_informasjon_id
-             WHERE fag.SAKSNUMMER = (:saksnummer) AND grp.aktiv = TRUE
-             UNION ALL
-             SELECT fag.bruker_aktoer_id FROM Fagsak fag
-             WHERE fag.SAKSNUMMER = (:saksnummer) AND fag.bruker_aktoer_id IS NOT NULL
-            """;
-
-        Query query = entityManager.createNativeQuery(sql); // NOSONAR
-        query.setParameter(SAKSNUMMER, saksnummer.getVerdi());
-
-        @SuppressWarnings("unchecked")
-        List<String> aktørIdList = query.getResultList();
-        return aktørIdList.stream().map(AktørId::new).collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
 
     @SuppressWarnings({"unchecked"})
-    public Set<Long> fagsakIdForJournalpostId(Collection<JournalpostId> journalpostId) {
+    public Set<Saksnummer> saksnumreForJournalpostId(Collection<JournalpostId> journalpostId) {
         if (journalpostId.isEmpty()) {
             return Collections.emptySet();
         }
-        String sql = "SELECT fagsak_id FROM JOURNALPOST WHERE journalpost_id in (:journalpostId)";
+        String sql = "SELECT saksnummer FROM JOURNALPOST jp JOIN FAGSAK f on f.id = jp.fagsak_id WHERE journalpost_id in (:journalpostId)";
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("journalpostId", journalpostId.stream().map(j -> j.getVerdi()).collect(Collectors.toList()));
 
-        var result = (List<Number>) query.getResultList();
-        return result.stream().map(Number::longValue).collect(Collectors.toCollection(LinkedHashSet::new));
+        var result = (List<String>) query.getResultList();
+        return result.stream().map(Saksnummer::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @SuppressWarnings({"unchecked"})
@@ -173,33 +153,33 @@ public class PipRepository {
     }
 
     @SuppressWarnings({"unchecked"})
-    public Set<Long> fagsakIderForSøker(Collection<AktørId> aktørId) {
+    public Set<Saksnummer> saksnumreForSøker(Collection<AktørId> aktørId) {
         if (aktørId.isEmpty()) {
             return Collections.emptySet();
         }
-        String sql = "SELECT f.id " +
+        String sql = "SELECT f.saksnummer " +
             "from FAGSAK f " +
             "where f.bruker_aktoer_id in (:aktørId)";
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("aktørId", aktørId.stream().map(AktørId::getId).collect(Collectors.toList()));
-        var result = (List<Number>) query.getResultList();
-        return result.stream().map(Number::longValue).collect(Collectors.toCollection(LinkedHashSet::new));
+        var result = (List<String>) query.getResultList();
+        return result.stream().map(Saksnummer::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @SuppressWarnings({"unchecked"})
-    public Set<Long> fagsakIdForSaksnummer(Collection<Saksnummer> saksnummere) {
-        if (saksnummere.isEmpty()) {
+    public Set<Saksnummer> saksnummerForFagsakId(Collection<Long> fagsakIder) {
+        if (fagsakIder.isEmpty()) {
             return Collections.emptySet();
         }
-        String sql = "SELECT id from FAGSAK where saksnummer in (:saksnummre) ";
+        String sql = "SELECT saksnummer from FAGSAK where id in (:fagsakIder) ";
         Query query = entityManager.createNativeQuery(sql);
-        query.setParameter("saksnummre", saksnummere.stream().map(Saksnummer::getVerdi).collect(Collectors.toSet()));
-        var result = (List<Number>) query.getResultList();
-        return result.stream().map(Number::longValue).collect(Collectors.toCollection(LinkedHashSet::new));
+        query.setParameter("fagsakIder", fagsakIder);
+        var result = (List<String>) query.getResultList();
+        return result.stream().map(Saksnummer::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Set<Long> behandlingsIdForUuid(Set<UUID> behandlingsUUIDer) {
-        if (behandlingsUUIDer == null || behandlingsUUIDer.isEmpty()) {
+        if (behandlingsUUIDer.isEmpty()) {
             return Collections.emptySet();
         }
         String sql = "SELECT beh.id from Behandling AS beh WHERE beh.uuid IN (:uuider)";

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/pip/PipRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/pip/PipRepositoryTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
+import no.nav.ung.sak.typer.Saksnummer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,9 +82,9 @@ public class PipRepositoryTest {
         @SuppressWarnings("unused")
         Fagsak fagsakAnnenAktør = new BasicBehandlingBuilder(entityManager).opprettFagsak(FagsakYtelseType.FORELDREPENGER);
 
-        Set<Long> resultat = pipRepository.fagsakIderForSøker(Collections.singleton(aktørId1));
+        Set<Saksnummer> resultat = pipRepository.saksnumreForSøker(Collections.singleton(aktørId1));
 
-        assertThat(resultat).containsOnly(fagsak1.getId(), fagsak2.getId());
+        assertThat(resultat).containsOnly(fagsak1.getSaksnummer(), fagsak2.getSaksnummer());
     }
 
     @Test
@@ -91,7 +92,7 @@ public class PipRepositoryTest {
         AktørId aktørId1 = AktørId.dummy();
         var fagsak = behandlingBuilder.opprettFagsak(FagsakYtelseType.FORELDREPENGER, aktørId1);
 
-        Set<AktørId> aktørIder = pipRepository.hentAktørIdKnyttetTilFagsaker(Collections.singleton(fagsak.getId()));
+        Set<AktørId> aktørIder = pipRepository.hentAktørIdKnyttetTilFagsaker(Collections.singleton(fagsak.getSaksnummer()));
         assertThat(aktørIder).containsOnly(aktørId1);
     }
 
@@ -106,8 +107,8 @@ public class PipRepositoryTest {
         fagsakRepository.lagre(journalpost2);
         (new Repository(entityManager)).flush();
 
-        Set<Long> fagsakId = pipRepository.fagsakIdForJournalpostId(Collections.singleton(JOURNALPOST_ID));
-        assertThat(fagsakId).containsOnly(fagsak1.getId());
+        Set<Saksnummer> fagsakId = pipRepository.saksnumreForJournalpostId(Collections.singleton(JOURNALPOST_ID));
+        assertThat(fagsakId).containsOnly(fagsak1.getSaksnummer());
     }
 
     @Test

--- a/web/src/main/java/no/nav/ung/sak/web/app/exceptions/KnownExceptionMappers.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/exceptions/KnownExceptionMappers.java
@@ -14,6 +14,7 @@ import no.nav.k9.felles.exception.ManglerTilgangException;
 import no.nav.k9.felles.exception.VLException;
 import no.nav.k9.felles.jpa.TomtResultatException;
 import no.nav.ung.sak.web.app.tjenester.behandling.aksjonspunkt.BehandlingEndretKonfliktException;
+import no.nav.ung.sak.web.server.abac.UkjentAbacVerdiException;
 
 public class KnownExceptionMappers {
 
@@ -31,6 +32,7 @@ public class KnownExceptionMappers {
         register(TomtResultatException.class, new TomtResultatExceptionMapper());
         register(UnsupportedOperationException.class, new UnsupportedOperationExceptionMapper());
         register(VLException.class, new VLExceptionMapper());
+        register(UkjentAbacVerdiException.class, new UkjentAbacVerdiExceptionMapper());
         register(Throwable.class, new ThrowableExceptionMapper());
     }
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/exceptions/UkjentAbacVerdiExceptionMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/exceptions/UkjentAbacVerdiExceptionMapper.java
@@ -1,0 +1,30 @@
+package no.nav.ung.sak.web.app.exceptions;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import no.nav.ung.sak.web.server.abac.UkjentAbacVerdiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class UkjentAbacVerdiExceptionMapper implements ExceptionMapper<UkjentAbacVerdiException> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Response toResponse(UkjentAbacVerdiException exception) {
+        String feilmelding = exception.getMessage();
+        log.warn(feilmelding, exception);
+        try {
+            return Response.status(Response.Status.NOT_FOUND)
+                .type(MediaType.TEXT_PLAIN_TYPE)
+                .entity(exception.getMessage())
+                .build();
+        } finally {
+            // key for å tracke prosess -- nullstill denne
+            MDC.remove("prosess");
+        }
+    }
+
+}

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/PdpRequestBuilderFeil.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/PdpRequestBuilderFeil.java
@@ -9,6 +9,7 @@ import no.nav.k9.felles.feil.LogLevel;
 import no.nav.k9.felles.feil.deklarasjon.DeklarerteFeil;
 import no.nav.k9.felles.feil.deklarasjon.ManglerTilgangFeil;
 import no.nav.k9.felles.feil.deklarasjon.TekniskFeil;
+import no.nav.ung.sak.typer.Saksnummer;
 
 interface PdpRequestBuilderFeil extends DeklarerteFeil {
 
@@ -17,6 +18,6 @@ interface PdpRequestBuilderFeil extends DeklarerteFeil {
     @TekniskFeil(feilkode = "FP-621834", feilmelding = "Ugyldig input. Støtter bare 0 eller 1 behandling, men har %s", logLevel = LogLevel.WARN)
     Feil ugyldigInputFlereBehandlingIder(Collection<Long> behandlingId);
 
-    @ManglerTilgangFeil(feilkode = "FP-280301", feilmelding = "Ugyldig input. Ikke samsvar mellom behandlingId %s og fagsakId %s", logLevel = LogLevel.WARN)
-    Feil ugyldigInputManglerSamsvarBehandlingFagsak(Long behandlingId, List<Long> fagsakIder);
+    @ManglerTilgangFeil(feilkode = "FP-280301", feilmelding = "Ugyldig input. Ikke samsvar mellom behandlingId %s og saksnummer %s", logLevel = LogLevel.WARN)
+    Feil ugyldigInputManglerSamsvarBehandlingFagsak(Long behandlingId, List<Saksnummer> fagsakIder);
 }

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/PipRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/PipRestTjeneste.java
@@ -62,7 +62,7 @@ public class PipRestTjeneste {
     @BeskyttetRessurs(action = READ, resource = PIP)
     @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
     public Set<AktørId> hentAktørIdListeTilknyttetSak(@NotNull @QueryParam("saksnummer") @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) SaksnummerDto saksnummerDto) {
-        Set<AktørId> aktører = pipRepository.hentAktørIdKnyttetTilSaksnummer(saksnummerDto.getVerdi());
+        Set<AktørId> aktører = pipRepository.hentAktørIdKnyttetTilFagsaker(Set.of( saksnummerDto.getVerdi()));
         return aktører;
     }
 
@@ -126,7 +126,7 @@ public class PipRestTjeneste {
     }
 
     private Set<AktørId> hentAktørIder(PipBehandlingsData pipBehandlingsData) {
-        return pipRepository.hentAktørIdKnyttetTilFagsaker(List.of(pipBehandlingsData.getFagsakId()));
+        return pipRepository.hentAktørIdKnyttetTilFagsaker(List.of(new Saksnummer(pipBehandlingsData.getSaksnummer())));
     }
 
 }

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentAbacVerdiException.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentAbacVerdiException.java
@@ -1,0 +1,15 @@
+package no.nav.ung.sak.web.server.abac;
+
+/**
+ * Lager egen exception for når ikke alt er som forventet med abac-verdier, for å kunne håndtere i egen ExceptionMapper
+ */
+public abstract class UkjentAbacVerdiException extends RuntimeException {
+
+    protected UkjentAbacVerdiException(String message) {
+        super(message);
+    }
+
+    protected UkjentAbacVerdiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentBehandlingException.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentBehandlingException.java
@@ -1,0 +1,16 @@
+package no.nav.ung.sak.web.server.abac;
+
+import java.util.Set;
+import java.util.UUID;
+
+
+public class UkjentBehandlingException extends UkjentAbacVerdiException {
+
+    protected UkjentBehandlingException(Long behandlingId) {
+        super("Behandlingen med id " + behandlingId + " finnes ikke i applikasjonen.");
+    }
+
+    protected UkjentBehandlingException(Set<UUID> behandlingUuid) {
+        super("Minst en ab behandlingen med uuid " + behandlingUuid + " finnes ikke i applikasjonen.");
+    }
+}

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentBehandlingException.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentBehandlingException.java
@@ -11,6 +11,6 @@ public class UkjentBehandlingException extends UkjentAbacVerdiException {
     }
 
     protected UkjentBehandlingException(Set<UUID> behandlingUuid) {
-        super("Minst en ab behandlingen med uuid " + behandlingUuid + " finnes ikke i applikasjonen.");
+        super("Minst en av behandlingen med uuid " + behandlingUuid + " finnes ikke i applikasjonen.");
     }
 }

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentFagsakException.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/UkjentFagsakException.java
@@ -1,0 +1,11 @@
+package no.nav.ung.sak.web.server.abac;
+
+import java.util.Set;
+
+
+public class UkjentFagsakException extends UkjentAbacVerdiException {
+
+    protected UkjentFagsakException(Set<Long> fagsakId) {
+        super("Minst en av fagsakene med id " + fagsakId + " finnes ikke i applikasjonen.");
+    }
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**

Det er unødvendig vanskelig å feilsøke når man sender inn feil behandlingId til applikasjonen. 

### **Løsning**

Kast egen exception, logg hva som var avvik, og returner http code 404 Not Found ved ukjent behandling/fagsak.

### **Andre endringer**

Legg til behandlingUuid som MDC-parameter for loggene. Fjernet fagsakId som MDC-parameter (siden vi alltid har saksnummer)

Endret fokus fra fagsakId til saksnummer noen steder i koden, det gjorde også at noe duplisert kode kunne fjernes.

Fjernet konstanter for omsorgsdager

### **Skjermbilder** (hvis relevant)
