### PR TITLE
TSFF-2601: Bruker "INGEN_BEREGNING" som beregningsresultatType hvis søkeren ikke har pgi

### DIFF
--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aktivitetspenger/beregning/BesteBeregningResultatType.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aktivitetspenger/beregning/BesteBeregningResultatType.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.kontrakt.aktivitetspenger.beregning;
 
 public enum BesteBeregningResultatType {
     SISTE_ÅR,
-    SNITT_SISTE_TRE_ÅR
+    SNITT_SISTE_TRE_ÅR,
+    INGEN_BEREGNING
 }
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
@@ -158,7 +158,7 @@ public class AktivitetspengerRestTjeneste {
             grunnlag.getBeregnetRedusertPrAar().setScale(0, RoundingMode.HALF_UP),
             grunnlag.getDagsats().setScale(0, RoundingMode.HALF_UP).intValueExact(),
             pgiÅrsinntekter,
-            mapBesteBeregningResultatType(grunnlag.utledBesteBeregningResultatType())
+            grunnlag.utledBesteBeregningResultatType()
         );
     }
 
@@ -166,12 +166,5 @@ public class AktivitetspengerRestTjeneste {
         return typer.stream()
             .map(type -> pgiInntektstyper.getOrDefault(type, Beløp.ZERO).getVerdi())
             .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    private static BesteBeregningResultatType mapBesteBeregningResultatType(no.nav.ung.ytelse.aktivitetspenger.beregning.beste.BesteBeregningResultatType type) {
-        return switch (type) {
-            case SISTE_ÅR -> BesteBeregningResultatType.SISTE_ÅR;
-            case SNITT_SISTE_TRE_ÅR -> BesteBeregningResultatType.SNITT_SISTE_TRE_ÅR;
-        };
     }
 }

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -2125,9 +2125,9 @@
         "type" : "object"
       },
       "ung.sak.kontrakt.aktivitetspenger.beregning.BesteBeregningResultatType" : {
-        "enum" : [ "SISTE_ÅR", "SNITT_SISTE_TRE_ÅR" ],
+        "enum" : [ "SISTE_ÅR", "SNITT_SISTE_TRE_ÅR", "INGEN_BEREGNING" ],
         "type" : "string",
-        "x-enum-varnames" : [ "SISTE_ÅR", "SNITT_SISTE_TRE_ÅR" ]
+        "x-enum-varnames" : [ "SISTE_ÅR", "SNITT_SISTE_TRE_ÅR", "INGEN_BEREGNING" ]
       },
       "ung.sak.kontrakt.aktivitetspenger.beregning.PgiÅrsinntektDto" : {
         "properties" : {

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/Beregningsgrunnlag.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/Beregningsgrunnlag.java
@@ -2,6 +2,7 @@ package no.nav.ung.ytelse.aktivitetspenger.beregning.beste;
 
 import jakarta.persistence.*;
 import no.nav.ung.sak.diff.DiffIgnore;
+import no.nav.ung.sak.kontrakt.aktivitetspenger.beregning.BesteBeregningResultatType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -82,6 +83,9 @@ public class Beregningsgrunnlag {
     }
 
     public BesteBeregningResultatType utledBesteBeregningResultatType() {
+        if (beregnetPrAar.compareTo(BigDecimal.ZERO) <= 0) {
+            return BesteBeregningResultatType.INGEN_BEREGNING;
+        }
         if (beregnetPrAar.compareTo(årsinntektAvkortetOppjustertSisteÅr) == 0) {
             return BesteBeregningResultatType.SISTE_ÅR;
         }

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/BesteBeregningResultatType.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/beregning/beste/BesteBeregningResultatType.java
@@ -1,7 +1,0 @@
-package no.nav.ung.ytelse.aktivitetspenger.beregning.beste;
-
-public enum BesteBeregningResultatType {
-    SISTE_ÅR,
-    SNITT_SISTE_TRE_ÅR
-}
-

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/dto/innvilgelse/beregning/BeregningDto.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/dto/innvilgelse/beregning/BeregningDto.java
@@ -1,6 +1,6 @@
 package no.nav.ung.ytelse.aktivitetspenger.formidling.dto.innvilgelse.beregning;
 
-import no.nav.ung.ytelse.aktivitetspenger.beregning.beste.BesteBeregningResultatType;
+import no.nav.ung.sak.kontrakt.aktivitetspenger.beregning.BesteBeregningResultatType;
 
 import java.math.BigDecimal;
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Misvisende å vise at en benytter siste år, når inntekten er kr 0. Burde ikke vist noen markering her.

### **Løsning**
Setter typen til INGEN_BEREGNING hvis beregnetPrAar er mindre eller lik 0