### PR TITLE
Fix: kan sende aksjonspunkt tilbake fra totrinnsvurdering ved lokalkontor

### DIFF
--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -461,12 +461,12 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     }
 
     public boolean validerGyldigStatusEndring(AksjonspunktStatus aksjonspunktStatus, BehandlingStatus status) {
-        return behandlingStatus.contains(status) || isFatterVedtak(aksjonspunktStatus, status);
+        return behandlingStatus.contains(status) || isBesluttningspunkt(aksjonspunktStatus, status);
     }
 
-    private boolean isFatterVedtak(AksjonspunktStatus aksjonspunktStatus, BehandlingStatus status) {
-        // I FatterVedtak kan beslutter reåpne (derav OPPRETTET) eksisterende aksjonspunkter før det sendes tilbake til saksbehandler
-        return Objects.equals(BehandlingStatus.FATTER_VEDTAK, status)
+    private boolean isBesluttningspunkt(AksjonspunktStatus aksjonspunktStatus, BehandlingStatus status) {
+        // I FatterVedtak/LokalkontorBeslutter kan beslutter reåpne (derav OPPRETTET) eksisterende aksjonspunkter før det sendes tilbake til saksbehandler
+        return Set.of(BehandlingStatus.FATTER_VEDTAK, BehandlingStatus.LOKALKONTOR_BESLUTTER_VILKÅR).contains(status)
             && Objects.equals(aksjonspunktStatus, AksjonspunktStatus.OPPRETTET);
     }
 

--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -461,10 +461,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     }
 
     public boolean validerGyldigStatusEndring(AksjonspunktStatus aksjonspunktStatus, BehandlingStatus status) {
-        return behandlingStatus.contains(status) || isBesluttningspunkt(aksjonspunktStatus, status);
+        return behandlingStatus.contains(status) || isBeslutningspunkt(aksjonspunktStatus, status);
     }
 
-    private boolean isBesluttningspunkt(AksjonspunktStatus aksjonspunktStatus, BehandlingStatus status) {
+    private boolean isBeslutningspunkt(AksjonspunktStatus aksjonspunktStatus, BehandlingStatus status) {
         // I FatterVedtak/LokalkontorBeslutter kan beslutter reåpne (derav OPPRETTET) eksisterende aksjonspunkter før det sendes tilbake til saksbehandler
         return Set.of(BehandlingStatus.FATTER_VEDTAK, BehandlingStatus.LOKALKONTOR_BESLUTTER_VILKÅR).contains(status)
             && Objects.equals(aksjonspunktStatus, AksjonspunktStatus.OPPRETTET);


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det feiler med exeption når beslutter sender lokalkontor-aksjonspunkt tilbake. https://jira.adeo.no/browse/TSFF-2620

### **Løsning**
Legger til nødvendig status i validering i AksjonspunktDefinisjon

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
