### PR TITLE
Tar i bruk tilkjent beløp i brev og frontend

### DIFF
--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/TilkjentYtelseBeregner.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/TilkjentYtelseBeregner.java
@@ -53,7 +53,9 @@ public class TilkjentYtelseBeregner {
         final var antallVirkedager = Virkedager.beregnAntallVirkedager(periode.getFomDato(), periode.getTomDato());
         sporing.put("antallVirkedager", String.valueOf(antallVirkedager));
         final var dagsats = antallVirkedager == 0 ?  BigDecimal.ZERO : redusertBeløp.divide(BigDecimal.valueOf(antallVirkedager), 0, RoundingMode.HALF_UP);
+        BigDecimal tilkjentBeløp = dagsats.multiply(BigDecimal.valueOf(antallVirkedager));
         sporing.put("dagsats", dagsats.toString());
+        sporing.put("tilkjentBeløp", tilkjentBeløp.toString());
 
         // Beregner utbetalingsgrad
         final var utbetalingsgrad = finnUtbetalingsgrad(redusertBeløp, sats.grunnsats(), dagsats);
@@ -66,7 +68,7 @@ public class TilkjentYtelseBeregner {
             redusertBeløp,
             dagsats,
             utbetalingsgrad,
-            dagsats.multiply(BigDecimal.valueOf(antallVirkedager)));
+            tilkjentBeløp);
         return new TilkjentYtelsePeriodeResultat(tilkjentYtelseVerdi, sporing);
     }
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektInnholdBygger.java
@@ -58,7 +58,7 @@ public class EndringRapportertInntektInnholdBygger implements VedtaksbrevInnhold
             LocalDateTimeline.JoinStyle.LEFT_JOIN);
 
         var utbetalingSum = relevantTilkjentYtelse.toSegments().stream()
-            .map(it -> it.getValue().redusertBeløp())
+            .map(it -> it.getValue().tilkjentBeløp())
             .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         var rapportertInntektSum = kontrollertInntektPerioderTidslinje.toSegments().stream()

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/EndringRapportertInntektTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/EndringRapportertInntektTest.java
@@ -29,7 +29,7 @@ class EndringRapportertInntektTest extends AbstractVedtaksbrevInnholdByggerTest 
         var ungTestGrunnlag = EndringInntektScenarioer.endringMedInntektPå10k_19år(fom);
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             "Vi har endret ungdomsprogramytelsen din " +
-                "Du får 8 329 kroner i ungdomsprogramytelse for perioden fra 1. januar 2025 til 31. januar 2025. " +
+                "Du får 8 326 kroner i ungdomsprogramytelse for perioden fra 1. januar 2025 til 31. januar 2025. " +
                 "Det er fordi du har hatt en inntekt på 10 000 kroner i denne perioden. " +
                 "Pengene får du utbetalt før den 10. denne måneden. " +
                 "Når du har en inntekt, får du mindre penger i ungdomsprogramytelse. " +
@@ -60,7 +60,7 @@ class EndringRapportertInntektTest extends AbstractVedtaksbrevInnholdByggerTest 
         var ungTestGrunnlag = EndringInntektScenarioer.endringMedInntektPå10k_flere_mnd_19år(fom);
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             "Vi har endret ungdomsprogramytelsen din " +
-                "Du får 14 710 kroner i ungdomsprogramytelse for perioden fra 1. januar 2025 til 28. februar 2025. " +
+                "Du får 14 706 kroner i ungdomsprogramytelse for perioden fra 1. januar 2025 til 28. februar 2025. " +
                 "Det er fordi du har hatt en inntekt på 20 000 kroner i denne perioden. " +
                 "Pengene får du utbetalt før den 10. denne måneden. " +
                 "Vi har registrert følgende inntekter på deg: " +

--- a/web/src/main/java/no/nav/ung/sak/web/app/ungdomsytelse/MånedsvisningDtoMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/ungdomsytelse/MånedsvisningDtoMapper.java
@@ -69,7 +69,7 @@ public class MånedsvisningDtoMapper {
 
     private static BigDecimal finnUtbetaltBeløp(LocalDateTimeline<TilkjentYtelseVerdi> tilkjentYtelseForMåned) {
         return tilkjentYtelseForMåned.toSegments().stream().map(LocalDateSegment::getValue)
-            .map(TilkjentYtelseVerdi::redusertBeløp)
+            .map(TilkjentYtelseVerdi::tilkjentBeløp)
             .reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er dagsats * virkedager som gir beløp som er mest lik det som sendes til utbetaling da avrundingen gjøres på den reduserte dagsatsen. 

Redusert beløp beregnes uten å avrunde til heltall. Dagsats beregnes ved å ta redusert beløp / antall virkedager og deretter avrunde til heltall. Sum av redusert beløp vil derfor gi et annet tall en å gange med dagsats for perioder over 1 måned.    
