### PR TITLE
Håndter endret startdato fra oppgitt startdato i EndretPeriodeOppgaveOppretter

### DIFF
--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/EndretPeriodeOppgaveOppretter.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/EndretPeriodeOppgaveOppretter.java
@@ -2,17 +2,6 @@ package no.nav.ung.sak.etterlysning.programperiode;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-import no.nav.ung.kodeverk.varsel.EtterlysningStatus;
-import no.nav.ung.kodeverk.varsel.EtterlysningType;
-import no.nav.ung.sak.behandlingslager.behandling.Behandling;
-import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoGrunnlag;
-import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
-import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
-import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
-import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
-import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
-import no.nav.ung.sak.etterlysning.UngBrukerdialogOppgaveKlient;
-import no.nav.ung.sak.etterlysning.OppgaveYtelsetypeMapper;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveYtelsetype;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OpprettOppgaveDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.EndretPeriodeDataDto;
@@ -20,12 +9,25 @@ import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.PeriodeDTO;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.PeriodeEndringType;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretsluttdato.EndretSluttdatoDataDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretstartdato.EndretStartdatoDataDto;
+import no.nav.ung.kodeverk.varsel.EtterlysningStatus;
+import no.nav.ung.kodeverk.varsel.EtterlysningType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoGrunnlag;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoer;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseSøktStartdato;
+import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
+import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
+import no.nav.ung.sak.etterlysning.OppgaveYtelsetypeMapper;
+import no.nav.ung.sak.etterlysning.UngBrukerdialogOppgaveKlient;
 import no.nav.ung.sak.typer.AktørId;
+
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.time.Period;
+import java.util.*;
 
 import static no.nav.ung.sak.domene.typer.tid.AbstractLocalDateInterval.TIDENES_ENDE;
 
@@ -110,9 +112,9 @@ public class EndretPeriodeOppgaveOppretter {
             log.info("Fant endring i både start og slutt for etterlysning {}. Ny sluttdato og grunnlag: {}, forrige sluttdato og grunnlag: {}. Ny startdato og grunnlag: {}, forrige startdato og grunnlag: {}.",
                 etterlysning.getEksternReferanse(),
                 endretSluttDato.get().nyDatoOgGrunnlag(),
-            endretSluttDato.get().forrigeDatoOgGrunnlag(),
-            endretStartDato.get().nyDatoOgGrunnlag(),
-            endretStartDato.get().forrigeDatoOgGrunnlag());
+                endretSluttDato.get().forrigeDatoOgGrunnlag(),
+                endretStartDato.get().nyDatoOgGrunnlag(),
+                endretStartDato.get().forrigeDatoOgGrunnlag());
             PeriodeDTO nyPeriode = hentPeriodeFraGrunnlag(gjeldendeGrunnlag);
             PeriodeDTO forrigePeriode = hentPeriodeFraGrunnlag(initieltPeriodeGrunnlag);
             var endringer = Set.of(PeriodeEndringType.ENDRET_STARTDATO, PeriodeEndringType.ENDRET_SLUTTDATO);
