### PR TITLE
Vedtaksbrev i riktig rekkefølge

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/bestilling/BrevbestillingTaskGenerator.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/bestilling/BrevbestillingTaskGenerator.java
@@ -1,0 +1,21 @@
+package no.nav.ung.sak.formidling.bestilling;
+
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskHandler;
+
+public class BrevbestillingTaskGenerator {
+
+    public static ProsessTaskData formidlingProsessTaskIGruppe(Class<? extends ProsessTaskHandler> taskKlasse, Long fagsakId) {
+        return formidlingProsessTaskIGruppe(taskKlasse, fagsakId, 0);
+    }
+
+    public static ProsessTaskData formidlingProsessTaskIGruppe(Class<? extends ProsessTaskHandler> taskKlasse, Long fagsakId, int indeks) {
+        var prosessTaskData = ProsessTaskData.forProsessTask(taskKlasse);
+        String nesteSekvens = String.format("%d-%d", System.currentTimeMillis(), indeks);
+        prosessTaskData
+            .medSekvens(nesteSekvens)
+            .medGruppe(("formidling-%d").formatted(fagsakId));
+        return prosessTaskData;
+    }
+
+}

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/bestilling/JournalføringOgDistribusjonsTjeneste.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/bestilling/JournalføringOgDistribusjonsTjeneste.java
@@ -43,8 +43,24 @@ public class JournalføringOgDistribusjonsTjeneste {
     }
 
 
+    /**
+     * Journalfører og lager distribusjonstask.
+     */
     public BrevbestillingResultat journalførOgDistribuer(Behandling behandling, BrevbestillingEntitet bestilling, GenerertBrev generertBrev) {
+        ProsessTaskData distribusjonstaskMal = ProsessTaskData.forProsessTask(BrevdistribusjonTask.class);
+        return journalførOgDistribuer(behandling, bestilling, generertBrev, distribusjonstaskMal);
+    }
 
