### PR TITLE
Legger til ansvarlig saksbehandler på AksjonspunktDto slik at det er tilgjengelig for frontend

### DIFF
--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/AksjonspunktDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/AksjonspunktDto.java
@@ -87,6 +87,11 @@ public class AksjonspunktDto {
     @Pattern(regexp = "^[\\p{Alnum}ÆØÅæøå\\p{Space}\\p{Sc}\\p{L}\\p{N}]+$", message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
     private String opprettetAv;
 
+    @JsonProperty(value = "ansvarligSaksbehandler")
+    @Size(max = 100)
+    @Pattern(regexp = "^[\\p{Alnum}ÆØÅæøå\\p{Space}\\p{Sc}\\p{L}\\p{N}]+$", message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    private String ansvarligSaksbehandler;
+
     public AksjonspunktDto() {
     }
 
@@ -208,6 +213,14 @@ public class AksjonspunktDto {
 
     public void setOpprettetAv(String opprettetAv) {
         this.opprettetAv = opprettetAv;
+    }
+
+    public String getAnsvarligSaksbehandler() {
+        return ansvarligSaksbehandler;
+    }
+
+    public void setAnsvarligSaksbehandler(String ansvarligSaksbehandler) {
+        this.ansvarligSaksbehandler = ansvarligSaksbehandler;
     }
 
     @Override

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktDtoMapper.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktDtoMapper.java
@@ -53,6 +53,7 @@ class AksjonspunktDtoMapper {
         dto.setVenteårsak(aksjonspunkt.getVenteårsak());
         dto.setVenteårsakVariant(aksjonspunkt.getVenteårsakVariant());
         dto.setOpprettetAv(aksjonspunkt.getOpprettetAv());
+        dto.setAnsvarligSaksbehandler(aksjonspunkt.getAnsvarligSaksbehandler());
 
         if (ttVurderinger != null && !ttVurderinger.isEmpty()) {
             Optional<Totrinnsvurdering> vurdering = ttVurderinger.stream().filter(v -> v.getAksjonspunktDefinisjon() == aksjonspunkt.getAksjonspunktDefinisjon()).findFirst();

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
@@ -19,6 +19,7 @@ import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursResourceType;
 import no.nav.k9.felles.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.ung.sak.behandlingslager.BaseEntitet;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.ung.sak.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.ung.sak.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
@@ -91,6 +92,11 @@ public class SaksbehandlerRestTjeneste {
             .map(BaseEntitet::getEndretAv)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet()));
+
+        unikeIdenter.addAll(behandling.getAksjonspunkter().stream()
+            .map(Aksjonspunkt::getAnsvarligSaksbehandler)
+            .filter(Objects::nonNull)
+            .toList());
 
         unikeIdenter.remove(systembruker);
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
@@ -70,7 +70,7 @@ public class SaksbehandlerRestTjeneste {
     @Operation(
         description = "Returnerer fullt navn for identer som har berørt en fagsak",
         tags = "nav-ansatt",
-        summary = ("Identer hentes fra historikkinnslag og sykdomsvurderinger.")
+        summary = ("Identer hentes fra historikkinnslag og aksjonspunkt.")
     )
     @BeskyttetRessurs(action = READ, resource = BeskyttetRessursResourceType.FAGSAK, auditlogg = false)
     public SaksbehandlerDto getSaksbehandlere(

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -9461,7 +9461,7 @@
             "description" : "default response"
           }
         },
-        "summary" : "Identer hentes fra historikkinnslag og sykdomsvurderinger.",
+        "summary" : "Identer hentes fra historikkinnslag og aksjonspunkt.",
         "tags" : [ "nav-ansatt" ]
       }
     },

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -1768,6 +1768,12 @@
           "aksjonspunktType" : {
             "$ref" : "#/components/schemas/ung.kodeverk.behandling.aksjonspunkt.AksjonspunktType"
           },
+          "ansvarligSaksbehandler" : {
+            "maxLength" : 100,
+            "minLength" : 0,
+            "pattern" : "^[\\p{Alnum}ÆØÅæøå\\p{Space}\\p{Sc}\\p{L}\\p{N}]+$",
+            "type" : "string"
+          },
           "begrunnelse" : {
             "maxLength" : 5000,
             "minLength" : 0,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Skisser for aktivitetspenger viser saksbehandler på aksjonspunkt.

### **Løsning**
Legger til ansvarlig saksbehandler på AksjonspunktDto slik at det er tilgjengelig for frontend

### **Andre endringer**

Legger saksbehandler fra aksjonspunkt til også i /saksbehandler-tjenesten, slik at mapping til navn er tilgjengelig i frontend

### **Skjermbilder** (hvis relevant)