@@ -125,9 +127,9 @@ public class EndretPeriodeOppgaveOppretter {
     }
 
     private List<PeriodeSnapshot> finnSortertSnapshotlisteForSammenligning(
-            Etterlysning etterlysning,
-            UngdomsprogramPeriodeGrunnlag initieltPeriodeGrunnlag,
-            Optional<UngdomsytelseStartdatoGrunnlag> startdatoGrunnlag) {
+        Etterlysning etterlysning,
+        UngdomsprogramPeriodeGrunnlag initieltPeriodeGrunnlag,
+        Optional<UngdomsytelseStartdatoGrunnlag> startdatoGrunnlag) {
         List<Etterlysning> sorterteEtterlysninger = etterlysningRepository.hentEtterlysningerMedSisteFørst(etterlysning.getId(), EtterlysningType.UTTALELSE_ENDRET_PERIODE);
 
         // Dersom vi treffer en etterlysning som er mottatt svar eller utløpt, betyr det at bruker har tatt stilling til alle endringer før denne. Det er derfor ikke nødvendig å sjekke flere grunnlag.
@@ -145,8 +147,12 @@ public class EndretPeriodeOppgaveOppretter {
         // Oppgitt startdato (fra søknaden) legges til sist.
         // Dette håndterer caset der perioden endres mellom søknadstidspunkt og innhenting: kun ett grunnlag finnes, men startdato er endret.
         startdatoGrunnlag
+            .stream()
             .map(UngdomsytelseStartdatoGrunnlag::getOppgitteStartdatoer)
-            .map(startdatoer -> startdatoer.getStartdatoer().iterator().next().getStartdato())
+            .map(UngdomsytelseStartdatoer::getStartdatoer)
+            .flatMap(Collection::stream)
+            .map(UngdomsytelseSøktStartdato::getStartdato)
+            .min(Comparator.comparing(d -> BigDecimal.valueOf(Period.between(d, etterlysning.getPeriode().getFomDato()).getDays()).abs())) // Finner startdato nærmest aktuell periode
             .map(PeriodeSnapshot::fraOppgittStartdato)
             .ifPresent(snapshotsSortert::add);
 

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/EndretPeriodeOppgaveOppretter.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/EndretPeriodeOppgaveOppretter.java
@@ -5,6 +5,8 @@ import jakarta.inject.Inject;
 import no.nav.ung.kodeverk.varsel.EtterlysningStatus;
 import no.nav.ung.kodeverk.varsel.EtterlysningType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoGrunnlag;
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseStartdatoRepository;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
@@ -18,9 +20,7 @@ import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.PeriodeDTO;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.PeriodeEndringType;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretsluttdato.EndretSluttdatoDataDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretstartdato.EndretStartdatoDataDto;
-import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.typer.AktørId;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,14 +37,17 @@ public class EndretPeriodeOppgaveOppretter {
     private final UngBrukerdialogOppgaveKlient oppgaveKlient;
     private final UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository;
     private final EtterlysningRepository etterlysningRepository;
+    private final UngdomsytelseStartdatoRepository startdatoRepository;
 
     @Inject
     public EndretPeriodeOppgaveOppretter(UngBrukerdialogOppgaveKlient oppgaveKlient,
                                          UngdomsprogramPeriodeRepository ungdomsprogramPeriodeRepository,
-                                         EtterlysningRepository etterlysningRepository) {
+                                         EtterlysningRepository etterlysningRepository,
+                                         UngdomsytelseStartdatoRepository startdatoRepository) {
         this.oppgaveKlient = oppgaveKlient;
         this.ungdomsprogramPeriodeRepository = ungdomsprogramPeriodeRepository;
         this.etterlysningRepository = etterlysningRepository;
+        this.startdatoRepository = startdatoRepository;
     }
 
 
@@ -61,23 +64,26 @@ public class EndretPeriodeOppgaveOppretter {
         }
         Etterlysning etterlysning = etterlysninger.getFirst();
         UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlagFraGrunnlagsReferanse(etterlysning.getGrunnlagsreferanse());
+        Optional<UngdomsytelseStartdatoGrunnlag> startdatoGrunnlag = startdatoRepository.hentGrunnlag(behandling.getId());
 
         // Dette med å finne diff kan potensielt forenkles dersom vi ikkje trenger å vise kva startdato og sluttdato var før endringen.
-        List<UngdomsprogramPeriodeGrunnlag> grunnlagslisteForSammenligning = finnSortertGrunnlagslisteForSammenligning(etterlysning, initieltPeriodeGrunnlag);
+        List<PeriodeSnapshot> snapshotsForSammenligning = finnSortertSnapshotlisteForSammenligning(etterlysning, initieltPeriodeGrunnlag, startdatoGrunnlag);
 
-        log.info("Utleder endringer fra grunnlag med referanse {} basert på følgende grunnlag for sammenligning: {}",
+        PeriodeSnapshot gjeldendeSnapshot = PeriodeSnapshot.fraGrunnlag(gjeldendeGrunnlag);
+
+        log.info("Utleder endringer fra grunnlag med referanse {} basert på følgende snapshots for sammenligning: {}",
             gjeldendeGrunnlag.getGrunnlagsreferanse(),
-            grunnlagslisteForSammenligning.stream().map(UngdomsprogramPeriodeGrunnlag::getGrunnlagsreferanse).toList());
+            snapshotsForSammenligning.stream().map(PeriodeSnapshot::grunnlagsreferanse).toList());
 
         Optional<SisteEndringsdatoUtleder.EndretDato> endretStartDato = SisteEndringsdatoUtleder.finnSistEndretDato(
-            gjeldendeGrunnlag,
-            grunnlagslisteForSammenligning,
-            EndretPeriodeOppgaveOppretter::getStartdato);
+            gjeldendeSnapshot,
+            snapshotsForSammenligning,
+            PeriodeSnapshot::fomDato);
 
         Optional<SisteEndringsdatoUtleder.EndretDato> endretSluttDato = SisteEndringsdatoUtleder.finnSistEndretDato(
-            gjeldendeGrunnlag,
-            grunnlagslisteForSammenligning,
-            EndretPeriodeOppgaveOppretter::getSluttdato);
+            gjeldendeSnapshot,
+            snapshotsForSammenligning,
+            s -> s.tomDato().filter(d -> !d.equals(TIDENES_ENDE)));
 
         if (endretStartDato.isPresent() && endretSluttDato.isEmpty()) {
             // ENDRING AV STARTDATO
@@ -118,7 +124,10 @@ public class EndretPeriodeOppgaveOppretter {
 
     }
 
-    private List<UngdomsprogramPeriodeGrunnlag> finnSortertGrunnlagslisteForSammenligning(Etterlysning etterlysning, UngdomsprogramPeriodeGrunnlag initieltPeriodeGrunnlag) {
+    private List<PeriodeSnapshot> finnSortertSnapshotlisteForSammenligning(
+            Etterlysning etterlysning,
+            UngdomsprogramPeriodeGrunnlag initieltPeriodeGrunnlag,
+            Optional<UngdomsytelseStartdatoGrunnlag> startdatoGrunnlag) {
         List<Etterlysning> sorterteEtterlysninger = etterlysningRepository.hentEtterlysningerMedSisteFørst(etterlysning.getId(), EtterlysningType.UTTALELSE_ENDRET_PERIODE);
 
         // Dersom vi treffer en etterlysning som er mottatt svar eller utløpt, betyr det at bruker har tatt stilling til alle endringer før denne. Det er derfor ikke nødvendig å sjekke flere grunnlag.
@@ -126,20 +135,22 @@ public class EndretPeriodeOppgaveOppretter {
             .takeWhile(it -> it.getStatus() != EtterlysningStatus.MOTTATT_SVAR && it.getStatus() != EtterlysningStatus.UTLØPT)
             .filter(it -> it.getStatus() == EtterlysningStatus.AVBRUTT).toList();
 
-        // Henter alle aktuelle grunnlag. Beholder rekkefølge fra etterlysningene
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = new ArrayList<>(ungdomsprogramPeriodeRepository.hentGrunnlagFraReferanser(
+        // Henter alle aktuelle grunnlag og konverterer til snapshots. Beholder rekkefølge fra etterlysningene.
+        List<PeriodeSnapshot> snapshotsSortert = new ArrayList<>(ungdomsprogramPeriodeRepository.hentGrunnlagFraReferanser(
             tidligereEtterlysningerSomBleAvbruttSortert.stream().map(Etterlysning::getGrunnlagsreferanse).toList()
-        ));
-        aktuelleGrunnlagSortert.add(initieltPeriodeGrunnlag); // Legger til initielt grunnlag sist for sjekk
-        return aktuelleGrunnlagSortert;
-    }
+        ).stream().map(PeriodeSnapshot::fraGrunnlag).toList());
 
-    private static Optional<LocalDate> getStartdato(UngdomsprogramPeriodeGrunnlag grunnlag) {
-        return grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-    }
+        snapshotsSortert.add(PeriodeSnapshot.fraGrunnlag(initieltPeriodeGrunnlag)); // Legger til initielt grunnlag for sjekk
 
-    private static Optional<LocalDate> getSluttdato(UngdomsprogramPeriodeGrunnlag grunnlag) {
-        return grunnlag.hentForEksaktEnPeriodeDersomFinnes().filter(it -> !it.getTomDato().equals(TIDENES_ENDE)).map(DatoIntervallEntitet::getTomDato);
+        // Oppgitt startdato (fra søknaden) legges til sist.
+        // Dette håndterer caset der perioden endres mellom søknadstidspunkt og innhenting: kun ett grunnlag finnes, men startdato er endret.
+        startdatoGrunnlag
+            .map(UngdomsytelseStartdatoGrunnlag::getOppgitteStartdatoer)
+            .map(startdatoer -> startdatoer.getStartdatoer().iterator().next().getStartdato())
+            .map(PeriodeSnapshot::fraOppgittStartdato)
+            .ifPresent(snapshotsSortert::add);
+
+        return snapshotsSortert;
     }
 
     private OpprettOppgaveDto mapTilEndretPeriodeOppgaveDto(Etterlysning etterlysning, AktørId aktørId, OppgaveYtelsetype ytelsetype, PeriodeDTO nyPeriode, PeriodeDTO forrigePeriode, Set<PeriodeEndringType> endringer) {

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/EndretPeriodeOppgaveOppretter.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/EndretPeriodeOppgaveOppretter.java
@@ -66,64 +66,74 @@ public class EndretPeriodeOppgaveOppretter {
         }
         Etterlysning etterlysning = etterlysninger.getFirst();
         UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlagFraGrunnlagsReferanse(etterlysning.getGrunnlagsreferanse());
-        Optional<UngdomsytelseStartdatoGrunnlag> startdatoGrunnlag = startdatoRepository.hentGrunnlag(behandling.getId());
 
-        // Dette med å finne diff kan potensielt forenkles dersom vi ikkje trenger å vise kva startdato og sluttdato var før endringen.
-        List<PeriodeSnapshot> snapshotsForSammenligning = finnSortertSnapshotlisteForSammenligning(etterlysning, initieltPeriodeGrunnlag, startdatoGrunnlag);
 
-        PeriodeSnapshot gjeldendeSnapshot = PeriodeSnapshot.fraGrunnlag(gjeldendeGrunnlag);
-
-        log.info("Utleder endringer fra grunnlag med referanse {} basert på følgende snapshots for sammenligning: {}",
-            gjeldendeGrunnlag.getGrunnlagsreferanse(),
-            snapshotsForSammenligning.stream().map(PeriodeSnapshot::grunnlagsreferanse).toList());
-
-        Optional<SisteEndringsdatoUtleder.EndretDato> endretStartDato = SisteEndringsdatoUtleder.finnSistEndretDato(
-            gjeldendeSnapshot,
-            snapshotsForSammenligning,
-            PeriodeSnapshot::fomDato);
-
-        Optional<SisteEndringsdatoUtleder.EndretDato> endretSluttDato = SisteEndringsdatoUtleder.finnSistEndretDato(
-            gjeldendeSnapshot,
-            snapshotsForSammenligning,
-            s -> s.tomDato().filter(d -> !d.equals(TIDENES_ENDE)));
-
-        if (endretStartDato.isPresent() && endretSluttDato.isEmpty()) {
-            // ENDRING AV STARTDATO
-            log.info("Fant kun endring i startdato for etterlysning {}. Ny startdato og grunnlag: {}, forrige startdato og grunnlag: {}",
-                etterlysning.getEksternReferanse(),
-                endretStartDato.get().nyDatoOgGrunnlag(),
-                endretStartDato.get().forrigeDatoOgGrunnlag());
-            var oppgaveDto = mapTilStartdatoOppgaveDto(etterlysning, aktørId, ytelsetype, endretStartDato.get().nyDatoOgGrunnlag().dato(), endretStartDato.get().forrigeDatoOgGrunnlag().dato());
-            oppgaveKlient.opprettOppgave(oppgaveDto);
-        } else if (endretStartDato.isEmpty() && endretSluttDato.isPresent()) {
-            // ENDRING AV SLUTTDATO
-            log.info("Fant kun endring i sluttdato for etterlysning {}. Ny sluttdato og grunnlag: {}, forrige sluttdato og grunnlag: {}",
-                etterlysning.getEksternReferanse(),
-                endretSluttDato.get().nyDatoOgGrunnlag(),
-                endretSluttDato.get().forrigeDatoOgGrunnlag());
-            var oppgaveDto = mapTilSluttdatoOppgaveDto(etterlysning, aktørId, ytelsetype, endretSluttDato.get().nyDatoOgGrunnlag().dato(), endretSluttDato.get().forrigeDatoOgGrunnlag().dato());
-            oppgaveKlient.opprettOppgave(oppgaveDto);
-        } else if (gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes().isEmpty()) {
+        if (erPeriodeFjernet(gjeldendeGrunnlag)) {
             // FJERNET PERIODE
             PeriodeDTO forrigePeriode = hentPeriodeFraGrunnlag(initieltPeriodeGrunnlag);
             var oppgaveDto = mapTilFjernetPeriodeOppgaveDto(etterlysning, aktørId, ytelsetype, forrigePeriode);
             oppgaveKlient.opprettOppgave(oppgaveDto);
-        } else if (endretStartDato.isPresent() && endretSluttDato.isPresent()) {
-            log.info("Fant endring i både start og slutt for etterlysning {}. Ny sluttdato og grunnlag: {}, forrige sluttdato og grunnlag: {}. Ny startdato og grunnlag: {}, forrige startdato og grunnlag: {}.",
-                etterlysning.getEksternReferanse(),
-                endretSluttDato.get().nyDatoOgGrunnlag(),
-                endretSluttDato.get().forrigeDatoOgGrunnlag(),
-                endretStartDato.get().nyDatoOgGrunnlag(),
-                endretStartDato.get().forrigeDatoOgGrunnlag());
-            PeriodeDTO nyPeriode = hentPeriodeFraGrunnlag(gjeldendeGrunnlag);
-            PeriodeDTO forrigePeriode = hentPeriodeFraGrunnlag(initieltPeriodeGrunnlag);
-            var endringer = Set.of(PeriodeEndringType.ENDRET_STARTDATO, PeriodeEndringType.ENDRET_SLUTTDATO);
-            var oppgaveDto = mapTilEndretPeriodeOppgaveDto(etterlysning, aktørId, ytelsetype, nyPeriode, forrigePeriode, endringer);
-            oppgaveKlient.opprettOppgave(oppgaveDto);
         } else {
-            throw new IllegalStateException("Fant ingen endringer som kunne mappes til oppgave for etterlysning " + etterlysning.getEksternReferanse());
+            Optional<UngdomsytelseStartdatoGrunnlag> startdatoGrunnlag = startdatoRepository.hentGrunnlag(behandling.getId());
+
+            // Dette med å finne diff kan potensielt forenkles dersom vi ikkje trenger å vise kva startdato og sluttdato var før endringen.
+            List<PeriodeSnapshot> snapshotsForSammenligning = finnSortertSnapshotlisteForSammenligning(etterlysning, initieltPeriodeGrunnlag, startdatoGrunnlag);
+
+            PeriodeSnapshot gjeldendeSnapshot = PeriodeSnapshot.fraGrunnlag(gjeldendeGrunnlag);
+
+            log.info("Utleder endringer fra grunnlag med referanse {} basert på følgende snapshots for sammenligning: {}",
+                gjeldendeGrunnlag.getGrunnlagsreferanse(),
+                snapshotsForSammenligning.stream().map(PeriodeSnapshot::beskrivelse).toList());
+
+            Optional<SisteEndringsdatoUtleder.EndretDato> endretStartDato = SisteEndringsdatoUtleder.finnSistEndretDato(
+                gjeldendeSnapshot,
+                snapshotsForSammenligning,
+                PeriodeSnapshot::fomDato);
+
+            Optional<SisteEndringsdatoUtleder.EndretDato> endretSluttDato = SisteEndringsdatoUtleder.finnSistEndretDato(
+                gjeldendeSnapshot,
+                snapshotsForSammenligning,
+                PeriodeSnapshot::fomDato);
+
+            if (endretStartDato.isPresent() && endretSluttDato.isEmpty()) {
+                // ENDRING AV STARTDATO
+                log.info("Fant kun endring i startdato for etterlysning {}. Ny startdato og grunnlag: {}, forrige startdato og grunnlag: {}",
+                    etterlysning.getEksternReferanse(),
+                    endretStartDato.get().nyDatoOgBeskrivelse(),
+                    endretStartDato.get().forrigeDatoOgBeskrivelse());
+                var oppgaveDto = mapTilStartdatoOppgaveDto(etterlysning, aktørId, ytelsetype, endretStartDato.get().nyDatoOgBeskrivelse().dato(), endretStartDato.get().forrigeDatoOgBeskrivelse().dato());
+                oppgaveKlient.opprettOppgave(oppgaveDto);
+            } else if (endretStartDato.isEmpty() && endretSluttDato.isPresent()) {
+                // ENDRING AV SLUTTDATO
+                log.info("Fant kun endring i sluttdato for etterlysning {}. Ny sluttdato og grunnlag: {}, forrige sluttdato og grunnlag: {}",
+                    etterlysning.getEksternReferanse(),
+                    endretSluttDato.get().nyDatoOgBeskrivelse(),
+                    endretSluttDato.get().forrigeDatoOgBeskrivelse());
+                var oppgaveDto = mapTilSluttdatoOppgaveDto(etterlysning, aktørId, ytelsetype, endretSluttDato.get().nyDatoOgBeskrivelse().dato(), endretSluttDato.get().forrigeDatoOgBeskrivelse().dato());
+                oppgaveKlient.opprettOppgave(oppgaveDto);
+            }  else if (endretStartDato.isPresent() && endretSluttDato.isPresent()) {
+                log.info("Fant endring i både start og slutt for etterlysning {}. Ny sluttdato og grunnlag: {}, forrige sluttdato og grunnlag: {}. Ny startdato og grunnlag: {}, forrige startdato og grunnlag: {}.",
+                    etterlysning.getEksternReferanse(),
+                    endretSluttDato.get().nyDatoOgBeskrivelse(),
+                    endretSluttDato.get().forrigeDatoOgBeskrivelse(),
+                    endretStartDato.get().nyDatoOgBeskrivelse(),
+                    endretStartDato.get().forrigeDatoOgBeskrivelse());
+                PeriodeDTO nyPeriode = hentPeriodeFraGrunnlag(gjeldendeGrunnlag);
+                PeriodeDTO forrigePeriode = hentPeriodeFraGrunnlag(initieltPeriodeGrunnlag);
+                var endringer = Set.of(PeriodeEndringType.ENDRET_STARTDATO, PeriodeEndringType.ENDRET_SLUTTDATO);
+                var oppgaveDto = mapTilEndretPeriodeOppgaveDto(etterlysning, aktørId, ytelsetype, nyPeriode, forrigePeriode, endringer);
+                oppgaveKlient.opprettOppgave(oppgaveDto);
+            } else {
+                throw new IllegalStateException("Fant ingen endringer som kunne mappes til oppgave for etterlysning " + etterlysning.getEksternReferanse());
+            }
+
         }
 
+
+    }
+
+    private static boolean erPeriodeFjernet(UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag) {
+        return gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes().isEmpty();
     }
 
     private List<PeriodeSnapshot> finnSortertSnapshotlisteForSammenligning(
@@ -151,8 +161,7 @@ public class EndretPeriodeOppgaveOppretter {
             .map(UngdomsytelseStartdatoGrunnlag::getOppgitteStartdatoer)
             .map(UngdomsytelseStartdatoer::getStartdatoer)
             .flatMap(Collection::stream)
-            .map(UngdomsytelseSøktStartdato::getStartdato)
-            .min(Comparator.comparing(d -> BigDecimal.valueOf(Period.between(d, etterlysning.getPeriode().getFomDato()).getDays()).abs())) // Finner startdato nærmest aktuell periode
+            .min(Comparator.comparing(s -> BigDecimal.valueOf(Period.between(s.getStartdato(), etterlysning.getPeriode().getFomDato()).getDays()).abs())) // Finner startdato nærmest aktuell periode
             .map(PeriodeSnapshot::fraOppgittStartdato)
             .ifPresent(snapshotsSortert::add);
 

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
@@ -1,0 +1,33 @@
+package no.nav.ung.sak.etterlysning.programperiode;
+
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Representerer et snapshot av periodedata (fom/tom + referanse) uavhengig av {@link UngdomsprogramPeriodeGrunnlag}.
+ * Brukes i sammenligningslogikken for å finne endringer i start- eller sluttdato.
+ * Kan være konstruert fra et reelt grunnlag eller syntetisk fra oppgitt startdato i søknaden.
+ */
+record PeriodeSnapshot(Optional<LocalDate> fomDato, Optional<LocalDate> tomDato, UUID grunnlagsreferanse) {
+
+    static PeriodeSnapshot fraGrunnlag(UngdomsprogramPeriodeGrunnlag grunnlag) {
+        var periode = grunnlag.hentForEksaktEnPeriodeDersomFinnes();
+        return new PeriodeSnapshot(
+            periode.map(p -> p.getFomDato()),
+            periode.map(p -> p.getTomDato()),
+            grunnlag.getGrunnlagsreferanse()
+        );
+    }
+
+    /**
+     * Syntetisk snapshot basert på oppgitt startdato fra søknaden.
+     * Brukes for å håndtere caset der perioden endres mellom søknadstidspunkt og innhenting av periodeopplysninger,
+     * slik at startdatoen kan sammenlignes mot hva bruker faktisk søkte på.
+     */
+    static PeriodeSnapshot fraOppgittStartdato(LocalDate oppgittStartdato) {
+        return new PeriodeSnapshot(Optional.ofNullable(oppgittStartdato), Optional.empty(), null);
+    }
+}

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
@@ -1,35 +1,39 @@
 package no.nav.ung.sak.etterlysning.programperiode;
 
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseSøktStartdato;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 
 import java.time.LocalDate;
 import java.util.Optional;
-import java.util.UUID;
+
+import static no.nav.ung.sak.domene.typer.tid.AbstractLocalDateInterval.TIDENES_ENDE;
 
 /**
  * Representerer et snapshot av periodedata (fom/tom + referanse) uavhengig av {@link UngdomsprogramPeriodeGrunnlag}.
  * Brukes i sammenligningslogikken for å finne endringer i start- eller sluttdato.
  * Kan være konstruert fra et reelt grunnlag eller syntetisk fra oppgitt startdato i søknaden.
  */
-record PeriodeSnapshot(Optional<LocalDate> fomDato, Optional<LocalDate> tomDato, UUID grunnlagsreferanse) {
+record PeriodeSnapshot(Optional<LocalDate> fomDato, Optional<LocalDate> tomDato, String beskrivelse) {
 
     static PeriodeSnapshot fraGrunnlag(UngdomsprogramPeriodeGrunnlag grunnlag) {
         var periode = grunnlag.hentForEksaktEnPeriodeDersomFinnes();
         return new PeriodeSnapshot(
-            periode.map(p -> p.getFomDato()),
-            periode.map(p -> p.getTomDato()),
-            grunnlag.getGrunnlagsreferanse()
+            periode.map(DatoIntervallEntitet::getFomDato),
+            periode.map(DatoIntervallEntitet::getTomDato).filter(d -> !d.equals(TIDENES_ENDE)),
+            "UngdomsprogramPeriodeGrunnlag-" + grunnlag.getGrunnlagsreferanse()
         );
     }
+
 
     /**
      * Syntetisk snapshot basert på oppgitt startdato fra søknaden.
      * Brukes for å håndtere caset der perioden endres mellom søknadstidspunkt og innhenting av periodeopplysninger,
      * slik at startdatoen kan sammenlignes mot hva bruker faktisk søkte på.
      */
-    static PeriodeSnapshot fraOppgittStartdato(LocalDate oppgittStartdato) {
-        return new PeriodeSnapshot(Optional.ofNullable(oppgittStartdato), Optional.empty(), null);
-    }
+    public static PeriodeSnapshot fraOppgittStartdato(UngdomsytelseSøktStartdato oppgittStartdato) {
+        return new PeriodeSnapshot(Optional.of(oppgittStartdato.getStartdato()), Optional.empty(), "UngdomsytelseSøktStartdato-JP" + oppgittStartdato.getJournalpostId().getVerdi());
 
+
+    }
 }

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
@@ -32,11 +32,4 @@ record PeriodeSnapshot(Optional<LocalDate> fomDato, Optional<LocalDate> tomDato,
         return new PeriodeSnapshot(Optional.ofNullable(oppgittStartdato), Optional.empty(), null);
     }
 
-    public DatoIntervallEntitet tilDatoIntervallEntitet() {
-        if (fomDato.isEmpty()) {
-            throw new IllegalStateException("Kan ikke konvertere til DatoIntervallEntitet dersom fom-dato er tom"); // Pun not intended
-        }
-        return DatoIntervallEntitet.fra(fomDato.get(), tomDato.orElse(null));
-    }
-
 }

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/PeriodeSnapshot.java
@@ -1,6 +1,7 @@
 package no.nav.ung.sak.etterlysning.programperiode;
 
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -30,4 +31,12 @@ record PeriodeSnapshot(Optional<LocalDate> fomDato, Optional<LocalDate> tomDato,
     static PeriodeSnapshot fraOppgittStartdato(LocalDate oppgittStartdato) {
         return new PeriodeSnapshot(Optional.ofNullable(oppgittStartdato), Optional.empty(), null);
     }
+
+    public DatoIntervallEntitet tilDatoIntervallEntitet() {
+        if (fomDato.isEmpty()) {
+            throw new IllegalStateException("Kan ikke konvertere til DatoIntervallEntitet dersom fom-dato er tom"); // Pun not intended
+        }
+        return DatoIntervallEntitet.fra(fomDato.get(), tomDato.orElse(null));
+    }
+
 }

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtleder.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtleder.java
@@ -3,7 +3,6 @@ package no.nav.ung.sak.etterlysning.programperiode;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public class SisteEndringsdatoUtleder {
 
@@ -23,20 +22,20 @@ public class SisteEndringsdatoUtleder {
         if (gjeldendeDato.isEmpty()) {
             return Optional.empty();
         }
-        var gjeldendeDatoOgGrunnlag = new DatoOgGrunnlag(gjeldendeDato.get(), gjeldendeSnapshot.grunnlagsreferanse());
+        var gjeldendeDatoOgGrunnlag = new DatoOgBeskrivelse(gjeldendeDato.get(), gjeldendeSnapshot.beskrivelse());
         boolean harEndringIDato = false;
-        DatoOgGrunnlag forrigeDatoOgGrunnlag = null;
+        DatoOgBeskrivelse forrigeDatoOgBeskrivelse = null;
         for (var snapshot : aktuelleSnapshotsSortert) {
             var datoISnapshot = aktuellDatoHenter.hent(snapshot);
             harEndringIDato = datoISnapshot.isEmpty() || !datoISnapshot.get().equals(gjeldendeDatoOgGrunnlag.dato);
             if (harEndringIDato) {
-                forrigeDatoOgGrunnlag = new DatoOgGrunnlag(datoISnapshot.orElse(null), gjeldendeDatoOgGrunnlag.grunnlagsreferanse);
+                forrigeDatoOgBeskrivelse = new DatoOgBeskrivelse(datoISnapshot.orElse(null), gjeldendeDatoOgGrunnlag.beskrivelse);
                 break;
             }
         }
 
         if (harEndringIDato) {
-            return Optional.of(new EndretDato(gjeldendeDatoOgGrunnlag, forrigeDatoOgGrunnlag));
+            return Optional.of(new EndretDato(gjeldendeDatoOgGrunnlag, forrigeDatoOgBeskrivelse));
         }
         return Optional.empty();
     }
@@ -48,23 +47,23 @@ public class SisteEndringsdatoUtleder {
     }
 
 
-    public record EndretDato(DatoOgGrunnlag nyDatoOgGrunnlag, DatoOgGrunnlag forrigeDatoOgGrunnlag) {
+    public record EndretDato(DatoOgBeskrivelse nyDatoOgBeskrivelse, DatoOgBeskrivelse forrigeDatoOgBeskrivelse) {
         @Override
         public String toString() {
             return "EndretDato{" +
-                "nyDatoOgGrunnlag=" + nyDatoOgGrunnlag +
-                ", forrigeDatoOgGrunnlag=" + forrigeDatoOgGrunnlag +
+                "nyDatoOgBeskrivelse=" + nyDatoOgBeskrivelse +
+                ", forrigeDatoOgBeskrivelse=" + forrigeDatoOgBeskrivelse +
                 '}';
         }
     }
 
 
-    public record DatoOgGrunnlag(LocalDate dato, UUID grunnlagsreferanse) {
+    public record DatoOgBeskrivelse(LocalDate dato, String beskrivelse) {
         @Override
         public String toString() {
             return "DatoOgGrunnlag{" +
                 "dato=" + dato +
-                ", grunnlagsreferanse=" + grunnlagsreferanse +
+                ", beskrivelse=" + beskrivelse +
                 '}';
         }
     }

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtleder.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtleder.java
@@ -1,7 +1,5 @@
 package no.nav.ung.sak.etterlysning.programperiode;
 
-import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -10,29 +8,29 @@ import java.util.UUID;
 public class SisteEndringsdatoUtleder {
 
     /**
-     * Finner endret dato (start- eller sluttdato) ved å sammenligne gjeldende grunnlag med tidligere etterlysninger og initielt grunnlag.
+     * Finner endret dato (start- eller sluttdato) ved å sammenligne gjeldende snapshot med tidligere snapshots.
      * <p>
      * Behovet for denne metoden oppstår fordi vi må finne ut om en dato har blitt endret fra det som bruker sist tok stilling til. Dersom vi har flere endringer på perioden der disse er av ulike typer (endring i startdato, endring i sluttdato...),
      * ønsker vi å kunne gi detaljert informasjon om hva som har blitt endret fra forrige etterlysning som enten ble besvart eller utløpt.
      *
-     * @param gjeldendeGrunnlag       Det aktive grunnlaget
-     * @param aktuelleGrunnlagSortert Alle aktuelle grunnlag for sammenligning sortert med nyeste først
+     * @param gjeldendeSnapshot       Snapshot av det aktive grunnlaget
+     * @param aktuelleSnapshotsSortert Alle aktuelle snapshots for sammenligning sortert med nyeste først
      * @param aktuellDatoHenter       Funksjon for å hente aktuell dato (start- eller sluttdato)
      * @return Evt. endret dato informasjon
      */
-    static Optional<EndretDato> finnSistEndretDato(UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag, List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert, AktuellDatoHenter aktuellDatoHenter) {
-        var gjeldendeDato = aktuellDatoHenter.hent(gjeldendeGrunnlag);
+    static Optional<EndretDato> finnSistEndretDato(PeriodeSnapshot gjeldendeSnapshot, List<PeriodeSnapshot> aktuelleSnapshotsSortert, AktuellDatoHenter aktuellDatoHenter) {
+        var gjeldendeDato = aktuellDatoHenter.hent(gjeldendeSnapshot);
         if (gjeldendeDato.isEmpty()) {
             return Optional.empty();
         }
-        var gjeldendeDatoOgGrunnlag = new DatoOgGrunnlag(gjeldendeDato.get(), gjeldendeGrunnlag.getGrunnlagsreferanse());
+        var gjeldendeDatoOgGrunnlag = new DatoOgGrunnlag(gjeldendeDato.get(), gjeldendeSnapshot.grunnlagsreferanse());
         boolean harEndringIDato = false;
         DatoOgGrunnlag forrigeDatoOgGrunnlag = null;
-        for (var grunnlag : aktuelleGrunnlagSortert) {
-            var datoIEtterlysning = aktuellDatoHenter.hent(grunnlag);
-            harEndringIDato = datoIEtterlysning.isEmpty() || !datoIEtterlysning.get().equals(gjeldendeDatoOgGrunnlag.dato);
+        for (var snapshot : aktuelleSnapshotsSortert) {
+            var datoISnapshot = aktuellDatoHenter.hent(snapshot);
+            harEndringIDato = datoISnapshot.isEmpty() || !datoISnapshot.get().equals(gjeldendeDatoOgGrunnlag.dato);
             if (harEndringIDato) {
-                forrigeDatoOgGrunnlag = new DatoOgGrunnlag(datoIEtterlysning.orElse(null), gjeldendeDatoOgGrunnlag.grunnlagsreferanse);
+                forrigeDatoOgGrunnlag = new DatoOgGrunnlag(datoISnapshot.orElse(null), gjeldendeDatoOgGrunnlag.grunnlagsreferanse);
                 break;
             }
         }
@@ -46,7 +44,7 @@ public class SisteEndringsdatoUtleder {
 
     @FunctionalInterface
     interface AktuellDatoHenter {
-        Optional<LocalDate> hent(UngdomsprogramPeriodeGrunnlag grunnlag);
+        Optional<LocalDate> hent(PeriodeSnapshot snapshot);
     }
 
 

--- a/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtlederTest.java
+++ b/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtlederTest.java
@@ -1,36 +1,30 @@
 package no.nav.ung.sak.etterlysning.programperiode;
 
-import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
-import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class SisteEndringsdatoUtlederTest {
+
+    private static PeriodeSnapshot snapshot(LocalDate fom, LocalDate tom) {
+        return new PeriodeSnapshot(Optional.ofNullable(fom), Optional.ofNullable(tom), UUID.randomUUID());
+    }
 
     @Test
     void skal_ikke_finne_endring_når_det_ikke_finnes_aktuelle_grunnlag() {
         // Arrange
         LocalDate gjeldendeFom = LocalDate.of(2024, 1, 1);
-        DatoIntervallEntitet gjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 12, 31));
-
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag -> grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = Collections.emptyList();
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, Collections.emptyList(), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isEmpty();
@@ -40,24 +34,13 @@ class SisteEndringsdatoUtlederTest {
     void skal_ikke_finne_endring_når_dato_er_lik_i_alle_grunnlag() {
         // Arrange
         LocalDate gjeldendeFom = LocalDate.of(2024, 1, 1);
-        DatoIntervallEntitet gjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 12, 31));
-
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        UngdomsprogramPeriodeGrunnlag grunnlag1 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag1.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        UngdomsprogramPeriodeGrunnlag grunnlag2 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag2.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag -> grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = List.of(grunnlag1, grunnlag2);
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot snapshot1 = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot snapshot2 = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(snapshot1, snapshot2), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isEmpty();
@@ -68,23 +51,12 @@ class SisteEndringsdatoUtlederTest {
         // Arrange
         LocalDate gjeldendeFom = LocalDate.of(2024, 1, 1);
         LocalDate forrigeFom = LocalDate.of(2024, 2, 1);
-
-        DatoIntervallEntitet gjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 12, 31));
-        DatoIntervallEntitet forrigePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(forrigeFom, LocalDate.of(2024, 12, 31));
-
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        UngdomsprogramPeriodeGrunnlag grunnlag1 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag1.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(forrigePeriode));
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag -> grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = List.of(grunnlag1);
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot snapshot1 = snapshot(forrigeFom, LocalDate.of(2024, 12, 31));
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(snapshot1), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isPresent();
@@ -99,30 +71,14 @@ class SisteEndringsdatoUtlederTest {
         LocalDate forrigeFom = LocalDate.of(2024, 2, 1);
         LocalDate eldsteFom = LocalDate.of(2024, 3, 1);
 
-        DatoIntervallEntitet gjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 12, 31));
-        DatoIntervallEntitet sameSomGjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 11, 30)); // Ulik TOM
-        DatoIntervallEntitet forrigePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(forrigeFom, LocalDate.of(2024, 12, 31));
-        DatoIntervallEntitet eldstePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(eldsteFom, LocalDate.of(2024, 12, 31));
-
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        UngdomsprogramPeriodeGrunnlag grunnlag1 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag1.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(sameSomGjeldendePeriode)); // Samme FOM, ulik TOM
-
-        UngdomsprogramPeriodeGrunnlag grunnlag2 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag2.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(forrigePeriode)); // Første som er ulik FOM
-
-        UngdomsprogramPeriodeGrunnlag grunnlag3 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag3.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(eldstePeriode)); // Skal ikke nås
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag -> grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = List.of(grunnlag1, grunnlag2, grunnlag3);
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot sameSomGjeldende = snapshot(gjeldendeFom, LocalDate.of(2024, 11, 30)); // Ulik TOM
+        PeriodeSnapshot forrige = snapshot(forrigeFom, LocalDate.of(2024, 12, 31));            // Første med ulik FOM
+        PeriodeSnapshot eldste = snapshot(eldsteFom, LocalDate.of(2024, 12, 31));              // Skal ikke nås
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende, forrige, eldste), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isPresent();
@@ -136,30 +92,14 @@ class SisteEndringsdatoUtlederTest {
         LocalDate gjeldendeFom = LocalDate.of(2024, 1, 1);
         LocalDate forrigeFom = LocalDate.of(2024, 2, 1);
 
-        DatoIntervallEntitet gjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 12, 31));
-        DatoIntervallEntitet sameSomGjeldendePeriode1 = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 11, 30)); // Ulik TOM
-        DatoIntervallEntitet sameSomGjeldendePeriode2 = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 10, 31)); // Ulik TOM
-        DatoIntervallEntitet forrigePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(forrigeFom, LocalDate.of(2024, 12, 31));
-
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        UngdomsprogramPeriodeGrunnlag grunnlag1 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag1.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(sameSomGjeldendePeriode1)); // Samme FOM, ulik TOM
-
-        UngdomsprogramPeriodeGrunnlag grunnlag2 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag2.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(sameSomGjeldendePeriode2)); // Samme FOM, ulik TOM
-
-        UngdomsprogramPeriodeGrunnlag grunnlag3 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag3.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(forrigePeriode)); // Tredje som er ulik FOM
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag -> grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = List.of(grunnlag1, grunnlag2, grunnlag3);
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot sameSomGjeldende1 = snapshot(gjeldendeFom, LocalDate.of(2024, 11, 30)); // Ulik TOM
+        PeriodeSnapshot sameSomGjeldende2 = snapshot(gjeldendeFom, LocalDate.of(2024, 10, 31)); // Ulik TOM
+        PeriodeSnapshot forrige = snapshot(forrigeFom, LocalDate.of(2024, 12, 31));             // Tredje med ulik FOM
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende1, sameSomGjeldende2, forrige), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isPresent();
@@ -170,17 +110,11 @@ class SisteEndringsdatoUtlederTest {
     @Test
     void skal_ikke_finne_endring_når_det_ikke_finnes_periode_i_gjeldende_grunnlag() {
         // Arrange
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.empty());
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag ->
-            grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = Collections.emptyList();
+        PeriodeSnapshot gjeldendeSnapshot = new PeriodeSnapshot(Optional.empty(), Optional.empty(), UUID.randomUUID());
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, Collections.emptyList(), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isEmpty();
@@ -192,33 +126,59 @@ class SisteEndringsdatoUtlederTest {
         LocalDate gjeldendeFom = LocalDate.of(2024, 1, 1);
         LocalDate forrigeFom = LocalDate.of(2024, 2, 1);
 
-        DatoIntervallEntitet gjeldendePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(gjeldendeFom, LocalDate.of(2024, 12, 31));
-        DatoIntervallEntitet forrigePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(forrigeFom, LocalDate.of(2024, 12, 31));
-
-        UngdomsprogramPeriodeGrunnlag gjeldendeGrunnlag = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(gjeldendeGrunnlag.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode));
-
-        UngdomsprogramPeriodeGrunnlag grunnlag1 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag1.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(gjeldendePeriode)); // Samme FOM
-
-        UngdomsprogramPeriodeGrunnlag grunnlag2 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag2.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.empty()); // Ingen periode
-
-        UngdomsprogramPeriodeGrunnlag grunnlag3 = mock(UngdomsprogramPeriodeGrunnlag.class);
-        when(grunnlag3.hentForEksaktEnPeriodeDersomFinnes()).thenReturn(Optional.of(forrigePeriode)); // Første som er ulik FOM
-
-        SisteEndringsdatoUtleder.AktuellDatoHenter datoHenter = grunnlag ->
-            grunnlag.hentForEksaktEnPeriodeDersomFinnes().map(DatoIntervallEntitet::getFomDato);
-
-        List<UngdomsprogramPeriodeGrunnlag> aktuelleGrunnlagSortert = List.of(grunnlag1, grunnlag2, grunnlag3);
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot sameSomGjeldende = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot ingenPeriode = new PeriodeSnapshot(Optional.empty(), Optional.empty(), UUID.randomUUID());
+        PeriodeSnapshot forrige = snapshot(forrigeFom, LocalDate.of(2024, 12, 31));
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeGrunnlag, aktuelleGrunnlagSortert, datoHenter);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende, ingenPeriode, forrige), PeriodeSnapshot::fomDato);
 
         // Assert
         assertThat(resultat).isPresent();
         assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
         assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isNull();
