### PR TITLE
Separerer rapporterte opplysninger for ytelse og for atfl-inntekt

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollerteInntekter.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/tilkjentytelse/KontrollerteInntekter.java
@@ -6,15 +6,16 @@ public record KontrollerteInntekter(
     BigDecimal inntekt,
     BigDecimal ytelse
 ) {
-    public BigDecimal inntekt() {
-        return inntekt != null ? inntekt : BigDecimal.ZERO;
-    }
-
     public BigDecimal arbeidsinntekt() {
-        return inntekt();
+        return inntekt != null ? inntekt : BigDecimal.ZERO;
     }
 
     public BigDecimal ytelse() {
         return ytelse != null ? ytelse : BigDecimal.ZERO;
     }
+
+    public BigDecimal arbeidsinntektOgYtelse() {
+        return arbeidsinntekt().add(ytelse());
+    }
+
 }

--- a/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjeneste.java
@@ -5,12 +5,10 @@ import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.fpsak.tidsserie.StandardCombinators;
 import no.nav.ung.kodeverk.varsel.EtterlysningStatus;
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
-import no.nav.ung.sak.kontroll.EtterlysningOgRegisterinntekt;
-import no.nav.ung.sak.kontroll.Inntektsresultat;
-import no.nav.ung.sak.kontroll.RapportertInntekt;
-import no.nav.ung.sak.kontroll.RapporterteInntekter;
+import no.nav.ung.sak.kontroll.*;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -79,7 +77,7 @@ public class KontrollerInntektTjeneste {
         // Siden vi tillater et visst avvik her er det ikke sikkert at registerinntekten er nøyaktig lik 0
         var inntektFraBrukerTidslinje = gjeldendeRapporterteInntekter.filterValue(it -> !it.brukerRapporterteInntekter().isEmpty());
         return ingenAvvikTidslinje.disjoint(inntektFraBrukerTidslinje)
-            .mapValue(it -> new Kontrollresultat(KontrollResultatType.FERDIG_KONTROLLERT, new Inntektsresultat(BigDecimal.ZERO, KontrollertInntektKilde.BRUKER)));
+            .mapValue(it -> new Kontrollresultat(KontrollResultatType.FERDIG_KONTROLLERT, new Inntektsresultat(Collections.emptySet(), KontrollertInntektKilde.BRUKER)));
     }
 
 
@@ -94,7 +92,7 @@ public class KontrollerInntektTjeneste {
             etterlysningTidslinje);
 
         return brukersGodkjenteEllerRapporterteInntekter.intersection(relevantTidslinje)
-            .mapValue(it -> new Inntektsresultat(summerInntekter(it), it.kilde()))
+            .mapValue(it -> new Inntektsresultat(it.inntekter(), it.kilde()))
             .mapValue(it -> new Kontrollresultat(KontrollResultatType.FERDIG_KONTROLLERT, it));
     }
 
@@ -117,10 +115,4 @@ public class KontrollerInntektTjeneste {
                         lhs != null ? KontrollertInntektKilde.REGISTER : KontrollertInntektKilde.BRUKER))
         );
     }
-
-    private static BigDecimal summerInntekter(BrukersAvklarteInntekter it) {
-        return it.inntekter().stream()
-            .map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
-    }
-
 }

--- a/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/ung/sak/domene/behandling/steg/registerinntektkontroll/KontrollerInntektTjenesteTest.java
@@ -143,11 +143,12 @@ class KontrollerInntektTjenesteTest {
         final var tom = LocalDate.now().plusDays(10);
         LocalDateTimeline<Set<BehandlingÅrsakType>> prosessTriggerTidslinje = lagProsesstriggerTidslinjeForKontroll(fom, tom);
         final var gjeldendeRapporterteInntekter = lagRapportertInntektTidslinjeMedDiffMotRegister(fom, tom, 2000, 0, 500);
+        RapportertInntekt rapportertInntekt = new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, BigDecimal.valueOf(2000));
         LocalDateTimeline<EtterlysningOgRegisterinntekt> ikkeGodkjentUttalelseTidslinje = new LocalDateTimeline<>(
             fom, tom,
             new EtterlysningOgRegisterinntekt(
                 Set.of(
-                    new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, BigDecimal.valueOf(2000))
+                    rapportertInntekt
                 ),
                 new InntektskontrollEtterlysningInfo(EtterlysningStatus.UTLØPT, null))
         );
