### PR TITLE
Typescript client generator v2

### DIFF
--- a/.github/actions/generate-typescript-client/action.yaml
+++ b/.github/actions/generate-typescript-client/action.yaml
@@ -21,12 +21,11 @@ runs:
       run: echo "resultDir=web/target/ts-client" >> $GITHUB_OUTPUT
     - name: Typescript generate
       id: typescript-generate
-      uses: navikt/openapi-ts-clientmaker@v1
+      uses: navikt/openapi-ts-clientmaker@v2
       with:
         openapi-spec-file: web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
         package-json-file: web/src/main/resources/openapi-ts-client/package.json
         package-json-version: "${{ env.PACKAGE_JSON_VERSION }}"
         out-dir: "${{ steps.set-output.outputs.resultDir }}"
-        client-name: UngSakClient
       env:
         PACKAGE_JSON_VERSION: "${{ inputs.openapiVersion }}.${{ inputs.patchVersion }}"

--- a/.run/web_generate typescript client.run.xml
+++ b/.run/web_generate typescript client.run.xml
@@ -2,8 +2,8 @@
   <configuration default="false" name="web/generate typescript client" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v1" />
-        <option name="command" value="-- --openapi-spec-file in/ung-sak.openapi.json --package-json-file in/package.json --client-name UngSakClient" />
+        <option name="imageTag" value="europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v2" />
+        <option name="command" value="-- --openapi-spec-file in/ung-sak.openapi.json --package-json-file in/package.json" />
         <option name="containerName" value="openapi-ts-clientmaker-cli" />
         <option name="showCommandPreview" value="true" />
         <option name="volumeBindings">

--- a/.run/web_pull-openapi-ts-clientmaker-cli.run.xml
+++ b/.run/web_pull-openapi-ts-clientmaker-cli.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="web/pull-openapi-ts-clientmaker-cli" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="docker container rm openapi-ts-clientmaker-cli; docker pull europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v1" />
+    <option name="SCRIPT_TEXT" value="docker container rm openapi-ts-clientmaker-cli; docker pull europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/openapi-ts-clientmaker-cli:v2" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />
     <option name="SCRIPT_OPTIONS" value="" />

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>no.nav.openapi.spec.utils</groupId>
             <artifactId>openapi-spec-utils</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
 
         <!-- CDI -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>no.nav.openapi.spec.utils</groupId>
             <artifactId>openapi-spec-utils</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5</version>
         </dependency>
 
         <!-- CDI -->

--- a/web/src/main/java/no/nav/ung/sak/web/app/ApplicationConfig.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/ApplicationConfig.java
@@ -28,7 +28,7 @@ public class ApplicationConfig extends ResourceConfig {
     public OpenAPI resolveOpenAPI() {
         final var info = new Info()
             .title("Ung saksbehandling - Saksbehandling for ungdomsprogramytelsen")
-            .version("1.0")
+            .version("2.0")
             .description("REST grensesnitt for Vedtaksløsningen.");
 
         final var server =new Server().url("/ung/sak");

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -1898,6 +1898,23 @@
         "type" : "object"
       },
       "ung.sak.kontrakt.aksjonspunkt.BekreftetAksjonspunktDto" : {
+        "discriminator" : {
+          "mapping" : {
+            "5015" : "#/components/schemas/ung.sak.kontrakt.vedtak.ForeslaVedtakAksjonspunktDto",
+            "5016" : "#/components/schemas/ung.sak.kontrakt.vedtak.FatterVedtakAksjonspunktDto",
+            "5018" : "#/components/schemas/ung.sak.kontrakt.vedtak.BekreftVedtakUtenTotrinnskontrollDto",
+            "5025" : "#/components/schemas/ung.sak.kontrakt.behandling.revurdering.VarselRevurderingEtterkontrollDto",
+            "5028" : "#/components/schemas/ung.sak.kontrakt.vedtak.ForeslaVedtakManueltAksjonspuntDto",
+            "5055" : "#/components/schemas/ung.sak.kontrakt.behandling.revurdering.KontrollerRevurderingsBehandlingDto",
+            "5056" : "#/components/schemas/ung.sak.kontrakt.behandling.revurdering.KontrollAvManueltOpprettetRevurderingsbehandlingDto",
+            "5077" : "#/components/schemas/ung.sak.kontrakt.søknadsfrist.aksjonspunkt.AvklarSøknadsfristDto",
+            "5084" : "#/components/schemas/ung.sak.kontrakt.økonomi.tilbakekreving.VurderFeilutbetalingDto",
+            "5085" : "#/components/schemas/ung.sak.kontrakt.økonomi.tilbakekreving.SjekkTilbakekrevingFørVedtakDto",
+            "5090" : "#/components/schemas/ung.sak.kontrakt.økonomi.tilbakekreving.VurderTilbaketrekkDto",
+            "8000" : "#/components/schemas/ung.sak.kontrakt.kontroll.FastsettInntektDto"
+          },
+          "propertyName" : "@type"
+        },
         "oneOf" : [ {
           "$ref" : "#/components/schemas/ung.sak.kontrakt.behandling.revurdering.KontrollAvManueltOpprettetRevurderingsbehandlingDto"
         }, {
@@ -1968,6 +1985,12 @@
         "type" : "object"
       },
       "ung.sak.kontrakt.aksjonspunkt.OverstyringAksjonspunktDto" : {
+        "discriminator" : {
+          "mapping" : {
+            "6006" : "#/components/schemas/ung.sak.kontrakt.søknadsfrist.aksjonspunkt.OverstyrtSøknadsfristDto"
+          },
+          "propertyName" : "@type"
+        },
         "oneOf" : [ {
           "$ref" : "#/components/schemas/ung.sak.kontrakt.søknadsfrist.aksjonspunkt.OverstyrtSøknadsfristDto"
         } ],
@@ -3012,6 +3035,12 @@
       },
       "ung.sak.kontrakt.hendelser.Hendelse" : {
         "discriminator" : {
+          "mapping" : {
+            "DOEDSFALL_V1" : "#/components/schemas/ung.sak.kontrakt.hendelser.DødsfallHendelse",
+            "FOEDSEL_V1" : "#/components/schemas/ung.sak.kontrakt.hendelser.FødselHendelse",
+            "UNGDOMSPROGRAM_ENDRET_STARTDATO" : "#/components/schemas/ung.sak.kontrakt.hendelser.UngdomsprogramEndretStartdatoHendelse",
+            "UNGDOMSPROGRAM_OPPHOER" : "#/components/schemas/ung.sak.kontrakt.hendelser.UngdomsprogramOpphørHendelse"
+          },
           "propertyName" : "type"
         },
         "oneOf" : [ {
@@ -4928,7 +4957,7 @@
   "info" : {
     "description" : "REST grensesnitt for Vedtaksløsningen.",
     "title" : "Ung saksbehandling - Saksbehandling for ungdomsprogramytelsen",
-    "version" : "1.0"
+    "version" : "2.0"
   },
   "openapi" : "3.0.1",
   "paths" : {


### PR DESCRIPTION
### **Behov / Bakgrunn**

Versjon 2 av klientgenerator genererer betre typer og klientkode for frontend, spesielt for endepunkt som bruker ein supertype.

### **Løsning**

Oppdaterer til versjon 2. Dette er ein breaking change i forhold til frontend, så oppjusterer samtidig major versjon på api.

Dette medfører ingen endring i oppførsel til serveren.

Samme endring som gjort på k9-sak: https://github.com/navikt/k9-sak/pull/12018