### PR TITLE
TSFF-1922: Endrer dag for inntektskontroll til den åttende i måneden

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -232,8 +232,8 @@ spec:
       value: "false"
     - name: INNSENDING_HENDELSER_FORSINKELSE
       value: "PT1M"
-    - name: RAPPORTERINGSFRIST_DAG_I_MAANED
-      value: "5"
+    - name: INNTEKTSKONTROLL_DAG_I_MAANED
+      value: "8"
     - name: AKSEPTERT_DIFFERANSE_KONTROLL
       value: "15"
     - name: VENTEFRIST_UTTALELSE

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -243,8 +243,8 @@ spec:
       value: "false"
     - name: INNSENDING_HENDELSER_FORSINKELSE
       value: "PT1H"
-    - name: RAPPORTERINGSFRIST_DAG_I_MAANED
-      value: "5"
+    - name: INNTEKTSKONTROLL_DAG_I_MAANED
+      value: "8"
     - name: AKSEPTERT_DIFFERANSE_KONTROLL
       value: "15"
     - name: VENTEFRIST_UTTALELSE

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettOppgaveForInntektsrapporteringTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettOppgaveForInntektsrapporteringTask.java
@@ -50,7 +50,7 @@ public class OpprettOppgaveForInntektsrapporteringTask implements ProsessTaskHan
     @Inject
     public OpprettOppgaveForInntektsrapporteringTask(PersoninfoAdapter personinfoAdapter,
                                                      UngOppgaveKlient ungOppgaveKlient,
-                                                     @KonfigVerdi(value = "RAPPORTERINGSFRIST_DAG_I_MAANED", defaultVerdi = "6") int rapporteringsfristDagIMåned) {
+                                                     @KonfigVerdi(value = "INNTEKTSKONTROLL_DAG_I_MAANED", defaultVerdi = "8") int rapporteringsfristDagIMåned) {
 
         this.personinfoAdapter = personinfoAdapter;
         this.ungOppgaveKlient = ungOppgaveKlient;
@@ -70,7 +70,7 @@ public class OpprettOppgaveForInntektsrapporteringTask implements ProsessTaskHan
         ungOppgaveKlient.opprettInntektrapporteringOppgave(new InntektsrapporteringOppgaveDTO(
             deltakerIdent.getIdent(),
             UUID.fromString(prosessTaskData.getPropertyValue(OPPGAVE_REF)),
-            fom.plusMonths(1).withDayOfMonth(rapporteringsfristDagIMåned + 1).atStartOfDay(),
+            fom.plusMonths(1).withDayOfMonth(rapporteringsfristDagIMåned).atStartOfDay(),
             fom,
             tom
         ));

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
@@ -20,10 +20,10 @@ import static no.nav.ung.sak.behandling.revurdering.OpprettRevurderingEllerOppre
 /**
  * Batchtask som starter kontroll av inntekt fra a-inntekt
  * <p>
- * Kjører den sjette i måneden kl 07:00.
+ * Kjører den åttende i måneden kl 07:00.
  */
 @ApplicationScoped
-@ProsessTask(value = OpprettRevurderingForInntektskontrollBatchTask.TASKNAME, cronExpression = "0 0 7 6 * *", maxFailedRuns = 1)
+@ProsessTask(value = OpprettRevurderingForInntektskontrollBatchTask.TASKNAME, cronExpression = "0 0 7 8 * *", maxFailedRuns = 1)
 public class OpprettRevurderingForInntektskontrollBatchTask implements ProsessTaskHandler {
 
     public static final String TASKNAME = "batch.opprettRevurderingForInntektskontrollBatch";

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/kontroll/ManglendeKontrollperioderTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/kontroll/ManglendeKontrollperioderTjeneste.java
@@ -29,7 +29,7 @@ public class ManglendeKontrollperioderTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(ManglendeKontrollperioderTjeneste.class);
 
-    private final int rapporteringsfristIMåned;
+    private final int dagIMånedForInntektsKontroll;
     private MånedsvisTidslinjeUtleder månedsvisTidslinjeUtleder;
     private ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder;
     private TilkjentYtelseRepository tilkjentYtelseRepository;
@@ -37,11 +37,11 @@ public class ManglendeKontrollperioderTjeneste {
     @Inject
     public ManglendeKontrollperioderTjeneste(MånedsvisTidslinjeUtleder månedsvisTidslinjeUtleder,
                                              ProsessTriggerPeriodeUtleder prosessTriggerPeriodeUtleder,
-                                             @KonfigVerdi(value = "RAPPORTERINGSFRIST_DAG_I_MAANED", defaultVerdi = "6") int rapporteringsfristIMåned,
+                                             @KonfigVerdi(value = "INNTEKTSKONTROLL_DAG_I_MAANED", defaultVerdi = "8") int dagIMånedForInntektsKontroll,
                                              TilkjentYtelseRepository tilkjentYtelseRepository) {
         this.månedsvisTidslinjeUtleder = månedsvisTidslinjeUtleder;
         this.prosessTriggerPeriodeUtleder = prosessTriggerPeriodeUtleder;
-        this.rapporteringsfristIMåned = rapporteringsfristIMåned;
+        this.dagIMånedForInntektsKontroll = dagIMånedForInntektsKontroll;
         this.tilkjentYtelseRepository = tilkjentYtelseRepository;
     }
 
@@ -86,7 +86,7 @@ public class ManglendeKontrollperioderTjeneste {
 
     private LocalDate getTomDatoForPassertRapporteringsfrist() {
         final var dagensDato = LocalDate.now();
-        return dagensDato.getDayOfMonth() <= rapporteringsfristIMåned ? dagensDato.minusMonths(2).with(TemporalAdjusters.lastDayOfMonth()) : dagensDato.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        return dagensDato.getDayOfMonth() < dagIMånedForInntektsKontroll ? dagensDato.minusMonths(2).with(TemporalAdjusters.lastDayOfMonth()) : dagensDato.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
     }
 
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dato endres til åttende i måneden for å redusere antall feil grunnet etterrapportering og for å unngå problematikk rundt endret rapporteringsfrist dersom den femte faller i helg

### **Andre endringer**
Øker robusthet til batchtask som oppretter kontrollbehandlinger ved å sjekke på kontrollerte perioder i tillegg til prosesstrigger