@@ -156,7 +157,7 @@ class KontrollerInntektTjenesteTest {
         var resultat = utførMedResultat(prosessTriggerTidslinje, gjeldendeRapporterteInntekter, ikkeGodkjentUttalelseTidslinje);
 
         // Assert
-        Kontrollresultat kontrollresultat = new Kontrollresultat(KontrollResultatType.FERDIG_KONTROLLERT, new Inntektsresultat(BigDecimal.valueOf(2000), KontrollertInntektKilde.REGISTER));
+        Kontrollresultat kontrollresultat = new Kontrollresultat(KontrollResultatType.FERDIG_KONTROLLERT, new Inntektsresultat(Set.of(rapportertInntekt), KontrollertInntektKilde.REGISTER));
         LocalDateTimeline<Kontrollresultat> forventet = new LocalDateTimeline<>(fom, tom, kontrollresultat);
         assertEquals(forventet, resultat);
     }

--- a/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/Inntektsresultat.java
+++ b/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/Inntektsresultat.java
@@ -2,8 +2,6 @@ package no.nav.ung.sak.kontroll;
 
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 
-import java.math.BigDecimal;
-import java.util.List;
 import java.util.Set;
 
 public record Inntektsresultat(Set<RapportertInntekt> inntekter, KontrollertInntektKilde kilde) {

--- a/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/Inntektsresultat.java
+++ b/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/Inntektsresultat.java
@@ -3,10 +3,8 @@ package no.nav.ung.sak.kontroll;
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
 
-public record Inntektsresultat(BigDecimal inntekt, KontrollertInntektKilde kilde) {
-
-    public static Inntektsresultat ingenInntektFraBruker() {
-        return new Inntektsresultat(BigDecimal.ZERO, KontrollertInntektKilde.BRUKER);
-    }
+public record Inntektsresultat(Set<RapportertInntekt> inntekter, KontrollertInntektKilde kilde) {
 }

--- a/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/KontrollerteInntektperioderTjeneste.java
+++ b/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/KontrollerteInntektperioderTjeneste.java
@@ -2,10 +2,7 @@ package no.nav.ung.sak.kontroll;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-import no.nav.fpsak.tidsserie.LocalDateSegment;
-import no.nav.fpsak.tidsserie.LocalDateSegmentCombinator;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
-import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 import no.nav.ung.sak.behandlingslager.tilkjentytelse.KontrollertInntektPeriode;
 import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseRepository;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
@@ -39,12 +36,12 @@ public class KontrollerteInntektperioderTjeneste {
 
     public void opprettKontrollerteInntekterPerioderFraBruker(Long behandlingId,
                                                               LocalDateTimeline<Inntektsresultat> inntektsresultat,
-                                                              LocalDateTimeline<RapporterteInntekter> rapporterteInntekter, String input,
+                                                              LocalDateTimeline<RapporterteInntekter> rapporterteInntekter,
+                                                              String input,
                                                               String sporing) {
-        final var kontrollertePerioder = mapAutomatiskKontrollerteInntektperioder(inntektsresultat.mapValue(it -> true),
-            inntektsresultat.mapValue(it -> new RapportertInntektOgKilde(it.kilde(), it.inntekt())),
-            rapporterteInntekter,
-            Optional.of(KontrollertInntektKilde.BRUKER)
+        final var kontrollertePerioder = mapAutomatiskKontrollerteInntektperioder(
+            inntektsresultat,
+            rapporterteInntekter
         );
         LOG.info("Lagrer inntekt fra bruker: {}", kontrollertePerioder);
 
@@ -139,30 +136,26 @@ public class KontrollerteInntektperioderTjeneste {
     /**
      * Mapper til kontrollerte inntekter for automatisk vurdering
      *
-     * @param vurdertTidslinje              Vurdert tidslinje
      * @param inntektTidslinje              Rapportert inntekt tidslinje
      * @param rapporterteInntekterTidslinje
-     * @param defaultKilde                  Kilde som skal settes der vi ikke har rapporterte inntekter
      * @return List med kontrollerte perioder
      */
-    private static List<KontrollertInntektPeriode> mapAutomatiskKontrollerteInntektperioder(LocalDateTimeline<Boolean> vurdertTidslinje,
-                                                                                            LocalDateTimeline<RapportertInntektOgKilde> inntektTidslinje,
-                                                                                            LocalDateTimeline<RapporterteInntekter> rapporterteInntekterTidslinje,
-                                                                                            Optional<KontrollertInntektKilde> defaultKilde) {
-
-        return vurdertTidslinje.combine(inntektTidslinje, settVerdiForIngenInntekter(defaultKilde), LocalDateTimeline.JoinStyle.LEFT_JOIN)
-            .toSegments().stream().map(vurdertInntektTidslinjesegment -> {
-                    var rapporterteInntekter = Optional.ofNullable(rapporterteInntekterTidslinje.getSegment(vurdertInntektTidslinjesegment.getLocalDateInterval())).map(it -> it.getValue());
-                    return KontrollertInntektPeriode.ny()
-                        .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(vurdertInntektTidslinjesegment.getFom(), vurdertInntektTidslinjesegment.getTom()))
-                        .medInntekt(vurdertInntektTidslinjesegment.getValue().samletInntekt())
-                        .medKilde(vurdertInntektTidslinjesegment.getValue().kilde())
-                        .medErManueltVurdert(false)
-                        .medRegisterInntekt(rapporterteInntekter.map(it -> it.registerRapporterteInntekter().stream().map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO)).orElse(BigDecimal.ZERO))
-                        .medRapportertInntekt(rapporterteInntekter.map(it -> it.brukerRapporterteInntekter().stream().map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO)).orElse(BigDecimal.ZERO))
-                        .build();
-                }
-            ).toList();
+    private static List<KontrollertInntektPeriode> mapAutomatiskKontrollerteInntektperioder(
+        LocalDateTimeline<Inntektsresultat> inntektTidslinje,
+        LocalDateTimeline<RapporterteInntekter> rapporterteInntekterTidslinje) {
+        return inntektTidslinje.toSegments().stream().map(vurdertInntektTidslinjesegment -> {
+                var rapporterteInntekter = Optional.ofNullable(rapporterteInntekterTidslinje.getSegment(vurdertInntektTidslinjesegment.getLocalDateInterval())).map(it -> it.getValue());
+                return KontrollertInntektPeriode.ny()
+                    .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(vurdertInntektTidslinjesegment.getFom(), vurdertInntektTidslinjesegment.getTom()))
+                    .medInntekt(vurdertInntektTidslinjesegment.getValue().inntekter().stream().filter(it -> it.inntektType().equals(InntektType.ARBEIDSTAKER_ELLER_FRILANSER)).map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO))
+                    .medYtelse(vurdertInntektTidslinjesegment.getValue().inntekter().stream().filter(it -> it.inntektType().equals(InntektType.YTELSE)).map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO))
+                    .medKilde(vurdertInntektTidslinjesegment.getValue().kilde())
+                    .medErManueltVurdert(false)
+                    .medRegisterInntekt(rapporterteInntekter.map(it -> it.registerRapporterteInntekter().stream().map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO)).orElse(BigDecimal.ZERO))
+                    .medRapportertInntekt(rapporterteInntekter.map(it -> it.brukerRapporterteInntekter().stream().map(RapportertInntekt::beløp).reduce(BigDecimal::add).orElse(BigDecimal.ZERO)).orElse(BigDecimal.ZERO))
+                    .build();
+            }
+        ).toList();
     }
 
     /**
@@ -188,13 +181,5 @@ public class KontrollerteInntektperioderTjeneste {
             }
         ).toList();
     }
-
-    private static LocalDateSegmentCombinator<Boolean, RapportertInntektOgKilde, RapportertInntektOgKilde> settVerdiForIngenInntekter(Optional<KontrollertInntektKilde> kilde) {
-        return (di, lhs, rhs) ->
-            rhs == null ?
-                new LocalDateSegment<>(di, new RapportertInntektOgKilde(kilde.orElseThrow(() -> new IllegalStateException("Forventer å få default kilde dersom tidslinjen med inntekter ikke dekker alle perioder til vurdering")), BigDecimal.ZERO)) :
-                rhs;
-    }
-
 
 }

--- a/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/RapportertInntektOgKilde.java
+++ b/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/RapportertInntektOgKilde.java
@@ -1,9 +1,0 @@
-package no.nav.ung.sak.kontroll;
-
-import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
-
-import java.math.BigDecimal;
-import java.util.List;
-
-public record RapportertInntektOgKilde(KontrollertInntektKilde kilde, List<RapportertInntekt> inntekter) {
-}

--- a/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/RapportertInntektOgKilde.java
+++ b/domenetjenester/inntektskontroll/src/main/java/no/nav/ung/sak/kontroll/RapportertInntektOgKilde.java
@@ -3,6 +3,7 @@ package no.nav.ung.sak.kontroll;
 import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
 
 import java.math.BigDecimal;
+import java.util.List;
 
-public record RapportertInntektOgKilde(KontrollertInntektKilde kilde, BigDecimal samletInntekt) {
+public record RapportertInntektOgKilde(KontrollertInntektKilde kilde, List<RapportertInntekt> inntekter) {
 }

--- a/domenetjenester/inntektskontroll/src/test/java/no/nav/ung/sak/kontroll/KontrollerteInntektperioderTjenesteTest.java
+++ b/domenetjenester/inntektskontroll/src/test/java/no/nav/ung/sak/kontroll/KontrollerteInntektperioderTjenesteTest.java
@@ -1,0 +1,117 @@
+package no.nav.ung.sak.kontroll;
+
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.kontroll.KontrollertInntektKilde;
+import no.nav.ung.sak.behandlingslager.tilkjentytelse.KontrollertInntektPeriode;
+import no.nav.ung.sak.behandlingslager.tilkjentytelse.TilkjentYtelseRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class KontrollerteInntektperioderTjenesteTest {
+
+    private static final LocalDate FOM = LocalDate.of(2025, 1, 1);
+    private static final LocalDate TOM = LocalDate.of(2025, 1, 31);
+
+    private TilkjentYtelseRepository tilkjentYtelseRepository;
+    private RelevanteKontrollperioderUtleder relevanteKontrollperioderUtleder;
+    private KontrollerteInntektperioderTjeneste tjeneste;
+
+    @BeforeEach
+    void setUp() {
+        tilkjentYtelseRepository = mock(TilkjentYtelseRepository.class);
+        relevanteKontrollperioderUtleder = mock(RelevanteKontrollperioderUtleder.class);
+        when(tilkjentYtelseRepository.hentKontrollertInntektPerioder(anyLong())).thenReturn(Optional.empty());
+        tjeneste = new KontrollerteInntektperioderTjeneste(tilkjentYtelseRepository, relevanteKontrollperioderUtleder);
+    }
+
+    @Test
+    void skal_separere_atfl_og_ytelse_korrekt() {
+        var atflBeløp = BigDecimal.valueOf(5000);
+        var ytelseBeløp = BigDecimal.valueOf(3000);
+        var inntektsresultat = new Inntektsresultat(
+            Set.of(
+                new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, atflBeløp),
+                new RapportertInntekt(InntektType.YTELSE, ytelseBeløp)
+            ),
+            KontrollertInntektKilde.BRUKER
+        );
+        var inntektTidslinje = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(FOM, TOM, inntektsresultat)));
+        var rapporterteInntekterTidslinje = LocalDateTimeline.<RapporterteInntekter>empty();
+
+        tjeneste.opprettKontrollerteInntekterPerioderFraBruker(1L, inntektTidslinje, rapporterteInntekterTidslinje, "input", "sporing");
+
+        ArgumentCaptor<List<KontrollertInntektPeriode>> captor = ArgumentCaptor.captor();
+        verify(tilkjentYtelseRepository).lagreKontrollertePerioder(eq(1L), captor.capture(), anyString(), anyString());
+        var perioder = captor.getValue();
+        assertThat(perioder).hasSize(1);
+        var periode = perioder.get(0);
+        assertThat(periode.getInntekt()).isEqualByComparingTo(atflBeløp);
+        assertThat(periode.getYtelse()).isEqualByComparingTo(ytelseBeløp);
+        assertThat(periode.getKilde()).isEqualTo(KontrollertInntektKilde.BRUKER);
+    }
+
+    @Test
+    void skal_sette_ytelse_til_null_naar_bare_atfl() {
+        var atflBeløp = BigDecimal.valueOf(4000);
+        var inntektsresultat = new Inntektsresultat(
+            Set.of(new RapportertInntekt(InntektType.ARBEIDSTAKER_ELLER_FRILANSER, atflBeløp)),
+            KontrollertInntektKilde.BRUKER
+        );
+        var inntektTidslinje = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(FOM, TOM, inntektsresultat)));
+        var rapporterteInntekterTidslinje = LocalDateTimeline.<RapporterteInntekter>empty();
+
+        tjeneste.opprettKontrollerteInntekterPerioderFraBruker(1L, inntektTidslinje, rapporterteInntekterTidslinje, "input", "sporing");
+
+        ArgumentCaptor<List<KontrollertInntektPeriode>> captor = ArgumentCaptor.captor();
+        verify(tilkjentYtelseRepository).lagreKontrollertePerioder(eq(1L), captor.capture(), anyString(), anyString());
+        var periode = captor.getValue().get(0);
+        assertThat(periode.getInntekt()).isEqualByComparingTo(atflBeløp);
+        assertThat(periode.getYtelse()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void skal_sette_inntekt_til_null_naar_bare_ytelse() {
+        var ytelseBeløp = BigDecimal.valueOf(2000);
+        var inntektsresultat = new Inntektsresultat(
+            Set.of(new RapportertInntekt(InntektType.YTELSE, ytelseBeløp)),
+            KontrollertInntektKilde.BRUKER
+        );
+        var inntektTidslinje = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(FOM, TOM, inntektsresultat)));
+        var rapporterteInntekterTidslinje = LocalDateTimeline.<RapporterteInntekter>empty();
+
+        tjeneste.opprettKontrollerteInntekterPerioderFraBruker(1L, inntektTidslinje, rapporterteInntekterTidslinje, "input", "sporing");
+
+        ArgumentCaptor<List<KontrollertInntektPeriode>> captor = ArgumentCaptor.captor();
+        verify(tilkjentYtelseRepository).lagreKontrollertePerioder(eq(1L), captor.capture(), anyString(), anyString());
+        var periode = captor.getValue().get(0);
+        assertThat(periode.getInntekt()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(periode.getYtelse()).isEqualByComparingTo(ytelseBeløp);
+    }
+
+    @Test
+    void skal_sette_begge_til_null_naar_ingen_inntekter() {
+        var inntektsresultat = new Inntektsresultat(Set.of(), KontrollertInntektKilde.BRUKER);
+        var inntektTidslinje = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(FOM, TOM, inntektsresultat)));
+        var rapporterteInntekterTidslinje = LocalDateTimeline.<RapporterteInntekter>empty();
+
+        tjeneste.opprettKontrollerteInntekterPerioderFraBruker(1L, inntektTidslinje, rapporterteInntekterTidslinje, "input", "sporing");
+
+        ArgumentCaptor<List<KontrollertInntektPeriode>> captor = ArgumentCaptor.captor();
+        verify(tilkjentYtelseRepository).lagreKontrollertePerioder(eq(1L), captor.capture(), anyString(), anyString());
+        var periode = captor.getValue().get(0);
+        assertThat(periode.getInntekt()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(periode.getYtelse()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/web/src/main/java/no/nav/ung/sak/web/app/ungdomsytelse/MånedsvisningDtoMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/ungdomsytelse/MånedsvisningDtoMapper.java
@@ -89,7 +89,7 @@ public class MånedsvisningDtoMapper {
 
     private static Optional<BigDecimal> finnRapportertInntekt(LocalDateTimeline<KontrollerteInntekter> kontrollertInntektForMåned) {
         return kontrollertInntektForMåned.toSegments().stream().map(LocalDateSegment::getValue)
-            .map(KontrollerteInntekter::inntekt)
+            .map(KontrollerteInntekter::arbeidsinntektOgYtelse)
             .reduce(BigDecimal::add);
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Ytelse og ATFL-inntekt må holdes separat for å kunne redusere utbetaling med ulik grad.

### **Løsning**

- `Inntektsresultat` bærer nå `Set<RapportertInntekt>` (med `InntektType`) fremfor én samlet sum
- `mapAutomatiskKontrollerteInntektperioder` summerer `ARBEIDSTAKER_ELLER_FRILANSER` og `YTELSE` separat og mapper til `medInntekt(...)`/`medYtelse(...)` på `KontrollertInntektPeriode`

### **Andre endringer**

- Fjernet ubrukt `RapportertInntektOgKilde`-record (død kode)
- Fjernet ubrukte `BigDecimal`- og `List`-importer fra `Inntektsresultat`
- Lagt til `KontrollerteInntektperioderTjenesteTest` med fire tester som dekker: kombinasjon av begge typer, bare ATFL, bare ytelse og tom mengde (0-tilfelle)
- Oppdatert berørte tester til ny `Inntektsresultat`-struktur

### **Skjermbilder** (hvis relevant)