### PR TITLE
Oppretter egen task for inntektskontroll av måned og legger på validering av dato

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
@@ -27,19 +27,14 @@ import static no.nav.ung.sak.behandling.revurdering.OpprettRevurderingEllerOppre
 public class OpprettRevurderingForInntektskontrollBatchTask implements ProsessTaskHandler {
 
     public static final String TASKNAME = "batch.opprettRevurderingForInntektskontrollBatch";
-
-    private static final Logger log = LoggerFactory.getLogger(OpprettRevurderingForInntektskontrollBatchTask.class);
-
     private ProsessTaskTjeneste prosessTaskTjeneste;
-    private FinnSakerForInntektkontroll finnRelevanteFagsaker;
 
     OpprettRevurderingForInntektskontrollBatchTask() {
     }
 
     @Inject
-    public OpprettRevurderingForInntektskontrollBatchTask(ProsessTaskTjeneste prosessTaskTjeneste, FinnSakerForInntektkontroll finnRelevanteFagsaker) {
+    public OpprettRevurderingForInntektskontrollBatchTask(ProsessTaskTjeneste prosessTaskTjeneste) {
         this.prosessTaskTjeneste = prosessTaskTjeneste;
-        this.finnRelevanteFagsaker = finnRelevanteFagsaker;
     }
 
 
@@ -47,49 +42,10 @@ public class OpprettRevurderingForInntektskontrollBatchTask implements ProsessTa
     public void doTask(ProsessTaskData prosessTaskData) {
         var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
         var tom = LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
-        final var fagsaker = finnRelevanteFagsaker.finnFagsaker(fom, tom);
-        opprettProsessTaskerForÅSetteInntektrapporteringTilUtløpt(fagsaker, fom, tom);
-        opprettKontrollProsessTasker(fagsaker, fom, tom);
+        ProsessTaskData kontrollTask = ProsessTaskData.forProsessTask(OpprettRevurderingForInntektskontrollTask.class);
+        kontrollTask.setProperty(PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        kontrollTask.setProperty(PERIODE_TOM, tom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        prosessTaskTjeneste.lagre(kontrollTask);
     }
-
-
-    private void opprettKontrollProsessTasker(List<Fagsak> fagsakerForKontroll, LocalDate fom, LocalDate tom) {
-        ProsessTaskGruppe taskGruppeTilRevurderinger = new ProsessTaskGruppe();
-
-        var revurderTasker = fagsakerForKontroll
-            .stream()
-            .map(fagsak -> {
-                log.info("Oppretter revurdering for fagsak med saksnummer {} for inntektskontroll av periode {} - {}", fagsak.getSaksnummer(), fom, tom);
-
-                ProsessTaskData tilVurderingTask = ProsessTaskData.forProsessTask(OpprettRevurderingEllerOpprettDiffTask.class);
-                tilVurderingTask.setFagsakId(fagsak.getId());
-                tilVurderingTask.setProperty(PERIODER, fom + "/" + tom);
-                tilVurderingTask.setProperty(BEHANDLING_ÅRSAK, BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT.getKode());
-                return tilVurderingTask;
-            }).toList();
-
-        taskGruppeTilRevurderinger.addNesteParallell(revurderTasker);
-        prosessTaskTjeneste.lagre(taskGruppeTilRevurderinger);
-    }
-
-
-    private void opprettProsessTaskerForÅSetteInntektrapporteringTilUtløpt(List<Fagsak> fagsakerForKontroll, LocalDate fom, LocalDate tom) {
-        ProsessTaskGruppe taskGruppeTilRevurderinger = new ProsessTaskGruppe();
-
-        var revurderTasker = fagsakerForKontroll
-            .stream()
-            .map(fagsak -> {
-                log.info("Setter inntektrapportering til utløpt for fagsak med saksnummer {} og periode {} - {}", fagsak.getSaksnummer(), fom, tom);
-                ProsessTaskData tilVurderingTask = ProsessTaskData.forProsessTask(SettOppgaveUtløptForInntektsrapporteringTask.class);
-                tilVurderingTask.setAktørId(fagsak.getAktørId().getAktørId());
-                tilVurderingTask.setProperty(SettOppgaveUtløptForInntektsrapporteringTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
-                tilVurderingTask.setProperty(SettOppgaveUtløptForInntektsrapporteringTask.PERIODE_TOM, tom.format(DateTimeFormatter.ISO_LOCAL_DATE));
-                return tilVurderingTask;
-            }).toList();
-
-        taskGruppeTilRevurderinger.addNesteParallell(revurderTasker);
-        prosessTaskTjeneste.lagre(taskGruppeTilRevurderinger);
-    }
-
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollTask.java
@@ -1,0 +1,105 @@
+package no.nav.ung.sak.behandling.revurdering.inntektskontroll;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
+import no.nav.k9.prosesstask.api.*;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.sak.behandling.revurdering.OpprettRevurderingEllerOpprettDiffTask;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static no.nav.ung.sak.behandling.revurdering.OpprettRevurderingEllerOpprettDiffTask.BEHANDLING_ÅRSAK;
+import static no.nav.ung.sak.behandling.revurdering.OpprettRevurderingEllerOpprettDiffTask.PERIODER;
+
+
+/**
+ * Task som starter kontroll av inntekt fra a-inntekt
+ */
+@ApplicationScoped
+@ProsessTask(value = OpprettRevurderingForInntektskontrollTask.TASKNAME, maxFailedRuns = 1)
+public class OpprettRevurderingForInntektskontrollTask implements ProsessTaskHandler {
+
+    public static final String TASKNAME = "batch.opprettRevurderingForInntektskontroll";
+
+    public static final String PERIODE_FOM = "fom";
+    public static final String PERIODE_TOM = "tom";
+
+    private static final Logger log = LoggerFactory.getLogger(OpprettRevurderingForInntektskontrollTask.class);
+
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    private FinnSakerForInntektkontroll finnRelevanteFagsaker;
+    private int inntektskontrollDagIMåned;
+
+    OpprettRevurderingForInntektskontrollTask() {
+    }
+
+    @Inject
+    public OpprettRevurderingForInntektskontrollTask(
+        ProsessTaskTjeneste prosessTaskTjeneste,
+        FinnSakerForInntektkontroll finnRelevanteFagsaker,
+        @KonfigVerdi(value = "INNTEKTSKONTROLL_DAG_I_MAANED", defaultVerdi = "1") int inntektskontrollDagIMåned) {
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
+        this.finnRelevanteFagsaker = finnRelevanteFagsaker;
+        this.inntektskontrollDagIMåned = inntektskontrollDagIMåned;
+    }
+
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        final var fom = LocalDate.parse(prosessTaskData.getPropertyValue(PERIODE_FOM), DateTimeFormatter.ISO_LOCAL_DATE);
+        if (LocalDate.now().isBefore(fom.plusMonths(1).withDayOfMonth(inntektskontrollDagIMåned))) {
+            throw new IllegalStateException("Kan ikke kjøre inntektskontroll for periode før den åttende i måneden etter perioden: " + fom);
+        }
+        final var tom = LocalDate.parse(prosessTaskData.getPropertyValue(PERIODE_TOM), DateTimeFormatter.ISO_LOCAL_DATE);
+        final var fagsaker = finnRelevanteFagsaker.finnFagsaker(fom, tom);
+        opprettProsessTaskerForÅSetteInntektrapporteringTilUtløpt(fagsaker, fom, tom);
+        opprettKontrollProsessTasker(fagsaker, fom, tom);
+    }
+
+
+    private void opprettKontrollProsessTasker(List<Fagsak> fagsakerForKontroll, LocalDate fom, LocalDate tom) {
+        ProsessTaskGruppe taskGruppeTilRevurderinger = new ProsessTaskGruppe();
+
+        var revurderTasker = fagsakerForKontroll
+            .stream()
+            .map(fagsak -> {
+                log.info("Oppretter revurdering for fagsak med saksnummer {} for inntektskontroll av periode {} - {}", fagsak.getSaksnummer(), fom, tom);
+
+                ProsessTaskData tilVurderingTask = ProsessTaskData.forProsessTask(OpprettRevurderingEllerOpprettDiffTask.class);
+                tilVurderingTask.setFagsakId(fagsak.getId());
+                tilVurderingTask.setProperty(PERIODER, fom + "/" + tom);
+                tilVurderingTask.setProperty(BEHANDLING_ÅRSAK, BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT.getKode());
+                return tilVurderingTask;
+            }).toList();
+
+        taskGruppeTilRevurderinger.addNesteParallell(revurderTasker);
+        prosessTaskTjeneste.lagre(taskGruppeTilRevurderinger);
+    }
+
+
+    private void opprettProsessTaskerForÅSetteInntektrapporteringTilUtløpt(List<Fagsak> fagsakerForKontroll, LocalDate fom, LocalDate tom) {
+        ProsessTaskGruppe taskGruppeTilRevurderinger = new ProsessTaskGruppe();
+
+        var revurderTasker = fagsakerForKontroll
+            .stream()
+            .map(fagsak -> {
+                log.info("Setter inntektrapportering til utløpt for fagsak med saksnummer {} og periode {} - {}", fagsak.getSaksnummer(), fom, tom);
+                ProsessTaskData tilVurderingTask = ProsessTaskData.forProsessTask(SettOppgaveUtløptForInntektsrapporteringTask.class);
+                tilVurderingTask.setAktørId(fagsak.getAktørId().getAktørId());
+                tilVurderingTask.setProperty(SettOppgaveUtløptForInntektsrapporteringTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+                tilVurderingTask.setProperty(SettOppgaveUtløptForInntektsrapporteringTask.PERIODE_TOM, tom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+                return tilVurderingTask;
+            }).toList();
+
+        taskGruppeTilRevurderinger.addNesteParallell(revurderTasker);
+        prosessTaskTjeneste.lagre(taskGruppeTilRevurderinger);
+    }
+
+
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Kontroll av ein måned burde ikkje vere avhengig av at tidligere kontroller har blitt kjørt uten å feile og periode for kontroll burde ikkje vere direkte avhengig av måned som batchtasken ble ferdig i.

Flytter kompleksitet ut i egen task for bedre feilhåndtering og enklere validering.
