### PR TITLE
Deaktivere task.manager.auto.traceparent

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/server/jetty/JettyServer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/jetty/JettyServer.java
@@ -131,9 +131,10 @@ public class JettyServer {
         System.setProperty("task.manager.polling.tasks.size", "10");
         System.setProperty("task.manager.polling.scrolling.select.size", "10");
 
+        /* TODO fiks - feiler i dev
         if (ENV.isDev()) {
             System.setProperty("task.manager.auto.traceparent", "true");
-        }
+        }*/
     }
 
     private void konfigurerJndi() throws Exception {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Unngå at kafka stopper:
java.lang.IllegalArgumentException: Ugyldig traceparent:00-80a845d1a0e0812cd59ae80dceeb6d8f-378d1769567100af-03
	at no.nav.k9.prosesstask.api.ProsessTaskData.setTraceparent(ProsessTaskData.java:518)
	at no.nav.k9.prosesstask.impl.ProsessTaskRepositoryImpl.lagre(ProsessTaskRepositoryImpl.java:141)
	at n.n.k.p.impl.ProsessTaskRepositoryImpl$Proxy$_$$_WeldClientProxy.lagre(Unknown Source)
	at no.nav.k9.prosesstask.impl.ProsessTaskTjenesteImpl.lagre(ProsessTaskTjenesteImpl.java:72)
	at n.n.k.p.impl.ProsessTaskTjenesteImpl$Proxy$_$$_WeldClientProxy.lagre(Unknown Source)
	at no.nav.ung.domenetjenester.arkiv.JournalføringHendelseHåndterer.handleMessage(JournalføringHendelseHåndterer.java:51)

### **Løsning**
Deaktiverer task.manager.auto.traceparent i dev
Tilsvarende https://github.com/navikt/k9-sak/pull/12891