+    }
+
+    @Test
+    void skal_finne_endring_fra_oppgitt_startdato_når_kun_ett_grunnlag_finnes() {
+        // Arrange - Perioden endres mellom søknad og innhenting: gjeldende og initiell er identiske, men oppgitt startdato er ulik
+        LocalDate gjeldendeFom = LocalDate.of(2024, 2, 1); // Endret av register
+        LocalDate oppgittStartdato = LocalDate.of(2024, 1, 1); // Hva bruker søkte på
+
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot initiellSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31)); // Identisk med gjeldende
+        PeriodeSnapshot oppgittSnapshot = PeriodeSnapshot.fraOppgittStartdato(oppgittStartdato);
+
+        List<PeriodeSnapshot> sammenligningsliste = List.of(initiellSnapshot, oppgittSnapshot);
+
+        // Act
+        Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, sammenligningsliste, PeriodeSnapshot::fomDato);
+
+        // Assert
+        assertThat(resultat).isPresent();
+        assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
+        assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isEqualTo(oppgittStartdato);
+    }
+
+    @Test
+    void skal_ikke_finne_endring_fra_oppgitt_startdato_når_den_er_lik_gjeldende() {
+        // Arrange - Oppgitt startdato er lik gjeldende (ingen endring)
+        LocalDate fom = LocalDate.of(2024, 1, 1);
+
+        PeriodeSnapshot gjeldendeSnapshot = snapshot(fom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot initiellSnapshot = snapshot(fom, LocalDate.of(2024, 12, 31));
+        PeriodeSnapshot oppgittSnapshot = PeriodeSnapshot.fraOppgittStartdato(fom);
+
+        List<PeriodeSnapshot> sammenligningsliste = List.of(initiellSnapshot, oppgittSnapshot);
+
+        // Act
+        Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, sammenligningsliste, PeriodeSnapshot::fomDato);
+
+        // Assert
+        assertThat(resultat).isEmpty();
     }
 }

