### PR TITLE
Fiks aktivitetspenger: Filtrerte på feil DetaljertResultatType

### DIFF
--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/innhold/FørstegangsInnvilgelseInnholdBygger.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/innhold/FørstegangsInnvilgelseInnholdBygger.java
@@ -62,7 +62,7 @@ public class FørstegangsInnvilgelseInnholdBygger implements VedtaksbrevInnholdB
     @WithSpan
     @Override
     public TemplateInnholdResultat bygg(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultatTidslinje) {
-        LocalDateTimeline<DetaljertResultat> periode = DetaljertResultat.filtererTidslinje(detaljertResultatTidslinje, DetaljertResultatType.INNVILGELSE_KUN_VILKÅR);
+        LocalDateTimeline<DetaljertResultat> periode = DetaljertResultat.filtererTidslinje(detaljertResultatTidslinje, DetaljertResultatType.INNVILGELSE_UTBETALING);
 
         LocalDate ytelseFom = periode.getMinLocalDate();
         LocalDate ytelseTom = null;

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/formidling/FørstegangsInnvilgelseTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/formidling/FørstegangsInnvilgelseTest.java
@@ -51,7 +51,7 @@ class FørstegangsInnvilgelseTest extends AbstractAktivitetspengerVedtaksbrevInn
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             """
                 Du får aktivitetspenger \
-                Fra 1. september 2025 får du aktivitetspenger på 681 kroner utenom lørdag og søndag. \
+                Fra 1. august 2025 får du aktivitetspenger på 681 kroner utenom lørdag og søndag. \
                 Fordi du fylte 25 år 16. august 2025, får du mer penger fra denne datoen. Da får du 1 022 kroner per dag, utenom lørdag og søndag. \
                 Pengene blir utbetalt én gang i måneden. Den første utbetalingen får du innen 12. september, og deretter får du pengene innen den 12. hver måned. \
                 Pengene du får, blir det trukket skatt av. Hvis du har frikort, blir det ikke trukket skatt. \


### PR DESCRIPTION
### **Behov / Bakgrunn**
Filtrerte på feil DetaljertResultatType ved utledning av fom dato for ytelse i brev.
Viste fom som neste måned istedenfor virkningstidspunkt.

### **Løsning**
Filtrerer på DetaljertResultatType .INNVILGELSE_UTBETALING ved utledning av ytelseperioder i vedtaksbrev
