### PR TITLE
Fjern utgatte brukerdialog-oppgave tabeller

### DIFF
--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_079__fjerne_brukerdialog_oppgave_tabeller.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_079__fjerne_brukerdialog_oppgave_tabeller.sql
@@ -1,0 +1,19 @@
+drop table if exists BD_OPPGAVE_DATA_ARBEID_FRILANS_INNTEKT;
+drop table if exists BD_OPPGAVE_DATA_YTELSE_INNTEKT;
+drop table if exists BD_OPPGAVE_DATA_PERIODE_ENDRING;
+
+drop table if exists BD_OPPGAVE_DATA_ENDRET_STARTDATO;
+drop table if exists BD_OPPGAVE_DATA_ENDRET_SLUTTDATO;
+drop table if exists BD_OPPGAVE_DATA_FJERNET_PERIODE;
+drop table if exists BD_OPPGAVE_DATA_ENDRET_PERIODE;
+drop table if exists BD_OPPGAVE_DATA_KONTROLLER_REGISTERINNTEKT;
+drop table if exists BD_OPPGAVE_DATA_INNTEKTSRAPPORTERING;
+drop table if exists BD_OPPGAVE_DATA_SOK_YTELSE;
+
+drop table if exists BD_OPPGAVE;
+
+drop sequence if exists SEQ_BD_OPPGAVE_DATA_ARBEID_FRILANS_INNTEKT;
+drop sequence if exists SEQ_BD_OPPGAVE_DATA_YTELSE_INNTEKT;
+drop sequence if exists SEQ_BD_OPPGAVE_DATA_PERIODE_ENDRING;
+drop sequence if exists SEQ_BD_OPPGAVE_DATA;
+drop sequence if exists SEQ_BD_OPPGAVE;


### PR DESCRIPTION
## Hva\nFjerner utgaatte tabeller for brukerdialog oppgave (BD_OPPGAVE) som ikke lenger er i bruk.\n\n## Endring\n- Legger til Flyway-migrering V1.0_079 som dropper BD_OPPGAVE-relaterte tabeller og sekvenser.\n\n## Hvorfor\n- Rydde opp i databaseobjekter som ikke lenger brukes av applikasjonen.\n- Redusere vedlikeholdsbyrde i skjemaet.