### PR TITLE
Fikser ventefrist for rapportering

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/kompletthet/registerinntektkontroll/RapporteringsfristAutopunktUtleder.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/kompletthet/registerinntektkontroll/RapporteringsfristAutopunktUtleder.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.domene.behandling.steg.kompletthet.registerinntektkontrol
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.ung.kodeverk.behandling.aksjonspunkt.Venteårsak;
@@ -17,10 +18,12 @@ import java.util.Set;
 public class RapporteringsfristAutopunktUtleder {
 
     private RelevanteKontrollperioderUtleder kontrollperioderUtleder;
+    private final int inntektskontrollDagIMåned;
 
     @Inject
-    public RapporteringsfristAutopunktUtleder(RelevanteKontrollperioderUtleder kontrollperioderUtleder) {
+    public RapporteringsfristAutopunktUtleder(RelevanteKontrollperioderUtleder kontrollperioderUtleder, @KonfigVerdi(value = "INNTEKTSKONTROLL_DAG_I_MAANED", defaultVerdi = "8") int inntektskontrollDagIMåned) {
         this.kontrollperioderUtleder = kontrollperioderUtleder;
+        this.inntektskontrollDagIMåned = inntektskontrollDagIMåned;
     }
 
     public Optional<AksjonspunktResultat> utledAutopunktForRapporteringsfrist(BehandlingReferanse behandlingReferanse) {
@@ -33,16 +36,12 @@ public class RapporteringsfristAutopunktUtleder {
         if (harIkkePassertRapporteringsfrist) {
             // Dersom vi ikkje har passert rapporteringsfrist (ikkje har kontroll-årsak) så skal vi vente til rapporteringsfrist
             final var sisteDatoForRapportertInntekt = ikkePassertRapporteringsfristTidslinje.getMaxLocalDate();
-            LocalDateTime venteFrist;
-            if (sisteDatoForRapportertInntekt.getDayOfMonth() < 7) {
-                venteFrist = sisteDatoForRapportertInntekt.withDayOfMonth(7).atStartOfDay();
-            } else {
-                venteFrist = sisteDatoForRapportertInntekt.plusMonths(1).withDayOfMonth(7).atStartOfDay();
-            }
+            // Ønker å sette på vent til vi har fått årsak RE_KONTROLL_REGISTER_INNTEKT, første gjenopptagelse skjer samme dag som inntektskontroll
+            LocalDateTime venteFrist = sisteDatoForRapportertInntekt.plusMonths(1).withDayOfMonth(inntektskontrollDagIMåned).atStartOfDay();
             return Optional.of(AksjonspunktResultat.opprettForAksjonspunktMedFrist(
                 AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_RAPPORTERINGSFRIST,
                 Venteårsak.VENT_INNTEKT_RAPPORTERINGSFRIST,
-                venteFrist));
+                venteFrist.isBefore(LocalDateTime.now()) ? LocalDateTime.now().plusDays(1) : venteFrist));
         }
 
         return Optional.empty();


### PR DESCRIPTION
### **Behov / Bakgrunn**
Setter på vent til samme dag som inntektskontroll og deretter en dag ved kvar gjenopptakelse