### PR TITLE
utleder tekst om automatisk vedtak basert på om det er utført manuelle aksjonspunkter på behandlingen.

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/informasjonsbrev/InformasjonsbrevGenerererTjeneste.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/informasjonsbrev/InformasjonsbrevGenerererTjeneste.java
@@ -64,7 +64,7 @@ public class InformasjonsbrevGenerererTjeneste {
 
         var input = new TemplateInput(innhold.templateType(),
             new TemplateDto(
-                FellesDto.lag(new MottakerDto(pdlMottaker.navn(), pdlMottaker.fnr()), innhold.automatiskGenerertFooter()),
+                FellesDto.lag(new MottakerDto(pdlMottaker.navn(), pdlMottaker.fnr()), false),
                 innhold.templateInnholdDto()
             ));
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/informasjonsbrev/innhold/GenereltFritekstbrevInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/informasjonsbrev/innhold/GenereltFritekstbrevInnholdBygger.java
@@ -21,6 +21,6 @@ public class GenereltFritekstbrevInnholdBygger implements InformasjonsbrevInnhol
             new GenereltFritekstBrevTemplateDto(
                 innhold.overskrift(),
                 MarkdownParser.markdownTilHtml(innhold.brødtekst())
-            ), false);
+            ));
     }
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringBarnetilleggInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringBarnetilleggInnholdBygger.java
@@ -48,7 +48,7 @@ public class EndringBarnetilleggInnholdBygger implements VedtaksbrevInnholdBygge
         var sats = Satsberegner.beregnBarnetilleggSats(nyeSatser);
 
         return new TemplateInnholdResultat(TemplateType.ENDRING_BARNETILLEGG,
-                new EndringBarnetilleggDto(satsendringsdato, nyeSatser.dagsatsBarnetillegg(), sats), true);
+                new EndringBarnetilleggDto(satsendringsdato, nyeSatser.dagsatsBarnetillegg(), sats));
 
     }
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringHøySatsInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringHøySatsInnholdBygger.java
@@ -49,7 +49,7 @@ public class EndringHøySatsInnholdBygger implements VedtaksbrevInnholdBygger {
                 Satsberegner.beregnDagsatsInklBarnetillegg(nyeSatser),
                 Sats.HØY.getFomAlder(),
                 totalBarnetillegg > 0 ? totalBarnetillegg : null
-            ), true);
+            ));
     }
 
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringProgramPeriodeInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringProgramPeriodeInnholdBygger.java
@@ -63,7 +63,7 @@ public class EndringProgramPeriodeInnholdBygger implements VedtaksbrevInnholdByg
             new EndringProgramPeriodeDto(
                 endretStartdato, endretSluttdato,
                 false
-            ), true);
+            ));
     }
 
     private EndretSluttDato bestemEndretSluttdato(LocalDateSegment<Boolean> denneProgramperiode, LocalDateSegment<Boolean> forrigeProgramperiode) {

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektReduksjonInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektReduksjonInnholdBygger.java
@@ -78,7 +78,7 @@ public class EndringRapportertInntektReduksjonInnholdBygger implements Vedtaksbr
             harIngenUtbetalingsperioder
         );
 
-        return new TemplateInnholdResultat(TemplateType.ENDRING_INNTEKT, dto, true);
+        return new TemplateInnholdResultat(TemplateType.ENDRING_INNTEKT, dto);
     }
 
     private static LocalDateSegment<EndringRapportertInntektPeriodeDto> mapTilPeriodeDto(

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektUtenReduksjonInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/EndringRapportertInntektUtenReduksjonInnholdBygger.java
@@ -52,8 +52,8 @@ public class EndringRapportertInntektUtenReduksjonInnholdBygger implements Vedta
 
 
         return new TemplateInnholdResultat(TemplateType.ENDRING_INNTEKT_UTEN_REDUKSJON,
-            new EndringRapportertInntektUtenReduksjonDto(fullUtbetalingsperioder),
-            true);
+            new EndringRapportertInntektUtenReduksjonDto(fullUtbetalingsperioder)
+        );
     }
 
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/FørstegangsInnvilgelseInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/FørstegangsInnvilgelseInnholdBygger.java
@@ -100,7 +100,7 @@ public class FørstegangsInnvilgelseInnholdBygger implements VedtaksbrevInnholdB
                 null,
                 erEtterbetaling,
                 satsEndringHendelseDtos.isEmpty(),
