### PR TITLE
TSFF-2595: Lar sak med fleire duplikate uttalelser gå igjennom uten å feile

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/GenerellOppgaveBekreftelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/ung/sak/mottak/dokumentmottak/oppgavebekreftelse/GenerellOppgaveBekreftelseHåndterer.java
@@ -54,7 +54,9 @@ public class GenerellOppgaveBekreftelseHåndterer implements BekreftelseHåndter
 
         if (!etterlysning.getStatus().equals(EtterlysningStatus.VENTER)) {
             if (etterlysning.getStatus().equals(EtterlysningStatus.MOTTATT_SVAR)) {
-                throw  new IllegalStateException("Etterlysning har allerede mottatt svar, kan ikke håndtere ny uttalelse fra bruker.");
+                if (etterlysning.getBehandlingId() != 3009650L) {
+                    throw  new IllegalStateException("Etterlysning har allerede mottatt svar, kan ikke håndtere ny uttalelse fra bruker.");
+                }
             }
             // Dette kan skje dersom bruker bekrefte mens etterlysningen står i SKAL_AVBRYTES status og tasken for å avbryte etterlysningen ikke er kjørt enda.
             // I dette tifellet går vi videre uten å oppdatere etterlysningen


### PR DESCRIPTION
### **Behov / Bakgrunn**
I saken har vi fått inn fleire svar på uttalelse på grunn av ein feil i brukerdialog. Alle uttalelsene er like og vi trenger ikkje å oppdatere uttalelse på behandling. Lar heller dei duplikate journalpostene gå igjennom.
