### PR TITLE
Optimize ObjectMapper creation by using cached base instance copy (#645)

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/jackson/ObjectMapperFactory.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/jackson/ObjectMapperFactory.java
@@ -26,6 +26,15 @@ import java.util.stream.Collectors;
 
 public class ObjectMapperFactory {
 
+    private static ObjectMapper baseObjectMapper;
+
+    public static ObjectMapper getBaseObjectMapperCopy() {
+        if(baseObjectMapper == null) {
+            baseObjectMapper = ObjectMapperFactory.createBaseObjectMapper();
+        }
+        return baseObjectMapper.copy();
+    }
+
     public static SimpleModule createOverstyrendeKodeverdiSerializerModule(final SakKodeverkOverstyringSerialisering sakKodeverkOverstyringSerialisering) {
         final SimpleModule module = new SimpleModule("KodeverdiSerialisering", new Version(1, 0, 0, null, null, null));
 
@@ -81,7 +90,7 @@ public class ObjectMapperFactory {
     }
 
 
-    public static ObjectMapper createBaseObjectMapper() {
+    private static ObjectMapper createBaseObjectMapper() {
         final var om = new ObjectMapper();
         om.registerModule(new Jdk8Module());
         om.registerModule(new JavaTimeModule());

--- a/web/src/main/java/no/nav/ung/sak/web/app/jackson/ObjectMapperResolver.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/jackson/ObjectMapperResolver.java
@@ -11,20 +11,11 @@ public class ObjectMapperResolver extends DynamicObjectMapperResolver {
     private final String JSON_SERIALIZER_ALLTID_SOM_STRING = "kodeverdi-string";
     private final String JSON_SERIALIZER_KODEVERDI_OBJEKT = "kodeverdi-objekt";
 
-    private static ObjectMapper baseObjectMapper;
-
-    public static ObjectMapper getBaseObjectMapperCopy() {
-        if(baseObjectMapper == null) {
-            baseObjectMapper = ObjectMapperFactory.createBaseObjectMapper();
-        }
-        return baseObjectMapper.copy();
-    }
-
     // defaultObjektMapper brukast når input header for overstyring ikkje er satt.
     // Har ingen overstyring, men har spesialkode for å støtte deserialisering frå kodeverdi som objekt i ein overgangsperiode,
     // for å støtte klienter med gammal versjon av kontrakt, som dermed serialiserer Kodeverdi enums til objekt.
     private static ObjectMapper createDefaultObjectMapper() {
-        return getBaseObjectMapperCopy().registerModule(ObjectMapperFactory.createOverstyrendeKodeverdiSerializerModule(SakKodeverkOverstyringSerialisering.INGEN));
+        return ObjectMapperFactory.getBaseObjectMapperCopy().registerModule(ObjectMapperFactory.createOverstyrendeKodeverdiSerializerModule(SakKodeverkOverstyringSerialisering.INGEN));
     }
 
     /**
@@ -32,12 +23,12 @@ public class ObjectMapperResolver extends DynamicObjectMapperResolver {
      */
     public ObjectMapperResolver() {
         super(createDefaultObjectMapper());
-        final var overstyrKodeverdiAlltidSomStringMapper = getBaseObjectMapperCopy().registerModule(ObjectMapperFactory.createOverstyrendeKodeverdiSerializerModule(SakKodeverkOverstyringSerialisering.KODE_STRING));
+        final var overstyrKodeverdiAlltidSomStringMapper = ObjectMapperFactory.getBaseObjectMapperCopy().registerModule(ObjectMapperFactory.createOverstyrendeKodeverdiSerializerModule(SakKodeverkOverstyringSerialisering.KODE_STRING));
         super.addObjectMapper(JSON_SERIALIZER_ALLTID_SOM_STRING, overstyrKodeverdiAlltidSomStringMapper);
-        final var overstyrKodeverdiLegacySomObjekt = getBaseObjectMapperCopy().registerModule(ObjectMapperFactory.createOverstyrendeKodeverdiSerializerModule(SakKodeverkOverstyringSerialisering.LEGACY_OBJEKT));
+        final var overstyrKodeverdiLegacySomObjekt = ObjectMapperFactory.getBaseObjectMapperCopy().registerModule(ObjectMapperFactory.createOverstyrendeKodeverdiSerializerModule(SakKodeverkOverstyringSerialisering.LEGACY_OBJEKT));
         super.addObjectMapper(JSON_SERIALIZER_KODEVERDI_OBJEKT, overstyrKodeverdiLegacySomObjekt);
         // openaapiObjektMapper bør brukast viss ein ønsker at enums skal bli serialisert slik openapi spesifikasjon tilseier.
-        final var openapiObjektMapper = OpenapiCompatObjectMapperModifier.withDefaultModifications().modify(getBaseObjectMapperCopy());
+        final var openapiObjektMapper = OpenapiCompatObjectMapperModifier.withDefaultModifications().modify(ObjectMapperFactory.getBaseObjectMapperCopy());
         super.addObjectMapper(JSON_SERIALIZER_OPENAPI, openapiObjektMapper);
     }
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/aksjonspunkt/AksjonspunktRestTjenesteDump.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/aksjonspunkt/AksjonspunktRestTjenesteDump.java
@@ -19,7 +19,7 @@ public class AksjonspunktRestTjenesteDump implements DebugDumpBehandling {
 
     private AksjonspunktRestTjeneste restTjeneste;
 
-    private final ObjectWriter ow = ObjectMapperFactory.createBaseObjectMapper().writerWithDefaultPrettyPrinter();
+    private final ObjectWriter ow = ObjectMapperFactory.getBaseObjectMapperCopy().writerWithDefaultPrettyPrinter();
 
     private final String relativePath = "rest/aksjonpunkter";
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/historikk/HistorikkTjenesteDump.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/historikk/HistorikkTjenesteDump.java
@@ -16,7 +16,7 @@ public class HistorikkTjenesteDump implements DebugDumpFagsak {
 
     private HistorikkTjenesteAdapter historikkTjeneste;
 
-    private final ObjectWriter ow = ObjectMapperFactory.createBaseObjectMapper().writerWithDefaultPrettyPrinter();
+    private final ObjectWriter ow = ObjectMapperFactory.getBaseObjectMapperCopy().writerWithDefaultPrettyPrinter();
 
     HistorikkTjenesteDump() {
         // for proxy

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/vilkår/VilkårRestTjenesteDump.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/dump/vilkår/VilkårRestTjenesteDump.java
@@ -19,7 +19,7 @@ public class VilkårRestTjenesteDump implements DebugDumpBehandling {
 
     private VilkårRestTjeneste restTjeneste;
 
-    private final ObjectWriter ow = ObjectMapperFactory.createBaseObjectMapper().writerWithDefaultPrettyPrinter();
+    private final ObjectWriter ow = ObjectMapperFactory.getBaseObjectMapperCopy().writerWithDefaultPrettyPrinter();
     private final String relativePath = "rest/vilkår";
 
     VilkårRestTjenesteDump() {

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/kodeverk/KodeverkRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/kodeverk/KodeverkRestTjeneste.java
@@ -206,7 +206,7 @@ public class KodeverkRestTjeneste {
     @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
     @Deprecated(forRemoval = true)
     public Response hentGruppertKodeliste() throws IOException {
-        final ObjectMapper om = ObjectMapperResolver.getBaseObjectMapperCopy();
+        final ObjectMapper om = ObjectMapperFactory.getBaseObjectMapperCopy();
 
         String kodelisteJson = om.writeValueAsString(legacyGruppertKodeverdi);
         jakarta.ws.rs.core.CacheControl cc = new jakarta.ws.rs.core.CacheControl();

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/kodeverk/KodeverkRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/kodeverk/KodeverkRestTjenesteTest.java
@@ -49,7 +49,7 @@ public class KodeverkRestTjenesteTest {
     public void hentGruppertKodeliste_fungerer_framleis() throws IOException {
         final KodeverkRestTjeneste tjeneste = new KodeverkRestTjeneste(behandlendeEnhetTjeneste);
         final Response hentGruppertKodelisteResponse = tjeneste.hentGruppertKodeliste();
-        final ObjectMapper om = ObjectMapperFactory.createBaseObjectMapper();
+        final ObjectMapper om = ObjectMapperFactory.getBaseObjectMapperCopy();
         final Map<String, Object> hentGruppertKodelisteObjectMap = om.readValue((String)hentGruppertKodelisteResponse.getEntity(), Map.class);
         final List<LinkedHashMap<String, String>> legacyFagsakYtelseType = getKodelisteMap(hentGruppertKodelisteObjectMap, "FagsakYtelseType");
         final AlleKodeverdierSomObjektResponse alleKodeverdierSomObjektResponse = tjeneste.alleKodeverdierSomObjekt();


### PR DESCRIPTION
### **Behov / Bakgrunn**

Behov / Bakgrunn
Sidan det å opprette ny ObjectMapper kan vere ein tung operasjon ønsker vi å gjere det så sjelden som mulig.

(https://github.com/navikt/k9-sak/pull/11983#discussion_r2273033369)

### **Løsning**

Skriver ObjectMapperFactory om til å kunne returnere ein kopi av cacha base ObjectMapper, og bruker denne istadenfor å opprette ny frå botnen av kvar gang.

Implementert av copilot.