-                sisteUtbetalingsdato), true);
+                sisteUtbetalingsdato));
     }
 
     private boolean erEtterbetaling(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultatTidslinje) {

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/ManueltVedtaksbrevInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/ManueltVedtaksbrevInnholdBygger.java
@@ -20,8 +20,8 @@ public class ManueltVedtaksbrevInnholdBygger {
 
         return new TemplateInnholdResultat(
             TemplateType.MANUELT_VEDTAKSBREV,
-            new ManuellVedtaksbrevDto(brevHtml),
-            false);
+            new ManuellVedtaksbrevDto(brevHtml)
+        );
     }
 
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/OpphørInnholdBygger.java
@@ -42,7 +42,7 @@ public class OpphørInnholdBygger implements VedtaksbrevInnholdBygger {
             new OpphørDto(
                 opphørStartdato,
                 sisteUtbetalingsdato
-            ), true);
+            ));
     }
 
     private YearMonth bestemInneværendeMåned() {

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/TemplateInnholdResultat.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/TemplateInnholdResultat.java
@@ -5,6 +5,6 @@ import no.nav.ung.sak.formidling.template.dto.TemplateInnholdDto;
 
 public record TemplateInnholdResultat(
     TemplateType templateType,
-    TemplateInnholdDto templateInnholdDto,
-    boolean automatiskGenerertFooter) {
+    TemplateInnholdDto templateInnholdDto
+) {
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/TomVedtaksbrevInnholdBygger.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/innhold/TomVedtaksbrevInnholdBygger.java
@@ -28,6 +28,6 @@ public class TomVedtaksbrevInnholdBygger implements VedtaksbrevInnholdBygger {
 
     @Override
     public TemplateInnholdResultat bygg(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultatTidslinje) {
-        return new TemplateInnholdResultat(TemplateType.MANUELT_VEDTAKSBREV, new ManuellVedtaksbrevDto(TOM_VEDTAKSBREV_HTML_MAL), false);
+        return new TemplateInnholdResultat(TemplateType.MANUELT_VEDTAKSBREV, new ManuellVedtaksbrevDto(TOM_VEDTAKSBREV_HTML_MAL));
     }
 }

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevGenerererTjenesteImpl.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevGenerererTjenesteImpl.java
@@ -5,6 +5,7 @@ import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import no.nav.ung.kodeverk.dokument.DokumentMalType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.formidling.BrevGenereringSemafor;
 import no.nav.ung.sak.formidling.GenerertBrev;
@@ -60,9 +61,10 @@ public class VedtaksbrevGenerererTjenesteImpl implements VedtaksbrevGenerererTje
         VedtaksbrevInnholdBygger bygger = vedtaksbrev.vedtaksbrevBygger();
         var resultat = bygger.bygg(behandling, vedtaksbrevGenerererInput.detaljertResultatTidslinje());
         var pdlMottaker = brevMottakerTjeneste.hentMottaker(behandling);
+        var automatiskGenerertFooter = harManuellAksjonspunkt(behandling);
         var input = new TemplateInput(resultat.templateType(),
             new TemplateDto(
-                FellesDto.lag(new MottakerDto(pdlMottaker.navn(), pdlMottaker.fnr()), resultat.automatiskGenerertFooter()),
+                FellesDto.lag(new MottakerDto(pdlMottaker.navn(), pdlMottaker.fnr()), automatiskGenerertFooter),
                 resultat.templateInnholdDto()
             )
         );
@@ -75,6 +77,10 @@ public class VedtaksbrevGenerererTjenesteImpl implements VedtaksbrevGenerererTje
             vedtaksbrev.dokumentMalType(),
             resultat.templateType()
         );
+    }
+
+    private static boolean harManuellAksjonspunkt(Behandling behandling) {
+        return behandling.getAksjonspunkter().stream().anyMatch(it -> !it.getAksjonspunktDefinisjon().getAksjonspunktType().erAutopunkt() && it.erUtført());
     }
 
 

--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevGenerererTjenesteImpl.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/VedtaksbrevGenerererTjenesteImpl.java
@@ -4,6 +4,7 @@ package no.nav.ung.sak.formidling.vedtak;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.ung.kodeverk.dokument.DokumentMalType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
@@ -61,10 +62,10 @@ public class VedtaksbrevGenerererTjenesteImpl implements VedtaksbrevGenerererTje
         VedtaksbrevInnholdBygger bygger = vedtaksbrev.vedtaksbrevBygger();
         var resultat = bygger.bygg(behandling, vedtaksbrevGenerererInput.detaljertResultatTidslinje());
         var pdlMottaker = brevMottakerTjeneste.hentMottaker(behandling);
