### PR TITLE
Erstatter OidcRestClient med SystemUserOidcRestClient i UngdomsprogramRegisterKlient.

### DIFF
--- a/domenetjenester/ungdomsprogram/src/main/java/no/nav/ung/sak/ungdomsprogram/UngdomsprogramRegisterKlient.java
+++ b/domenetjenester/ungdomsprogram/src/main/java/no/nav/ung/sak/ungdomsprogram/UngdomsprogramRegisterKlient.java
@@ -1,27 +1,27 @@
 package no.nav.ung.sak.ungdomsprogram;
 
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.k9.felles.integrasjon.rest.ScopedRestIntegration;
+import no.nav.k9.felles.integrasjon.rest.SystemUserOidcRestClient;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
+import no.nav.ung.sak.kontrakt.person.AktørIdDto;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
-import no.nav.k9.felles.integrasjon.rest.OidcRestClient;
-import no.nav.k9.felles.integrasjon.rest.ScopedRestIntegration;
-import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
-import no.nav.ung.sak.kontrakt.person.AktørIdDto;
-
 @Dependent
 @ScopedRestIntegration(scopeKey = "ungdomsprogramregister.scope", defaultScope = "api://prod-gcp.k9saksbehandling.ung-deltakelse-opplyser/.default")
 public class UngdomsprogramRegisterKlient {
-    private final OidcRestClient restClient;
+    private final SystemUserOidcRestClient restClient;
     private final URI hentUri;
 
     @Inject
     public UngdomsprogramRegisterKlient(
-        OidcRestClient restClient,
+        SystemUserOidcRestClient restClient,
         @KonfigVerdi(value = "ungdomsprogramregister.url", defaultVerdi = "http://ung-deltakelse-opplyser.k9saksbehandling") String url) {
         this.restClient = restClient;
         hentUri = tilUri(url, "register/hent/alle");

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/fordeling/PapirsøknadHåndteringTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/fordeling/PapirsøknadHåndteringTjeneste.java
@@ -76,8 +76,10 @@ public class PapirsøknadHåndteringTjeneste {
 
     private void validerDeltakelseEksisterer(UUID deltakelseId, AktørId aktørId) {
         List<UngdomsprogramRegisterKlient.DeltakerProgramOpplysningDTO> deltakerOpplysningerDTO = ungdomsprogramRegisterKlient.hentForAktørId(aktørId.getAktørId()).opplysninger();
-        boolean deltakelseIkkeEksister = deltakerOpplysningerDTO.stream()
-            .noneMatch(deltakelse -> deltakelse.id() == deltakelseId);
+        boolean deltakelseIkkeEksister = deltakerOpplysningerDTO
+            .stream()
+            .noneMatch(deltakelse -> deltakelse.id().equals(deltakelseId));
+
         if (deltakelseIkkeEksister) {
             throw new IllegalStateException("Finner ikke deltakelse med id " + deltakelseId);
         }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved kall til ung-deltakelse-opplyser via restkall i ung-sak, blir brukertokenet propagert videre til ung-sak.
Denne brukeren har ikke ungdomsprogramveileder rolle og får dermed ikke tilgang.

### **Løsning**
Da ingen andre brukere enn ungdomsprogramveiledere skal ha tilgang til ung-deltakelse-opplyser, er det da best å bruke systemklient her.

### **Andre endringer**
- Fikser sjekk på deltakelseId.
