### PR TITLE
Fikser at vi får 500-feil på saksbehandler-endepunktet

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
@@ -47,6 +47,7 @@ public class SaksbehandlerRestTjeneste {
 
     private String systembruker;
 
+    private String appName;
     private HistorikkinnslagRepository historikkRepository;
     private BehandlingRepository behandlingRepository;
 
@@ -56,11 +57,14 @@ public class SaksbehandlerRestTjeneste {
 
     @Inject
     public SaksbehandlerRestTjeneste(
-        MicrosoftGraphTjeneste microsoftGraphTjeneste, @KonfigVerdi(value = "systembruker.username", required = false) String systembruker,
+        MicrosoftGraphTjeneste microsoftGraphTjeneste,
+        @KonfigVerdi(value = "systembruker.username", required = false) String systembruker,
+        @KonfigVerdi(value = "NAIS_APP_NAME", defaultVerdi = "ung-sak") String appName,
         HistorikkinnslagRepository historikkRepository,
         BehandlingRepository behandlingRepository) {
         this.microsoftGraphTjeneste = microsoftGraphTjeneste;
         this.systembruker = systembruker;
+        this.appName = appName;
         this.historikkRepository = historikkRepository;
         this.behandlingRepository = behandlingRepository;
     }
@@ -98,7 +102,8 @@ public class SaksbehandlerRestTjeneste {
             .filter(Objects::nonNull)
             .toList());
 
-        unikeIdenter.remove(systembruker);
+        unikeIdenter.remove(systembruker); //bare relevant lokat
+        unikeIdenter.remove(appName);
 
         Map<String, String> identTilNavn = microsoftGraphTjeneste.navnPåNavAnsatte(unikeIdenter);
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Endepunktet feiler i dev fordi det står 'ung-sak' som ansvarlig saksbehandler i historikknnslag

### **Løsning**
Filtrer bort ung-sak fra oppslag for navn

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
