### PR TITLE
Legger til lenker og proxy for tjeneste i k9-oppdrag som oppsummerer hva som sendes til oppdrag

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/simulering/klient/K9OppdragRestKlient.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/ung/sak/økonomi/simulering/klient/K9OppdragRestKlient.java
@@ -9,6 +9,7 @@ import no.nav.k9.oppdrag.kontrakt.BehandlingReferanseDomene;
 import no.nav.k9.oppdrag.kontrakt.Domene;
 import no.nav.k9.oppdrag.kontrakt.SaksnummerDomene;
 import no.nav.k9.oppdrag.kontrakt.aktørbytte.ByttAktørRequest;
+import no.nav.k9.oppdrag.kontrakt.oppsummering.OppsummeringDto;
 import no.nav.k9.oppdrag.kontrakt.simulering.v1.SimuleringDto;
 import no.nav.k9.oppdrag.kontrakt.simulering.v1.SimuleringResultatDto;
 import no.nav.k9.oppdrag.kontrakt.tilkjentytelse.TilkjentYtelseOppdrag;
@@ -41,6 +42,7 @@ public class K9OppdragRestKlient {
     private URI uriAlleOppdragXmler;
     private URI uriDetaljertSimuleringResultat;
     private URI uriKansellerSimulering;
+    private URI uriOppsummering;
 
     public K9OppdragRestKlient() {
     }
@@ -57,6 +59,7 @@ public class K9OppdragRestKlient {
         this.uriAlleOppdragXmler = tilUri(urlK9Oppdrag, "iverksett/forvaltning/hent-oppdrag-xmler");
         this.uriDetaljertSimuleringResultat = tilUri(urlK9Oppdrag, "simulering/v2/detaljert-resultat");
         this.uriKansellerSimulering = tilUri(urlK9Oppdrag, "simulering/v2/kanseller");
+        this.uriOppsummering = tilUri(urlK9Oppdrag, "oppsummering/v2/oppsummering");
 
         //avviker fra @Inject av OidcRestClient fordi det trengs lenger timeout enn normalt mot k9-oppdrag pga simuleringer som tar lang tid (over 20 sekunder) når det er mange perioder
         restClient = new K9OppdragRestClientConfig().createOidcRestClient(tokenProvider, k9OppdragScope);
@@ -98,6 +101,12 @@ public class K9OppdragRestKlient {
         BehandlingReferanse behandlingreferanse = new BehandlingReferanse(behandlingUuid);
         BehandlingReferanseDomene behandlingReferanseDomene = new BehandlingReferanseDomene(behandlingreferanse, DOMENE);
         restClient.post(uriKansellerSimulering, behandlingReferanseDomene);
+    }
+
+    public OppsummeringDto hentOppsummering(UUID behandlingUuid) {
+        BehandlingReferanse behandlingreferanse = new BehandlingReferanse(behandlingUuid);
+        BehandlingReferanseDomene behandlingReferanseDomene = new BehandlingReferanseDomene(behandlingreferanse, DOMENE);
+        return restClient.post(uriOppsummering, behandlingReferanseDomene, OppsummeringDto.class);
     }
 
     public List<OppdragXmlDto> alleOppdragXmler(Saksnummer saksnummer) {

--- a/web/src/main/java/no/nav/ung/sak/web/app/proxy/oppdrag/OppdragProxyRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/proxy/oppdrag/OppdragProxyRestTjeneste.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.k9.felles.sikkerhet.abac.TilpassetAbacAttributt;
+import no.nav.k9.oppdrag.kontrakt.oppsummering.OppsummeringDto;
 import no.nav.k9.oppdrag.kontrakt.simulering.v1.SimuleringDto;
 import no.nav.ung.abac.BeskyttetRessursKoder;
 import no.nav.ung.sak.kontrakt.behandling.BehandlingUuidDto;
@@ -27,6 +28,7 @@ import static no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionAttributt.RE
 public class OppdragProxyRestTjeneste {
 
     public static final String SIMULERING_RESULTAT_URL = "/proxy/oppdrag/simulering/detaljert-resultat";
+    public static final String OPPSUMMERING_URL = "/proxy/oppdrag/oppsummering/v2/oppsummering";
 
     private K9OppdragRestKlient restKlient;
 
@@ -45,6 +47,15 @@ public class OppdragProxyRestTjeneste {
     @BeskyttetRessurs(action = READ, resource = BeskyttetRessursKoder.FAGSAK)
     public Optional<SimuleringDto> hentSimuleringResultat(@NotNull @QueryParam(BehandlingUuidDto.NAME) @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) BehandlingUuidDto behandlingIdDto) {
         return restKlient.hentDetaljertSimuleringResultat(behandlingIdDto.getBehandlingUuid());
+    }
+
+
+    @GET
+    @Path("/simulering/oppsummering/v2/oppsummering")
+    @Operation(description = "Viser oppsummering av hva som sendes til OS. Både totalt opp til og med behandlingen, og differanse mot hva som fantes før behandlingen", summary = ("Oppsummering av hva som sendes til OS"), tags = "oppsummering")
+    @BeskyttetRessurs(action = READ, resource = BeskyttetRessursKoder.FAGSAK)
+    public OppsummeringDto hentOppdragOppsummering(@NotNull @QueryParam(BehandlingUuidDto.NAME) @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) BehandlingUuidDto behandlingIdDto) {
+        return restKlient.hentOppsummering(behandlingIdDto.getBehandlingUuid());
     }
 
 }

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/BehandlingDtoTjeneste.java
@@ -120,6 +120,9 @@ public class BehandlingDtoTjeneste {
         }
         dto.leggTil(getFraMap(PerioderTilBehandlingMedKildeRestTjeneste.BEHANDLING_PERIODER, "behandling-perioder-årsak", uuidQueryParams));
         dto.leggTil(getFraMap(PerioderTilBehandlingMedKildeRestTjeneste.BEHANDLING_PERIODER_MED_VILKÅR, "behandling-perioder-årsak-med-vilkår", uuidQueryParams));
+        if (behandling.erYtelseBehandling()){
+            dto.leggTil(get(OppdragProxyRestTjeneste.OPPSUMMERING_URL, "oppdrag-oppsummering", uuidQueryParams));
+        }
     }
 
     private void leggTilHandlingerResourceLinks(Behandling behandling, BehandlingDto dto) {


### PR DESCRIPTION
### **Behov / Bakgrunn**

Tjenesten skal i første omgang brukes fra ung-tilbake for å unngå å sette behandlinger der på vent. Grunnen til å ikke kalle direkte er at tjenesten i k9-tilbake som henter data baserer seg på HATEOS-lenkene

### **Løsning**

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
