### PR TITLE
Dependabot: ikke ta med major oppgraderinger i grupper, ikke behandle jersey/jetty annerledes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,15 +45,19 @@ updates:
       - fp-tidsserie
     groups:
       nav-deps:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*no.nav*"
       annet-deps:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
         exclude-patterns:
           - "*no.nav*"
-          - "*jersey-bom*"
-          - "*jetty-bom*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
### **Behov / Bakgrunn**

Manuell jobb ved å fjerne major-oppgraderinger fra grupper om de ikke skal være med, bedre at de får separat PR i utgangspunktet

### **Løsning**

### **Andre endringer**

Ikke behandle jersey/jetty annerledes

### **Skjermbilder** (hvis relevant)
