### PR TITLE
endrer fra 10. til 12. i brev

### DIFF
--- a/formidling/src/main/resources/pdfgen/templates/ungdomsprogramytelse/innvilgelse.hbs
+++ b/formidling/src/main/resources/pdfgen/templates/ungdomsprogramytelse/innvilgelse.hbs
@@ -28,7 +28,7 @@
         {{/each}}
 
         <p>
-            Pengene får du utbetalt én gang i måneden før den 10. i måneden.
+            Pengene får du utbetalt én gang i måneden før den 12. i måneden.
             {{#if etterbetaling}}
                 Den første utbetalingen får du innen en uke.
             {{else}}

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseMedDødsfallBarnTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseMedDødsfallBarnTest.java
@@ -63,7 +63,7 @@ public class FørstegangsInnvilgelseMedDødsfallBarnTest {
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 får du ungdomsprogramytelse på 718 kroner per dag, utenom lørdag og søndag. \
                 Fordi du mistet barn 16. august 2025, får du ikke barnetillegg på 37 kroner fra denne datoen. Da får du 681 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/FørstegangsInnvilgelseTest.java
@@ -52,7 +52,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
             """
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 får du ungdomsprogramytelse på 681 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
@@ -90,7 +90,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
             """
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 til 12. desember 2025 får du ungdomsprogramytelse på 681 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Den siste utbetalingen får du før den 10. januar 2026. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
@@ -135,7 +135,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
             """
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 får du ungdomsprogramytelse på 1 022 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
@@ -166,7 +166,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
             """
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 til 15. februar 2026 får du ungdomsprogramytelse på 1 022 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Den siste utbetalingen får du før den 10. mars 2026. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
@@ -205,7 +205,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 får du ungdomsprogramytelse på 681 kroner per dag, utenom lørdag og søndag. \
                 Fordi du fylte 25 år 16. august 2025, får du mer penger fra denne datoen. Da får du 1 022 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
@@ -254,7 +254,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
                 Du får ungdomsprogramytelse \
                 Fra 1. august 2025 får du ungdomsprogramytelse på 681 kroner per dag, utenom lørdag og søndag. \
                 Fordi du fikk barn 16. august 2025, får du 37 kroner mer fra denne datoen. Da får du 718 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du måneden etter at du begynner i ungdomsprogrammet. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \
@@ -297,7 +297,7 @@ class FørstegangsInnvilgelseTest extends AbstractVedtaksbrevInnholdByggerTest {
                 Fra 21. april 2025 får du ungdomsprogramytelse på 649 kroner per dag, utenom lørdag og søndag. \
                 Fordi du fikk barn 6. mai 2025, får du 37 kroner mer for hvert barn fra denne datoen. Da får du 755 kroner per dag, utenom lørdag og søndag. \
                 Fordi du fylte 25 år 8. mai 2025, får du mer penger fra denne datoen. Da får du 1 096 kroner per dag, utenom lørdag og søndag. \
-                Pengene får du utbetalt én gang i måneden før den 10. i måneden. \
+                Pengene får du utbetalt én gang i måneden før den 12. i måneden. \
                 Den første utbetalingen får du innen en uke. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \
                 Du finner mer informasjon om utbetalingen hvis du logger inn på Min side på nav.no. \


### PR DESCRIPTION
### **Behov / Bakgrunn**
Da inntektsopplysninger kan komme noen dager etter den 6. så opplyser vi at utbetalingene skjer før den 12. i brevet