+    /**
+     *
+     * Sørger for at distribuert etter evt. tidligere brev i samme fagsak.
+     */
+    public BrevbestillingResultat journalførOgDistribuerISekvens(Behandling behandling, BrevbestillingEntitet bestilling, GenerertBrev generertBrev) {
+        ProsessTaskData distTaskMal = BrevbestillingTaskGenerator.formidlingProsessTaskIGruppe(BrevdistribusjonTask.class, behandling.getFagsakId());
+        return journalførOgDistribuer(behandling, bestilling, generertBrev, distTaskMal);
+    }
+
+    private BrevbestillingResultat journalførOgDistribuer(Behandling behandling, BrevbestillingEntitet bestilling, GenerertBrev generertBrev, ProsessTaskData distTaskMal) {
         var dokArkivRequest = opprettJournalpostRequest(bestilling.getBrevbestillingUuid(), generertBrev, behandling);
         var opprettJournalpostResponse = dokArkivKlient.opprettJournalpost(dokArkivRequest);
 
@@ -54,14 +70,13 @@ public class JournalføringOgDistribusjonsTjeneste {
             new BrevMottaker(generertBrev.mottaker().aktørId().getAktørId(), IdType.AKTØRID));
 
         brevbestillingRepository.lagre(bestilling);
-        var distTask = ProsessTaskData.forProsessTask(BrevdistribusjonTask.class);
-        distTask.setBehandling(bestilling.getFagsakId(), bestilling.getBehandlingId());
-        distTask.setSaksnummer(behandling.getFagsak().getSaksnummer().toString());
-        distTask.setProperty(BREVBESTILLING_ID_PARAM, bestilling.getId().toString());
-        distTask.setProperty(BREVBESTILLING_DISTRIBUSJONSTYPE, bestilling.isVedtaksbrev() ?
+        distTaskMal.setBehandling(bestilling.getFagsakId(), bestilling.getBehandlingId());
+        distTaskMal.setSaksnummer(behandling.getFagsak().getSaksnummer().toString());
+        distTaskMal.setProperty(BREVBESTILLING_ID_PARAM, bestilling.getId().toString());
+        distTaskMal.setProperty(BREVBESTILLING_DISTRIBUSJONSTYPE, bestilling.isVedtaksbrev() ?
             DistribuerJournalpostRequest.DistribusjonsType.VEDTAK.name() : DistribuerJournalpostRequest.DistribusjonsType.VIKTIG.name());
-        prosessTaskTjeneste.lagre(distTask);
-        distTask.setCallIdFraEksisterende();
+        prosessTaskTjeneste.lagre(distTaskMal);
+        distTaskMal.setCallIdFraEksisterende();
 
         LOG.info("Brevbestilling med id={} journalført med journalpostId={}", bestilling.getId(), bestilling.getJournalpostId());
         return new BrevbestillingResultat(new JournalpostId(bestilling.getJournalpostId()));

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/bestilling/VedtaksbrevBestillingTask.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/bestilling/VedtaksbrevBestillingTask.java
@@ -71,7 +71,7 @@ public class VedtaksbrevBestillingTask extends BehandlingProsessTask {
 
         if (dokumentMalType == DokumentMalType.MANUELT_VEDTAK_DOK) {
             GenerertBrev generertBrev = vedtaksbrevGenerererTjeneste.genererManuellVedtaksbrev(behandling.getId(), false);
-            journalføringOgDistribusjonsTjeneste.journalførOgDistribuer(behandling, brevbestilling, generertBrev);
+            journalføringOgDistribusjonsTjeneste.journalførOgDistribuerISekvens(behandling, brevbestilling, generertBrev);
             return;
         }
 
@@ -91,7 +91,7 @@ public class VedtaksbrevBestillingTask extends BehandlingProsessTask {
         var generertBrev = vedtaksbrevGenerererTjeneste.genererAutomatiskVedtaksbrev(
             new VedtaksbrevGenerererInput(behandling.getId(), vedtaksbrev, totalresultater.detaljertResultatTimeline(), false));
 
-        journalføringOgDistribusjonsTjeneste.journalførOgDistribuer(behandling, brevbestilling, generertBrev);
+        journalføringOgDistribusjonsTjeneste.journalførOgDistribuerISekvens(behandling, brevbestilling, generertBrev);
     }
 
 }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/bestilling/JournalføringOgDistribusjonsTjenesteTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/bestilling/JournalføringOgDistribusjonsTjenesteTest.java
@@ -85,7 +85,7 @@ class JournalføringOgDistribusjonsTjenesteTest {
             generertBrev.malType()
         );
 
-        journalføringOgDistribusjonsTjeneste.journalførOgDistribuer(behandling, bestilling1, generertBrev);
+        journalføringOgDistribusjonsTjeneste.journalførOgDistribuerISekvens(behandling, bestilling1, generertBrev);
 
 
         var bestilling = brevbestillingRepository.hentForBehandling(behandling.getId()).getFirst();
@@ -127,7 +127,7 @@ class JournalføringOgDistribusjonsTjenesteTest {
             generertBrev.malType()
         );
 
-        journalføringOgDistribusjonsTjeneste.journalførOgDistribuer(behandling, bestilling1, generertBrev);
+        journalføringOgDistribusjonsTjeneste.journalførOgDistribuerISekvens(behandling, bestilling1, generertBrev);
 
 
         var bestilling = brevbestillingRepository.hentForBehandling(behandling.getId()).getFirst();


### PR DESCRIPTION
### **Behov / Bakgrunn**
Hvis utsending av et vedtaksbrev feiler så stopper ikke det fremtidige vedtaksbrev. Hvis brevene kommer i feil rekkefølge kan det være svært misvisende for bruker.  
### **Løsning**
Kjører vedtaksbrev i egen prosesstask gruppe basert på tidstempel og fagsakid som sekvensnr slik at de havner i riktig rekkefølge pr fagsak. Holder informasjonsbrev utenfor fordi det kan være relevant å sende de uavhengig av vedtaksbrevene
