### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -195,7 +195,7 @@ spec:
     - name: DOKDISTFORDELING_URL
       value: https://dokdistfordeling.dev-fss-pub.nais.io/rest/v1
     - name: DOKDISTFORDELING_SCOPE
-      value: api://dev-fss.teamdokumenthandtering.saf/.default
+      value: api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default
     - name: DOKARKIV_URL
       value: https://dokarkiv-q2.dev-fss-pub.nais.io/rest/journalpostapi/v1
     - name: DOKARKIV_BASE_URL

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -197,7 +197,7 @@ spec:
     - name: DOKDISTFORDELING_URL
       value: https://dokdistfordeling.prod-fss-pub.nais.io/rest/v1
     - name: DOKDISTFORDELING_SCOPE
-      value: api://prod-fss.teamdokumenthandtering.saf/.default
+      value: api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default
     - name: DOKARKIV_URL
       value: https://dokarkiv.prod-fss-pub.nais.io/rest/journalpostapi/v1
     - name: DOKARKIV_BASE_URL

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/dokdist/DokDistRestKlientImpl.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/dokdist/DokDistRestKlientImpl.java
@@ -18,7 +18,7 @@ import no.nav.ung.sak.formidling.dokdist.dto.DistribuerJournalpostResponse;
  *
  */
 @Dependent
-@ScopedRestIntegration(scopeKey = "DOKDISTFORDELING_SCOPE", defaultScope = "api://prod-fss.teamdokumenthandtering.saf/.default")
+@ScopedRestIntegration(scopeKey = "DOKDISTFORDELING_SCOPE", defaultScope = "api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default")
 public class DokDistRestKlientImpl implements DokDistRestKlient {
 
     private final OidcRestClient restClient;


### PR DESCRIPTION
### **Behov / Bakgrunn**
> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

### **Løsning**
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen
