### PR TITLE
TSFF-2076: Innhente nye inntektsopplysninger daglig for behandlinger som venter på svar på varsel

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
@@ -39,15 +39,16 @@ public class OppfriskInntektForBehandlingerPåVentBatchTask implements ProsessTa
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
         // finn alle behandlinger som er på vent og ikke har blitt oppfrisket de siste 24 timene
-        final Query q = entityManager.createNativeQuery("select b.* from behandling b " +
-            "inner join fagsak f on f.id = b.fagsak_id " +
-            "inner join behandling_arsak ba on ba.behandling_id = b.id " +
-            "inner join aksjonspunkt ap on ap.behandling_id = b.id " +
-            "where b.behandling_status = 'UTRED' " +
-            "and ba.behandling_arsak_type = 'RE_KONTROLL_REGISTER_INNTEKT' " +
-            "and ap.aksjonspunkt_status = 'OPPRE' " +
-            "and ap.vent_aarsak = 'AUTO_SATT_PÅ_VENT_ETTERLYST_INNTEKTUTTALELSE'",
-            Behandling.class);
+        final Query q = entityManager.createNativeQuery("select b.* " +
+                    "from behandling b " +
+                    "inner join behandling_arsak ba on ba.behandling_id = b.id " +
+                    "inner join aksjonspunkt ap on ap.behandling_id = b.id " +
+                    "where behandling_status = 'UTRED' " +
+                    "and behandling_arsak_type = 'RE-KONTROLL-REGISTER-INNTEKT' " +
+                    "and aksjonspunkt_def = '7040' " +
+                    "and aksjonspunkt_status = 'OPPRE' " +
+                    "and vent_aarsak = 'VENTER_ETTERLYS_INNTEKT_UTTALELSE'",
+                    Behandling.class);
         final List<Behandling> behandlinger = q.getResultList();
 
         // opprett oppfrisk-tasker for alle behandlingene funnet

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
@@ -1,0 +1,81 @@
+package no.nav.ung.sak.behandling.prosessering.task;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import no.nav.k9.prosesstask.api.*;
+import no.nav.ung.sak.behandling.prosessering.ProsesseringAsynkTjeneste;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+@ProsessTask(value = OppfriskInntektForBehandlingerPåVentBatchTask.TASKTYPE, cronExpression = "0 0 20 * * MON-FRI")
+public class OppfriskInntektForBehandlingerPåVentBatchTask implements ProsessTaskHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(OppfriskInntektForBehandlingerPåVentBatchTask.class);
+
+    public static final String TASKTYPE = "ung.oppfrisk.inntekt.påvent";
+
+    private EntityManager entityManager;
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    private ProsesseringAsynkTjeneste prosesseringAsynkTjeneste;
+
+    public OppfriskInntektForBehandlingerPåVentBatchTask() {}
+
+    @Inject
+    public OppfriskInntektForBehandlingerPåVentBatchTask(EntityManager entityManager,
+                                                         ProsessTaskTjeneste prosessTaskTjeneste,
+                                                         ProsesseringAsynkTjeneste prosesseringAsynkTjeneste) {
+        this.entityManager = entityManager;
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
+        this.prosesseringAsynkTjeneste = prosesseringAsynkTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        // finn alle behandlinger som er på vent og ikke har blitt oppfrisket de siste 24 timene
+        final Query q = entityManager.createNativeQuery("select b.* from behandling b " +
+            "inner join fagsak f on f.id = b.fagsak_id " +
+            "inner join behandling_arsak ba on ba.behandling_id = b.id " +
+            "inner join aksjonspunkt ap on ap.behandling_id = b.id " +
+            "where b.behandling_status = 'UTRED' " +
+            "and ba.behandling_arsak_type = 'RE_KONTROLL_REGISTER_INNTEKT' " +
+            "and ap.aksjonspunkt_status = 'OPPRE' " +
+            "and ap.vent_aarsak = 'AUTO_SATT_PÅ_VENT_ETTERLYST_INNTEKTUTTALELSE'",
+            Behandling.class);
+        final List<Behandling> behandlinger = q.getResultList();
+
+        // opprett oppfrisk-tasker for alle behandlingene funnet
+        if (behandlinger.isEmpty()) {
+            log.info("Ingen behandlinger på vent som skal oppfriskes");
+            return;
+        }
+        log.info("Starter asynk oppfrisk av inntekt for" + behandlinger.size() + "behandlinger på vent");
+        opprettTaskerForOppfrisking(behandlinger);
+    }
+
+    private void opprettTaskerForOppfrisking(List<Behandling> behandlinger) {
+        final ProsessTaskGruppe gruppe = new ProsessTaskGruppe();
+        for (Behandling behandling : behandlinger) {
+            if (behandling.isBehandlingPåVent() && !harPågåendeEllerFeiletTask(behandling)) {
+                log.info("oppfrisker behandling " + behandling.getId());
+                final ProsessTaskData oppfriskTaskData = OppfriskTask.create(behandling, false);
+                gruppe.addNesteParallell(oppfriskTaskData);
+            } else {
+                log.info("oppfrisker ikke behandling " + behandling.getId());
+            }
+        }
+        String gruppeId = prosessTaskTjeneste.lagre(gruppe);
+        log.info("Lagret oppfrisk-tasker i taskgruppe [{}]", gruppeId);
+    }
+
+    private boolean harPågåendeEllerFeiletTask(Behandling behandling) {
+        Map<String, ProsessTaskData> nesteTask = prosesseringAsynkTjeneste.sjekkProsessTaskPågårForBehandling(behandling, null);
+        return !nesteTask.isEmpty();
+    }
+}

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @ApplicationScoped
-@ProsessTask(value = OppfriskInntektForBehandlingerPåVentBatchTask.TASKTYPE, cronExpression = "0 0 20 * * MON-FRI")
+@ProsessTask(value = OppfriskInntektForBehandlingerPåVentBatchTask.TASKTYPE, cronExpression = "0 0 12 * * *")
 public class OppfriskInntektForBehandlingerPåVentBatchTask implements ProsessTaskHandler {
 
     private static final Logger log = LoggerFactory.getLogger(OppfriskInntektForBehandlingerPåVentBatchTask.class);

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.k9.prosesstask.api.*;
 import no.nav.ung.sak.behandling.prosessering.ProsesseringAsynkTjeneste;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -20,24 +21,34 @@ public class OppfriskInntektForBehandlingerPåVentBatchTask implements ProsessTa
     private static final Logger log = LoggerFactory.getLogger(OppfriskInntektForBehandlingerPåVentBatchTask.class);
 
     public static final String TASKTYPE = "ung.oppfrisk.inntekt.påvent";
+    private final boolean oppfriskKontrollbehandlingEnabled;
 
     private EntityManager entityManager;
     private ProsessTaskTjeneste prosessTaskTjeneste;
     private ProsesseringAsynkTjeneste prosesseringAsynkTjeneste;
 
-    public OppfriskInntektForBehandlingerPåVentBatchTask() {}
+    public OppfriskInntektForBehandlingerPåVentBatchTask(@KonfigVerdi(value = "OPPFRISK_KONTROLLBEHANDLING_ENABLED", required = false, defaultVerdi = "false") boolean oppfriskKontrollbehandlingEnabled) {
+        this.oppfriskKontrollbehandlingEnabled = oppfriskKontrollbehandlingEnabled;
+    }
 
     @Inject
     public OppfriskInntektForBehandlingerPåVentBatchTask(EntityManager entityManager,
                                                          ProsessTaskTjeneste prosessTaskTjeneste,
-                                                         ProsesseringAsynkTjeneste prosesseringAsynkTjeneste) {
+                                                         ProsesseringAsynkTjeneste prosesseringAsynkTjeneste,
+                                                         @KonfigVerdi(value = "OPPFRISK_KONTROLLBEHANDLING_ENABLED", required = false, defaultVerdi = "false") boolean oppfriskKontrollbehandlingEnabled) {
         this.entityManager = entityManager;
         this.prosessTaskTjeneste = prosessTaskTjeneste;
         this.prosesseringAsynkTjeneste = prosesseringAsynkTjeneste;
+        this.oppfriskKontrollbehandlingEnabled = oppfriskKontrollbehandlingEnabled;
     }
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
+        if (!oppfriskKontrollbehandlingEnabled) {
+            log.info("Oppfrisk av kontrollbehandling er ikke aktivert, avslutter task");
+            return;
+        }
+
         // finn alle behandlinger som er på vent og ikke har blitt oppfrisket de siste 24 timene
         final Query q = entityManager.createNativeQuery("select b.* " +
                     "from behandling b " +

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/task/OppfriskInntektForBehandlingerPåVentBatchTask.java
@@ -21,14 +21,13 @@ public class OppfriskInntektForBehandlingerPåVentBatchTask implements ProsessTa
     private static final Logger log = LoggerFactory.getLogger(OppfriskInntektForBehandlingerPåVentBatchTask.class);
 
     public static final String TASKTYPE = "ung.oppfrisk.inntekt.påvent";
-    private final boolean oppfriskKontrollbehandlingEnabled;
+    private boolean oppfriskKontrollbehandlingEnabled;
 
     private EntityManager entityManager;
     private ProsessTaskTjeneste prosessTaskTjeneste;
     private ProsesseringAsynkTjeneste prosesseringAsynkTjeneste;
 
-    public OppfriskInntektForBehandlingerPåVentBatchTask(@KonfigVerdi(value = "OPPFRISK_KONTROLLBEHANDLING_ENABLED", required = false, defaultVerdi = "false") boolean oppfriskKontrollbehandlingEnabled) {
-        this.oppfriskKontrollbehandlingEnabled = oppfriskKontrollbehandlingEnabled;
+    public OppfriskInntektForBehandlingerPåVentBatchTask() {
     }
 
     @Inject


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi henter bare nye registerdata når det kommer inn nye dokumenter eller hendelser. Ligger saken på vent, hentes det ikke noe nytt. Dermed kan vi ende opp med å be bruker bekrefte et avvik basert på utdaterte (ikke lenger gyldige) registeropplysninger.

### **Løsning**
For alle kontrollbehandlinger som står på vent pga varsel om avvik mot registeropplysninger for inntekt, innhente vi hver dag nye inntektsopplysninger og eventuelt oppdatere varselet dersom disse endres.