--- a/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtlederTest.java
+++ b/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/programperiode/SisteEndringsdatoUtlederTest.java
@@ -1,5 +1,7 @@
 package no.nav.ung.sak.etterlysning.programperiode;
 
+import no.nav.ung.sak.behandlingslager.behandling.startdato.UngdomsytelseSøktStartdato;
+import no.nav.ung.sak.typer.JournalpostId;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -13,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SisteEndringsdatoUtlederTest {
 
     private static PeriodeSnapshot snapshot(LocalDate fom, LocalDate tom) {
-        return new PeriodeSnapshot(Optional.ofNullable(fom), Optional.ofNullable(tom), UUID.randomUUID());
+        return new PeriodeSnapshot(Optional.ofNullable(fom), Optional.ofNullable(tom), "en beskrivelse");
     }
 
     @Test
@@ -24,11 +26,12 @@ class SisteEndringsdatoUtlederTest {
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, Collections.emptyList(), PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, Collections.emptyList(), getFomDato());
 
         // Assert
         assertThat(resultat).isEmpty();
     }
+
 
     @Test
     void skal_ikke_finne_endring_når_dato_er_lik_i_alle_grunnlag() {
@@ -40,11 +43,12 @@ class SisteEndringsdatoUtlederTest {
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(snapshot1, snapshot2), PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(snapshot1, snapshot2), getFomDato());
 
         // Assert
         assertThat(resultat).isEmpty();
     }
