### PR TITLE
Fjerner behandling_id og aktiv-flagg fra periode-aggregat

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPeriode.java
@@ -70,6 +70,10 @@ public class KontrollertInntektPeriode extends BaseEntitet {
         this.begrunnelse = begrunnelse;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public DatoIntervallEntitet getPeriode() {
         return DatoIntervallEntitet.fra(periode);
     }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPerioder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollertInntektPerioder.java
@@ -21,12 +21,6 @@ public class KontrollertInntektPerioder extends BaseEntitet {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_KONTROLLERT_INNTEKT_PERIODER")
     private Long id;
 
-    @Column(name = "behandling_id", nullable = false, updatable = false)
-    private Long behandlingId;
-
-    @Column(name = "aktiv", nullable = false, updatable = true)
-    private boolean aktiv = true;
-
     @Lob
     @Column(name = "regel_input")
     @DiffIgnore
@@ -43,18 +37,6 @@ public class KontrollertInntektPerioder extends BaseEntitet {
     private List<KontrollertInntektPeriode> perioder = new ArrayList<>();
 
     public KontrollertInntektPerioder() {
-    }
-
-    public Long getBehandlingId() {
-        return behandlingId;
-    }
-
-    public boolean isAktiv() {
-        return aktiv;
-    }
-
-    void setIkkeAktiv() {
-        this.aktiv = false;
     }
 
     public List<KontrollertInntektPeriode> getPerioder() {
@@ -74,27 +56,25 @@ public class KontrollertInntektPerioder extends BaseEntitet {
         if (behandlingId == null) {
             throw new IllegalArgumentException("behandlingId kan ikke være null");
         }
-        return new Builder(behandlingId);
+        return new Builder();
     }
 
-    public static Builder kopi(Long behandlingId, KontrollertInntektPerioder perioder) {
-        return new Builder(behandlingId, perioder);
+    public static Builder kopi(KontrollertInntektPerioder perioder) {
+        return new Builder(perioder);
     }
 
     public static class Builder {
-        private Long behandlingId;
         private List<KontrollertInntektPeriode> perioder = new ArrayList<>();
         private Clob regelInput;
         private Clob regelSporing;
 
 
-        public Builder(Long behandlingId, KontrollertInntektPerioder perioder) {
-            this.behandlingId = behandlingId;
+        public Builder(KontrollertInntektPerioder perioder) {
+
             this.perioder = perioder.perioder.stream().map(KontrollertInntektPeriode::new).toList();
         }
 
-        public Builder(Long behandlingId) {
-            this.behandlingId = behandlingId;
+        public Builder() {
         }
 
         public Builder medPerioder(List<KontrollertInntektPeriode> perioder) {
@@ -118,7 +98,6 @@ public class KontrollertInntektPerioder extends BaseEntitet {
 
         public KontrollertInntektPerioder build() {
             KontrollertInntektPerioder kontrollertInntektPerioder = new KontrollertInntektPerioder();
-            kontrollertInntektPerioder.behandlingId = this.behandlingId;
             kontrollertInntektPerioder.perioder = this.perioder;
             kontrollertInntektPerioder.regelInput = this.regelInput;
             kontrollertInntektPerioder.regelSporing = this.regelSporing;

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_062__kontrollert_inntekt_grunnlag_del2.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_062__kontrollert_inntekt_grunnlag_del2.sql
@@ -9,12 +9,6 @@ DELETE FROM KONTROLLERT_INNTEKT_PERIODER perioder where
 and not exists (Select 1 from GR_KONTROLLERT_INNTEKT gk where gk.KONTROLLERT_INNTEKT_PERIODER_ID = perioder.id);
 
 drop index idx_kontrollert_inntekt_perioder_behandling_id;
-
-create unique index idx_kontrollert_inntekt_perioder_aktiv_behandling_id
-    on kontrollert_inntekt_perioder (behandling_id)
-    where aktiv = true;
-
--- Drop the unique index before dropping the column
 drop index idx_kontrollert_inntekt_perioder_aktiv_behandling_id;
 
 ALTER table KONTROLLERT_INNTEKT_PERIODER

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_062__kontrollert_inntekt_grunnlag_del2.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_062__kontrollert_inntekt_grunnlag_del2.sql
@@ -1,0 +1,23 @@
+DELETE FROM KONTROLLERT_INNTEKT_PERIODE periode where
+    periode.KONTROLLERT_INNTEKT_PERIODER_ID in (select perioder.id from KONTROLLERT_INNTEKT_PERIODER perioder where
+                                             aktiv = false
+and not exists (Select 1 from GR_KONTROLLERT_INNTEKT gk where gk.KONTROLLERT_INNTEKT_PERIODER_ID = perioder.id));
+
+
+DELETE FROM KONTROLLERT_INNTEKT_PERIODER perioder where
+                                             aktiv = false
+and not exists (Select 1 from GR_KONTROLLERT_INNTEKT gk where gk.KONTROLLERT_INNTEKT_PERIODER_ID = perioder.id);
+
+drop index idx_kontrollert_inntekt_perioder_behandling_id;
+
+create unique index idx_kontrollert_inntekt_perioder_aktiv_behandling_id
+    on kontrollert_inntekt_perioder (behandling_id)
+    where aktiv = true;
+
+-- Drop the unique index before dropping the column
+drop index idx_kontrollert_inntekt_perioder_aktiv_behandling_id;
+
+ALTER table KONTROLLERT_INNTEKT_PERIODER
+DROP COLUMN BEHANDLING_ID;
+ALTER table KONTROLLERT_INNTEKT_PERIODER
+DROP COLUMN AKTIV;


### PR DESCRIPTION
### **Behov / Bakgrunn**
Sidan vi ikkje har data i prod og enda ikkje lagrer ned data i denne tabellen anser eg det som trygt å fjerne bruk av kolonnene i samme PR som DDL