-        var automatiskGenerertFooter = harManuellAksjonspunkt(behandling);
+        var brukAutomatiskGenerertVedtakFooter = !harManuellAksjonspunkt(behandling);
         var input = new TemplateInput(resultat.templateType(),
             new TemplateDto(
-                FellesDto.lag(new MottakerDto(pdlMottaker.navn(), pdlMottaker.fnr()), automatiskGenerertFooter),
+                FellesDto.lag(new MottakerDto(pdlMottaker.navn(), pdlMottaker.fnr()), brukAutomatiskGenerertVedtakFooter),
                 resultat.templateInnholdDto()
             )
         );
@@ -80,7 +81,11 @@ public class VedtaksbrevGenerererTjenesteImpl implements VedtaksbrevGenerererTje
     }
 
     private static boolean harManuellAksjonspunkt(Behandling behandling) {
-        return behandling.getAksjonspunkter().stream().anyMatch(it -> !it.getAksjonspunktDefinisjon().getAksjonspunktType().erAutopunkt() && it.erUtført());
+        return behandling.getAksjonspunkter().stream()
+            .anyMatch(
+                it -> (!it.getAksjonspunktDefinisjon().getAksjonspunktType().erAutopunkt() && it.erUtført())
+                    || (it.getAksjonspunktDefinisjon() == AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT && it.erÅpentAksjonspunkt())
+            );
     }
 
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/EndringRapportertInntektUtenReduksjonTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/EndringRapportertInntektUtenReduksjonTest.java
@@ -25,7 +25,7 @@ class EndringRapportertInntektUtenReduksjonTest extends AbstractVedtaksbrevInnho
             EndringInntektScenarioer.endring0KrInntekt_19år(fom), ungTestRepositories
         );
 
-        var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
+        var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooterManuell(fnr,
             "Vi har ikke endret ungdomsprogramytelsen din " +
                 "Du har gitt oss beskjed om at du hadde inntekt i perioden fra 1. september 2025 til 30. september 2025. " +
                 "Vi har kontrollert inntekten din for denne perioden og kommet frem til at du ikke får redusert ungdomsprogramytelsen din. " +

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/TomVedtaksbrevMalTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/TomVedtaksbrevMalTest.java
@@ -3,7 +3,9 @@ package no.nav.ung.sak.formidling;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.behandling.BehandlingStegType;
 import no.nav.ung.kodeverk.behandling.BehandlingType;
+import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.formidling.scenarioer.AvslagScenarioer;
 import no.nav.ung.sak.formidling.vedtak.VedtaksbrevTjeneste;
@@ -39,9 +41,11 @@ class TomVedtaksbrevMalTest {
         UngTestRepositories ungTestRepositories = BrevTestUtils.lagAlleUngTestRepositories(entityManager);
         LocalDate fom = LocalDate.of(2025, 8, 1);
         UngTestScenario ungTestGrunnlag = AvslagScenarioer.avslagAlder(fom);
-        var behandling = TestScenarioBuilder.builderMedSøknad()
+        TestScenarioBuilder scenarioBuilder = TestScenarioBuilder.builderMedSøknad()
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
-            .medUngTestGrunnlag(ungTestGrunnlag)
+            .medUngTestGrunnlag(ungTestGrunnlag);
+        scenarioBuilder.leggTilAksjonspunkt(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, BehandlingStegType.FORESLÅ_VEDTAK);
+        var behandling = scenarioBuilder
             .buildOgLagreMedUng(ungTestRepositories);
 
 

--- a/formidling/src/test/java/no/nav/ung/sak/formidling/innhold/ManueltVedtaksbrevInnholdByggerTest.java
+++ b/formidling/src/test/java/no/nav/ung/sak/formidling/innhold/ManueltVedtaksbrevInnholdByggerTest.java
@@ -18,7 +18,6 @@ class ManueltVedtaksbrevInnholdByggerTest {
         TemplateInnholdResultat bygg = bygger.bygg(redigertBrevHtml);
 
         assertThat(bygg.templateType()).isEqualTo(TemplateType.MANUELT_VEDTAKSBREV);
-        assertThat(bygg.automatiskGenerertFooter()).isFalse();
         assertThat(bygg.templateInnholdDto()).isInstanceOf(ManuellVedtaksbrevDto.class);
         var dto = (ManuellVedtaksbrevDto) bygg.templateInnholdDto();
         assertThat(dto.tekstHtml()).isEqualTo(redigertBrevHtml);


### PR DESCRIPTION
### **Behov / Bakgrunn**
Alle vedtak som har utførte manuelle autopunkter (aksjonspunkt) skal ikke ha footer om automatisk vedtak. 
### **Løsning**
Endret til å sjekke aksjonspunkter på behandling for å utlede footerteksten