+
 
     @Test
     void skal_finne_endring_når_dato_er_ulik_i_første_grunnlag() {
@@ -56,12 +60,12 @@ class SisteEndringsdatoUtlederTest {
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(snapshot1), PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(snapshot1), getFomDato());
 
         // Assert
         assertThat(resultat).isPresent();
-        assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
-        assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isEqualTo(forrigeFom);
+        assertThat(resultat.get().nyDatoOgBeskrivelse().dato()).isEqualTo(gjeldendeFom);
+        assertThat(resultat.get().forrigeDatoOgBeskrivelse().dato()).isEqualTo(forrigeFom);
     }
 
     @Test
@@ -78,12 +82,12 @@ class SisteEndringsdatoUtlederTest {
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende, forrige, eldste), PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende, forrige, eldste), getFomDato());
 
         // Assert
         assertThat(resultat).isPresent();
-        assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
-        assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isEqualTo(forrigeFom);
+        assertThat(resultat.get().nyDatoOgBeskrivelse().dato()).isEqualTo(gjeldendeFom);
+        assertThat(resultat.get().forrigeDatoOgBeskrivelse().dato()).isEqualTo(forrigeFom);
     }
 
     @Test
@@ -99,25 +103,12 @@ class SisteEndringsdatoUtlederTest {
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende1, sameSomGjeldende2, forrige), PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende1, sameSomGjeldende2, forrige), getFomDato());
 
         // Assert
         assertThat(resultat).isPresent();
-        assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
-        assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isEqualTo(forrigeFom);
-    }
-
-    @Test
-    void skal_ikke_finne_endring_når_det_ikke_finnes_periode_i_gjeldende_grunnlag() {
-        // Arrange
-        PeriodeSnapshot gjeldendeSnapshot = new PeriodeSnapshot(Optional.empty(), Optional.empty(), UUID.randomUUID());
-
-        // Act
-        Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, Collections.emptyList(), PeriodeSnapshot::fomDato);
-
-        // Assert
-        assertThat(resultat).isEmpty();
+        assertThat(resultat.get().nyDatoOgBeskrivelse().dato()).isEqualTo(gjeldendeFom);
+        assertThat(resultat.get().forrigeDatoOgBeskrivelse().dato()).isEqualTo(forrigeFom);
     }
 
     @Test
@@ -128,17 +119,17 @@ class SisteEndringsdatoUtlederTest {
 
         PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
         PeriodeSnapshot sameSomGjeldende = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
-        PeriodeSnapshot ingenPeriode = new PeriodeSnapshot(Optional.empty(), Optional.empty(), UUID.randomUUID());
+        PeriodeSnapshot ingenPeriode = new PeriodeSnapshot(Optional.empty(), Optional.empty(), "en beskrivelse");
         PeriodeSnapshot forrige = snapshot(forrigeFom, LocalDate.of(2024, 12, 31));
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende, ingenPeriode, forrige), PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, List.of(sameSomGjeldende, ingenPeriode, forrige), getFomDato());
 
         // Assert
         assertThat(resultat).isPresent();
