### PR TITLE
Bump saksnummersekvens

### DIFF
--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_060__bumpe_saksnummer_sekvense.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_060__bumpe_saksnummer_sekvense.sql
@@ -1,1 +1,2 @@
+-- Tilfeldig valgt startverdi for sekvensen som ligger langt foran sekvensen for k9-sak for å unngå kollisjon med eksisterende saksnummer k9-sak
 ALTER SEQUENCE seq_saksnummer RESTART WITH 35038750;


### PR DESCRIPTION
Bumper saksnummersekvensen slik at saksnummer i k9-sak og ung-sak ikkje overlapper
