### PR TITLE
Update pom.xml med nyeste teamdokumenthandtering-avro-schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
             <dependency>
                 <groupId>no.nav.teamdokumenthandtering</groupId>
                 <artifactId>teamdokumenthandtering-avro-schemas</artifactId>
-                <version>08271806</version>
+                <version>1.1.6</version>
             </dependency>
 
 


### PR DESCRIPTION
Hei! 
Dere bruker en gammel versjon av teamdokumenthandtering-avro-schemas. Vi brukte tidligere git short hash til å identifisere versjon, men dette skaper krøll for Dependabot som ikke forstår hva som er nyeste versjon. Vi har gått over til semver og vil at dere oppdaterer slik at vi kan slette de gamle releasene og Dependabot foreslår riktig versjon for oppdateringer.
Kan dere sjekke at oppdatering til siste versjon av teamdokumenthandtering-avro-schemas går fint og ta det i bruk?