-        assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
-        assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isNull();
+        assertThat(resultat.get().nyDatoOgBeskrivelse().dato()).isEqualTo(gjeldendeFom);
+        assertThat(resultat.get().forrigeDatoOgBeskrivelse().dato()).isNull();
     }
 
     @Test
@@ -149,18 +140,18 @@ class SisteEndringsdatoUtlederTest {
 
         PeriodeSnapshot gjeldendeSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31));
         PeriodeSnapshot initiellSnapshot = snapshot(gjeldendeFom, LocalDate.of(2024, 12, 31)); // Identisk med gjeldende
-        PeriodeSnapshot oppgittSnapshot = PeriodeSnapshot.fraOppgittStartdato(oppgittStartdato);
+        PeriodeSnapshot oppgittSnapshot = getOppgittSnapshot(oppgittStartdato);
 
         List<PeriodeSnapshot> sammenligningsliste = List.of(initiellSnapshot, oppgittSnapshot);
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, sammenligningsliste, PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, sammenligningsliste, getFomDato());
 
         // Assert
         assertThat(resultat).isPresent();
-        assertThat(resultat.get().nyDatoOgGrunnlag().dato()).isEqualTo(gjeldendeFom);
-        assertThat(resultat.get().forrigeDatoOgGrunnlag().dato()).isEqualTo(oppgittStartdato);
+        assertThat(resultat.get().nyDatoOgBeskrivelse().dato()).isEqualTo(gjeldendeFom);
+        assertThat(resultat.get().forrigeDatoOgBeskrivelse().dato()).isEqualTo(oppgittStartdato);
     }
 
     @Test
