### PR TITLE
TSFF-2496: Håndterer at det er færre enn 3 lignede år fra SIGRUN

### DIFF
--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/BeregningTjeneste.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/BeregningTjeneste.java
@@ -10,6 +10,7 @@ import no.nav.ung.sak.domene.iay.modell.InntektFilter;
 import no.nav.ung.sak.domene.iay.modell.Inntektspost;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.Collection;
@@ -57,8 +58,6 @@ public class BeregningTjeneste {
         var pgiKalkulator = new PgiKalkulator(input);
         var pgiPerÅr = pgiKalkulator.avgrensOgOppjusterÅrsinntekter();
 
-        if (pgiPerÅr.size() < 3) { throw new IllegalStateException("BesteBeregning: Kan ikke utføre besteberegning uten komplette data."); }
-
         BigDecimal årsinntektSisteÅr = pgiPerÅr.getOrDefault(input.sisteLignedeÅr(), BigDecimal.ZERO);
         BigDecimal årsinntektSisteTreÅr = hentSnittTreSisteÅr(pgiPerÅr);
         BigDecimal beregningsgrunnlag = årsinntektSisteÅr.max(årsinntektSisteTreÅr);
@@ -74,6 +73,6 @@ public class BeregningTjeneste {
             .limit(3)
             .map(Map.Entry::getValue)
             .reduce(BigDecimal.ZERO, BigDecimal::add)
-            .divide(BigDecimal.valueOf(3), 10, java.math.RoundingMode.HALF_EVEN);
+            .divide(BigDecimal.valueOf(3), 10, RoundingMode.HALF_UP);
     }
 }

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/BeregningTjenesteTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/BeregningTjenesteTest.java
@@ -19,6 +19,35 @@ class BeregningTjenesteTest {
     private static final Year SIST_LIGNEDE_ÅR = Year.of(2025);
 
     @Test
+    void skal_bruke_siste_år_med_kun_to_lignede_år() {
+        var inntektsposter = List.of(
+            lagInntektspost(2025, BigDecimal.valueOf(300_000)),
+            lagInntektspost(2024, BigDecimal.valueOf(200_000))
+        );
+
+        var resultat = BeregningTjeneste.avgjørBesteberegning(lagBeregningInput(SIST_LIGNEDE_ÅR, VIRKNINGSDATO, inntektsposter));
+        assertThat(resultat.getBeregningsgrunnlag()).isEqualByComparingTo(resultat.getÅrsinntektSisteÅr());
+    }
+
+    @Test
+    void skal_bruke_snitt_av_siste_tre_år_med_kun_to_lignede_år_dersom_første_året_er_høyt() {
+        var inntektsposter = List.of(
+            lagInntektspost(2025, BigDecimal.valueOf(25_000)),
+            lagInntektspost(2024, BigDecimal.valueOf(600_000))
+        );
+
+        var resultat = BeregningTjeneste.avgjørBesteberegning(lagBeregningInput(SIST_LIGNEDE_ÅR, VIRKNINGSDATO, inntektsposter));
+        assertThat(resultat.getBeregningsgrunnlag()).isEqualByComparingTo("221450.5361216667");
+    }
+
+    @Test
+    void skal_håndtere_ingen_inntekter() {
+        var resultat = BeregningTjeneste.avgjørBesteberegning(lagBeregningInput(SIST_LIGNEDE_ÅR, VIRKNINGSDATO, List.of()));
+        assertThat(resultat.getBeregningsgrunnlag()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+
+    @Test
     void siste_år_brukes_når_det_er_høyere_enn_snitt_av_tre_år() {
         var inntektsposter = List.of(
             lagInntektspost(2025, BigDecimal.valueOf(600_000)),


### PR DESCRIPTION
### **Behov / Bakgrunn**
Håndterer at vi ikkje har inntektsposter for alle inntektsårene. Denne delen av domenelogikken burde ikkje ha avhengigheter til kva år som er tilgjengelige fra eksterne integrasjoner.

### **Løsning**
Dersom det ikkje finnes inntekt for eitt år regnes denne som 0.

### **Andre endringer**
Bruker riktig avrundingsregel (skal bruke standard avrundingsregler som er HALF_UP og ikkje HALF_EVEN).
