### PR TITLE
Tsff 1205 kun kontroller inntekt skal redigeres

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevTjeneste.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevTjeneste.java
@@ -150,16 +150,18 @@ public class VedtaksbrevTjeneste {
 
         var vedtaksbrevEgenskaper = vedtaksbrev.vedtaksbrevEgenskaper();
 
-        if (!vedtaksbrevEgenskaper.kanRedigere() && dto.redigert() != null) {
+        boolean redigert = Boolean.TRUE.equals(dto.redigert());
+        if (!vedtaksbrevEgenskaper.kanRedigere() && redigert) {
             throw new IllegalArgumentException("Brevet kan ikke redigeres.");
         }
 
-        if (!vedtaksbrevEgenskaper.kanHindre() && dto.hindret() != null) {
+        boolean hindret = Boolean.TRUE.equals(dto.hindret());
+        if (!vedtaksbrevEgenskaper.kanHindre() && hindret) {
             throw new IllegalArgumentException("Brevet kan ikke hindres. ");
         }
 
-        vedtaksbrevValgEntitet.setHindret(Boolean.TRUE.equals(dto.hindret()));
-        vedtaksbrevValgEntitet.setRedigert(Boolean.TRUE.equals(dto.redigert()));
+        vedtaksbrevValgEntitet.setHindret(hindret);
+        vedtaksbrevValgEntitet.setRedigert(redigert);
         vedtaksbrevValgEntitet.rensOgSettRedigertHtml(dto.redigertHtml());
 
         LOG.info("Lagrer vedtaksbrevvalg for dokumentMalType={} med verdier redigert={} hindret={} redigertHtml={}",

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/VedtaksbrevRegelResultat.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/VedtaksbrevRegelResultat.java
@@ -9,19 +9,6 @@ import no.nav.ung.sak.formidling.innhold.VedtaksbrevInnholdBygger;
 public sealed interface VedtaksbrevRegelResultat permits IngenBrev, Vedtaksbrev {
     String forklaring();
 
-    static Vedtaksbrev automatiskBrev(DokumentMalType dokumentMalType, VedtaksbrevInnholdBygger bygger, String forklaring, boolean kanRedigere) {
-        return new Vedtaksbrev(
-                dokumentMalType,
-                bygger,
-                new VedtaksbrevEgenskaper(
-                        kanRedigere,
-                        kanRedigere,
-                        kanRedigere,
-                        kanRedigere
-                ),
-            forklaring);
-    }
-
     static Vedtaksbrev tomRedigerbarBrev(VedtaksbrevInnholdBygger bygger, String forklaring) {
         return new Vedtaksbrev(
             DokumentMalType.MANUELT_VEDTAK_DOK,

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/VedtaksbrevRegler.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/VedtaksbrevRegler.java
@@ -76,7 +76,7 @@ public class VedtaksbrevRegler {
             .toList();
 
         if (!automatiskBrevResultat.isEmpty()) {
-            var automatiskVedtaksbrevResultater = byggAutomatiskVedtaksbrevResultat(automatiskBrevResultat, redigerRegelResultat);
+            var automatiskVedtaksbrevResultater = byggAutomatiskVedtaksbrevResultat(automatiskBrevResultat);
             return BehandlingVedtaksbrevResultat.medBrev(detaljertResultat, automatiskVedtaksbrevResultater);
         }
 
@@ -126,20 +126,18 @@ public class VedtaksbrevRegler {
     }
 
 
-    private static List<Vedtaksbrev> byggAutomatiskVedtaksbrevResultat(
-        List<VedtaksbrevStrategyResultat> resultat,
-        RedigerRegelResultat redigerRegelResultat) {
-
+    private static List<Vedtaksbrev> byggAutomatiskVedtaksbrevResultat(List<VedtaksbrevStrategyResultat> resultat) {
         return resultat.stream()
-            .map(it -> {
-                String forklaring = it.forklaring() + (redigerRegelResultat.kanRedigere() ? " Kan redigeres pga " + redigerRegelResultat.forklaring() : "");
-                    return VedtaksbrevRegelResultat
-                        .automatiskBrev(
-                            it.dokumentMalType(),
-                            it.bygger(),
-                            forklaring,
-                            redigerRegelResultat.kanRedigere());
-                }
+            .map(it -> new Vedtaksbrev(
+                it.dokumentMalType(),
+                it.bygger(),
+                new VedtaksbrevEgenskaper(
+                    it.kanHindre(),
+                    it.kanHindre(),
+                    it.kanRedigere(),
+                    it.kanRedigere()
+                ),
+                it.forklaring())
             ).toList();
     }
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringBarnetilleggStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringBarnetilleggStrategy.java
@@ -21,7 +21,7 @@ public final class EndringBarnetilleggStrategy implements VedtaksbrevInnholdbygg
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
-        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_BARNETILLEGG, endringBarnetilleggInnholdBygger, "Automatisk brev ved fødsel av barn.");
+        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_BARNETILLEGG, false, endringBarnetilleggInnholdBygger, "Automatisk brev ved fødsel av barn.");
     }
 
     @Override

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringHøySatsStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringHøySatsStrategy.java
@@ -21,7 +21,7 @@ public final class EndringHøySatsStrategy implements VedtaksbrevInnholdbyggerSt
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
-        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_HØY_SATS, endringHøySatsInnholdBygger, "Automatisk brev ved endring til høy sats.");
+        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_HØY_SATS, false, endringHøySatsInnholdBygger, "Automatisk brev ved endring til høy sats.");
     }
 
     @Override

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringInntektReduksjonStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringInntektReduksjonStrategy.java
@@ -3,8 +3,10 @@ package no.nav.ung.sak.formidling.vedtak.regler.strategy;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.ung.kodeverk.dokument.DokumentMalType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.ung.sak.formidling.innhold.EndringRapportertInntektInnholdBygger;
 import no.nav.ung.sak.formidling.vedtak.resultat.DetaljertResultat;
 import no.nav.ung.sak.formidling.vedtak.resultat.DetaljertResultatType;
@@ -21,8 +23,18 @@ public final class EndringInntektReduksjonStrategy implements VedtaksbrevInnhold
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
+        boolean harUtførtKontrollerInntekt = behandling.getAksjonspunkterMedTotrinnskontroll().stream()
+            .filter(Aksjonspunkt::erUtført)
+            .anyMatch(it -> it.getAksjonspunktDefinisjon() == AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
 
-        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_INNTEKT, false, endringRapportertInntektInnholdBygger, "Automatisk brev ved endring av rapportert inntekt.");
+        var forklaring = "Automatisk brev ved endring av rapportert inntekt. ";
+        if (harUtførtKontrollerInntekt) {
+            forklaring += "Kan redigere pga ap " + AksjonspunktDefinisjon.KONTROLLER_INNTEKT.getKode() + ".";
+        }
+        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_INNTEKT,
+            harUtførtKontrollerInntekt,
+            endringRapportertInntektInnholdBygger,
+            forklaring);
     }
 
     @Override

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringInntektReduksjonStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringInntektReduksjonStrategy.java
@@ -21,7 +21,8 @@ public final class EndringInntektReduksjonStrategy implements VedtaksbrevInnhold
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
-        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_INNTEKT, endringRapportertInntektInnholdBygger, "Automatisk brev ved endring av rapportert inntekt.");
+
+        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_INNTEKT, false, endringRapportertInntektInnholdBygger, "Automatisk brev ved endring av rapportert inntekt.");
     }
 
     @Override

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringInntektReduksjonStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringInntektReduksjonStrategy.java
@@ -23,13 +23,13 @@ public final class EndringInntektReduksjonStrategy implements VedtaksbrevInnhold
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
-        boolean harUtførtKontrollerInntekt = behandling.getAksjonspunkterMedTotrinnskontroll().stream()
+        boolean harUtførtKontrollerInntekt = behandling.getAksjonspunkter().stream()
             .filter(Aksjonspunkt::erUtført)
             .anyMatch(it -> it.getAksjonspunktDefinisjon() == AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
 
-        var forklaring = "Automatisk brev ved endring av rapportert inntekt. ";
+        var forklaring = "Automatisk brev ved endring av rapportert inntekt.";
         if (harUtførtKontrollerInntekt) {
-            forklaring += "Kan redigere pga ap " + AksjonspunktDefinisjon.KONTROLLER_INNTEKT.getKode() + ".";
+            forklaring += " Kan redigere pga ap=" + AksjonspunktDefinisjon.KONTROLLER_INNTEKT.getKode() + ".";
         }
         return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_INNTEKT,
             harUtførtKontrollerInntekt,

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringProgramPeriodeStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/EndringProgramPeriodeStrategy.java
@@ -24,7 +24,7 @@ public final class EndringProgramPeriodeStrategy implements VedtaksbrevInnholdby
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
-        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_PROGRAMPERIODE, endringProgramPeriodeInnholdBygger, "Automatisk brev ved endring av programperiode");
+        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.ENDRING_PROGRAMPERIODE, false, endringProgramPeriodeInnholdBygger, "Automatisk brev ved endring av programperiode");
     }
 
     @Override

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/FørstegangsInnvilgelseStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/FørstegangsInnvilgelseStrategy.java
@@ -21,7 +21,7 @@ public final class FørstegangsInnvilgelseStrategy implements VedtaksbrevInnhold
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
-        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.INNVILGELSE_DOK, førstegangsInnvilgelseInnholdBygger, "Automatisk brev ved ny innvilgelse. ");
+        return VedtaksbrevStrategyResultat.medBrev(DokumentMalType.INNVILGELSE_DOK, false, førstegangsInnvilgelseInnholdBygger, "Automatisk brev ved ny innvilgelse. ");
     }
 
     @Override

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/OpphørStrategy.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/OpphørStrategy.java
@@ -29,7 +29,7 @@ public final class OpphørStrategy implements VedtaksbrevInnholdbyggerStrategy {
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
         return VedtaksbrevStrategyResultat.medBrev(
-            DokumentMalType.OPPHØR_DOK, opphørInnholdBygger,
+            DokumentMalType.OPPHØR_DOK, false, opphørInnholdBygger,
             "Automatisk brev ved opphør.");
     }
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/VedtaksbrevStrategyResultat.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/regler/strategy/VedtaksbrevStrategyResultat.java
@@ -7,26 +7,32 @@ import no.nav.ung.sak.formidling.vedtak.regler.IngenBrevÅrsakType;
 public record VedtaksbrevStrategyResultat(
     DokumentMalType dokumentMalType,
     VedtaksbrevInnholdBygger bygger,
-    String forklaring,
-    IngenBrevÅrsakType ingenBrevÅrsakType) {
+    boolean kanRedigere,
+    boolean kanHindre,
+    IngenBrevÅrsakType ingenBrevÅrsakType,
+    String forklaring
+) {
 
     public static VedtaksbrevStrategyResultat utenBrev(IngenBrevÅrsakType ingenBrevÅrsakType, String forklaring) {
         return new VedtaksbrevStrategyResultat(
             null,
             null,
-            forklaring,
-            ingenBrevÅrsakType);
+            false, false, ingenBrevÅrsakType, forklaring
+        );
     }
 
     public static VedtaksbrevStrategyResultat medBrev(
         DokumentMalType dokumentMalType,
-        VedtaksbrevInnholdBygger bygger,
+        boolean kanRedigere, VedtaksbrevInnholdBygger bygger,
         String forklaring) {
         return new VedtaksbrevStrategyResultat(
             dokumentMalType,
             bygger,
-            forklaring,
-            null);
+            kanRedigere,
+            false,
+            null,
+            forklaring
+        );
     }
 
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/resultat/DetaljertResultatType.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/resultat/DetaljertResultatType.java
@@ -2,7 +2,7 @@ package no.nav.ung.sak.formidling.vedtak.resultat;
 
 public enum DetaljertResultatType {
     AVSLAG_INNGANGSVILKÅR("Avslag inngangsvilkår"),
-    ENDRING_ØKT_SATS("Endring økt sats 25 prosent"),
+    ENDRING_ØKT_SATS("Endring økt sats"),
     ENDRING_BARN_FØDSEL("Endring pga fødsel av nytt barn"),
     KONTROLLER_INNTEKT_REDUKSJON("Reduksjon etter kontroll av inntekt"),
     KONTROLLER_INNTEKT_FULL_UTBETALING("Full utbetaling etter kontroll av inntekt"),

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/bestilling/VurderVedtaksbrevTaskTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/bestilling/VurderVedtaksbrevTaskTest.java
@@ -162,7 +162,7 @@ class VurderVedtaksbrevTaskTest {
 
         String redigertBrevHtml = "<h1>redigert</h1>";
         vedtaksbrevValgRepository.lagre(
-            new VedtaksbrevValgEntitet(behandling.getId(), DokumentMalType.ENDRING_BARNETILLEGG, true, false, redigertBrevHtml)
+            new VedtaksbrevValgEntitet(behandling.getId(), DokumentMalType.ENDRING_INNTEKT, true, false, redigertBrevHtml)
         );
 
 
@@ -176,7 +176,7 @@ class VurderVedtaksbrevTaskTest {
         assertThat(bestillinger).hasSize(2);
 
         var bestilling1 = bestillinger.stream()
-            .filter(b -> b.getDokumentMalType().equals(DokumentMalType.ENDRING_INNTEKT))
+            .filter(b -> b.getDokumentMalType().equals(DokumentMalType.ENDRING_BARNETILLEGG))
             .findFirst()
             .orElseThrow();
         assertThat(bestilling1.getStatus()).isEqualTo(BrevbestillingStatusType.NY);

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/scenarioer/EndringInntektScenarioer.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/scenarioer/EndringInntektScenarioer.java
@@ -232,7 +232,7 @@ public class EndringInntektScenarioer {
         assertThat(t.reduksjon()).isEqualByComparingTo("6600"); //66% av 10 0000
         assertThat(t.dagsats()).isEqualByComparingTo("362"); //649 - ((6600/22)  )
         assertThat(t.redusertBeløp()).isEqualByComparingTo("8328.8369336998"); // 14928.84 - 6600
-        assertThat(t.utbetalingsgrad()).isEqualTo(56); // 8328.84 / 14928.84 * 100
+        assertThat(t.utbetalingsgrad()).isEqualByComparingTo("55.7781201849"); // 8328.84 / 14928.84 * 100
 
     }
 }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/scenarioer/EndringInntektScenarioer.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/scenarioer/EndringInntektScenarioer.java
@@ -3,22 +3,15 @@ package no.nav.ung.sak.formidling.scenarioer;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
-import no.nav.ung.kodeverk.behandling.BehandlingResultatType;
-import no.nav.ung.kodeverk.behandling.BehandlingStegType;
-import no.nav.ung.kodeverk.behandling.BehandlingType;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.ung.kodeverk.vilkår.Utfall;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
-import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
-import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.AksjonspunktTestSupport;
-import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
 import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseVerdi;
 import no.nav.ung.sak.domene.iay.modell.OppgittOpptjeningBuilder;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.test.util.UngTestRepositories;
-import no.nav.ung.sak.test.util.behandling.TestScenarioBuilder;
 import no.nav.ung.sak.test.util.behandling.UngTestScenario;
 import no.nav.ung.sak.trigger.Trigger;
 import org.junit.jupiter.api.Test;
@@ -217,20 +210,12 @@ public class EndringInntektScenarioer {
             Collections.emptyList(), null);
     }
 
-    public static Behandling lagBehandlingMedAksjonspunktKontrollerInntekt(UngTestScenario ungTestscenario, UngTestRepositories ungTestRepositories1) {
-        TestScenarioBuilder scenarioBuilder = TestScenarioBuilder.builderMedSøknad()
-            .medBehandlingType(BehandlingType.REVURDERING)
-            .medUngTestGrunnlag(ungTestscenario);
+    public static Behandling lagBehandlingMedAksjonspunktKontrollerInntekt(UngTestScenario ungTestscenario, UngTestRepositories ungTestRepositories) {
+        return BrevScenarioerUtils.lagBehandlingMedAP(ungTestscenario, ungTestRepositories, AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
+    }
 
-        scenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.KONTROLLER_INNTEKT, BehandlingStegType.KONTROLLER_REGISTER_INNTEKT);
-
-        var behandling = scenarioBuilder.buildOgLagreMedUng(ungTestRepositories1);
-        behandling.setBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        Aksjonspunkt aksjonspunkt = behandling.getAksjonspunktFor(AksjonspunktDefinisjon.KONTROLLER_INNTEKT);
-        new AksjonspunktTestSupport().setTilUtført(aksjonspunkt, "utført");
-        BehandlingRepository behandlingRepository = ungTestRepositories1.repositoryProvider().getBehandlingRepository();
-        behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
-        return behandling;
+    public static Behandling lagBehandlingMedAksjonspunktVurderFeilutbetaling(UngTestScenario ungTestscenario, UngTestRepositories ungTestRepositories) {
+        return BrevScenarioerUtils.lagBehandlingMedAP(ungTestscenario, ungTestRepositories, AksjonspunktDefinisjon.VURDER_FEILUTBETALING);
     }
 
     @Test

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevReglerTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevReglerTest.java
@@ -114,7 +114,7 @@ class VedtaksbrevReglerTest {
 
     }
 
-    @Test //TODO remove
+    @Test
     void skal_gi_ingen_brev_ved_avslag_aldersvilkår() {
         LocalDate fom = LocalDate.of(2025, 8, 1);
         UngTestScenario ungTestGrunnlag = AvslagScenarioer.avslagAlder(fom);
@@ -152,14 +152,7 @@ class VedtaksbrevReglerTest {
 
         var regelResulat = totalresultater.vedtaksbrevResultater().getFirst();
 
-        var vedtaksbrevEgenskaper = regelResulat.vedtaksbrevEgenskaper();
-
-        assertThat(regelResulat.vedtaksbrevBygger()).isInstanceOf(EndringHøySatsInnholdBygger.class);
-        assertThat(vedtaksbrevEgenskaper.kanHindre()).isFalse();
-        assertThat(vedtaksbrevEgenskaper.kanRedigere()).isFalse();
-        assertThat(vedtaksbrevEgenskaper.kanOverstyreHindre()).isFalse();
-        assertThat(vedtaksbrevEgenskaper.kanOverstyreRediger()).isFalse();
-
+        assertFullAutomatiskBrev(regelResulat, DokumentMalType.ENDRING_HØY_SATS, EndringHøySatsInnholdBygger.class);
         assertThat(regelResulat.forklaring()).contains("høy sats");
 
     }

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevReglerTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevReglerTest.java
@@ -65,32 +65,6 @@ class VedtaksbrevReglerTest {
     }
 
     @Test
-    void skal_kunne_redigere_endring_inntekt_ved_ved_aksjonspunkt() {
-        LocalDate fom = LocalDate.of(2024, 12, 1);
-        UngTestScenario ungTestGrunnlag = EndringInntektScenarioer.endringMedInntektPå10k_19år(fom);
-        var behandling = EndringInntektScenarioer
-            .lagBehandlingMedAksjonspunktKontrollerInntekt(ungTestGrunnlag, ungTestRepositories);
-        behandling.avsluttBehandling();
-
-        var totalresultater = vedtaksbrevRegler.kjør(behandling.getId());
-        assertThat(totalresultater.harBrev()).isTrue();
-        assertThat(totalresultater.vedtaksbrevResultater()).hasSize(1);
-
-        var regelResulat = totalresultater.vedtaksbrevResultater().getFirst();
-
-        var vedtaksbrevEgenskaper = regelResulat.vedtaksbrevEgenskaper();
-
-        assertThat(regelResulat.vedtaksbrevBygger()).isInstanceOf(EndringRapportertInntektInnholdBygger.class);
-        assertThat(vedtaksbrevEgenskaper.kanHindre()).isTrue();
-        assertThat(vedtaksbrevEgenskaper.kanRedigere()).isTrue();
-        assertThat(vedtaksbrevEgenskaper.kanOverstyreHindre()).isTrue();
-        assertThat(vedtaksbrevEgenskaper.kanOverstyreRediger()).isTrue();
-
-        assertThat(regelResulat.forklaring()).contains(AksjonspunktDefinisjon.KONTROLLER_INNTEKT.getKode());
-
-    }
-
-    @Test
     void skal_gi_ingen_brev_ved_full_ungdomsprogram_med_ingen_rapportert_inntekt_uten_ap() {
         LocalDate fom = LocalDate.of(2024, 12, 1);
         var behandling = lagBehandling(EndringInntektScenarioer.endring0KrInntekt_19år(fom));
@@ -186,7 +160,7 @@ class VedtaksbrevReglerTest {
         assertThat(vedtaksbrevEgenskaper.kanOverstyreHindre()).isFalse();
         assertThat(vedtaksbrevEgenskaper.kanOverstyreRediger()).isFalse();
 
-        assertThat(regelResulat.forklaring()).contains("økt sats");
+        assertThat(regelResulat.forklaring()).contains("høy sats");
 
     }
 
@@ -248,9 +222,9 @@ class VedtaksbrevReglerTest {
         var egenskaper = vedtaksbrev.vedtaksbrevEgenskaper();
         assertThat(vedtaksbrev.vedtaksbrevBygger()).isInstanceOf(type);
         assertThat(vedtaksbrev.dokumentMalType()).isEqualTo(dokumentMalType);
-        assertThat(egenskaper.kanHindre()).isTrue();
+        assertThat(egenskaper.kanHindre()).isFalse();
+        assertThat(egenskaper.kanOverstyreHindre()).isFalse();
         assertThat(egenskaper.kanRedigere()).isTrue();
-        assertThat(egenskaper.kanOverstyreHindre()).isTrue();
         assertThat(egenskaper.kanOverstyreRediger()).isTrue();
     }
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevReglerTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevReglerTest.java
@@ -136,7 +136,7 @@ class VedtaksbrevReglerTest {
     }
 
     @Test
-    void skal_ikke_kunne_redigere_eller_hindre_brev_for_andre_totrinn_ap_enn_kontroller_inntekt() {
+    void skal_ikke_kunne_redigere_eller_hindre_automatisk_brev_for_andre_totrinn_ap_enn_kontroller_inntekt() {
         LocalDate fom = LocalDate.of(2024, 12, 1);
         // Bruker aksjonspunkt med totrinn for å trigge redigering av brev
         var behandling = BrevScenarioerUtils.lagBehandlingMedAP(


### PR DESCRIPTION
### **Behov / Bakgrunn**
Kun kontrollbehandlinger med aksjonspunkt for kontroller inntekt skal kunne redigeres foreløpig. Ingen brev skal kunne hindres
### **Løsning**
Flytter utledning av redigering og hindring til strategiene