@@ -170,15 +161,25 @@ class SisteEndringsdatoUtlederTest {
 
         PeriodeSnapshot gjeldendeSnapshot = snapshot(fom, LocalDate.of(2024, 12, 31));
         PeriodeSnapshot initiellSnapshot = snapshot(fom, LocalDate.of(2024, 12, 31));
-        PeriodeSnapshot oppgittSnapshot = PeriodeSnapshot.fraOppgittStartdato(fom);
+        PeriodeSnapshot oppgittSnapshot = getOppgittSnapshot(fom);
 
         List<PeriodeSnapshot> sammenligningsliste = List.of(initiellSnapshot, oppgittSnapshot);
 
         // Act
         Optional<SisteEndringsdatoUtleder.EndretDato> resultat =
-            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, sammenligningsliste, PeriodeSnapshot::fomDato);
+            SisteEndringsdatoUtleder.finnSistEndretDato(gjeldendeSnapshot, sammenligningsliste, getFomDato());
 
         // Assert
         assertThat(resultat).isEmpty();
     }
+
+    private static PeriodeSnapshot getOppgittSnapshot(LocalDate fom) {
+        return PeriodeSnapshot.fraOppgittStartdato(new UngdomsytelseSøktStartdato(fom, new JournalpostId("123")));
+    }
+
+
+    private static SisteEndringsdatoUtleder.AktuellDatoHenter getFomDato() {
+        return PeriodeSnapshot::fomDato;
+    }
+
 }


### PR DESCRIPTION
## Bakgrunn

Løser caset der perioden endres mellom søknadstidspunkt og innhenting av periodeopplysninger i ung-sak. I dette tilfellet finnes kun ett `UngdomsprogramPeriodeGrunnlag` (gjeldende == initiell), men startdatoen er endret fra hva bruker oppga i søknaden. `SisteEndringsdatoUtleder` fant ingen endring siden alle grunnlag hadde samme startdato – men oppgitt startdato fra `UngdomsytelseStartdatoGrunnlag` avvek.

Håndtering for selve opprettelsen av etterlysning fantes allerede i `EtterlysningForEndretProgramperiodeResultatUtlederV2.harEndretStartdatoFraOppgittStartdatoer`. Denne PR-en fikser den tilsvarende mappingen fra etterlysning til oppgave.

## Endringer

### Ny fil: `PeriodeSnapshot`
Record som kapsler periodedata (fom/tom + grunnlagsreferanse) uavhengig av `UngdomsprogramPeriodeGrunnlag`. Har to factory-metoder:
- `fraGrunnlag(UngdomsprogramPeriodeGrunnlag)` – normal case
- `fraOppgittStartdato(LocalDate)` – syntetisk entry for oppgitt startdato

### `SisteEndringsdatoUtleder`
Refaktorert til å bruke `PeriodeSnapshot` i stedet for `UngdomsprogramPeriodeGrunnlag`. Logikken er uendret.

### `EndretPeriodeOppgaveOppretter`
- Ny avhengighet: `UngdomsytelseStartdatoRepository`
- `finnSortertSnapshotlisteForSammenligning` returnerer `List<PeriodeSnapshot>`
- Legger alltid til syntetisk oppgitt-startdato-entry **etter** `initiellGrunnlag` i listen, når `UngdomsytelseStartdatoGrunnlag` finnes

Rekkefølge i sammenligningslisten:
`[avbrutte etterlysninger (nyeste først), initiellGrunnlag, oppgittStartdatoEntry?]`

`SisteEndringsdatoUtleder` stopper ved første avvik – avbrutte etterlysninger og initiell-grunnlag prioriteres. Den syntetiske entry aktiveres kun dersom ingen andre grunnlag avviker. Dersom oppgitt startdato er lik gjeldende, oppstår ingen falsk positiv.

### `SisteEndringsdatoUtlederTest`
- Erstatter mocking av `UngdomsprogramPeriodeGrunnlag` med direkte `PeriodeSnapshot`-konstruksjon
- To nye testcaser for oppgitt-startdato-caset