### PR TITLE
fix: legg til YTELSETYPE abac-attributt på papirsøknad-DTOer

### DIFF
--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknad/JournalførPapirSøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknad/JournalførPapirSøknadDto.java
@@ -6,7 +6,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.felles.sikkerhet.abac.StandardAbacAttributtType;
+import no.nav.ung.kodeverk.abac.AppAbacAttributt;
+import no.nav.ung.kodeverk.abac.AppAbacAttributtType;
 import no.nav.ung.kodeverk.abac.StandardAbacAttributt;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.typer.JournalpostId;
 
 public record JournalførPapirSøknadDto(
@@ -26,4 +29,16 @@ public record JournalførPapirSøknadDto(
     String deltakerIdent
 
 ) {
+
+    /**
+     * Papirsøknad-flyten gjelder kun ungdomsytelsen, og fagsaken opprettes som
+     * en del av dette endepunktet. PDP/ABAC krever at ytelsestype kan utledes
+     * for {@code BeskyttetRessursResourceType.FAGSAK}, så vi eksponerer den
+     * eksplisitt her siden den verken kan utledes fra eksisterende fagsak eller
+     * behandling på dette tidspunktet.
+     */
+    @AppAbacAttributt(AppAbacAttributtType.YTELSETYPE)
+    public String getYtelseTypeKode() {
+        return FagsakYtelseType.UNGDOMSYTELSE.getKode();
+    }
 }

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknad/SendInnPapirsøknadopplysningerRequestDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknad/SendInnPapirsøknadopplysningerRequestDto.java
@@ -4,7 +4,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.felles.sikkerhet.abac.StandardAbacAttributtType;
+import no.nav.ung.kodeverk.abac.AppAbacAttributt;
+import no.nav.ung.kodeverk.abac.AppAbacAttributtType;
 import no.nav.ung.kodeverk.abac.StandardAbacAttributt;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.typer.JournalpostId;
 
 public record SendInnPapirsøknadopplysningerRequestDto(
@@ -18,4 +21,15 @@ public record SendInnPapirsøknadopplysningerRequestDto(
     @Valid
     JournalpostId journalpostIdForPapirsøknad
 ) {
+
+    /**
+     * Papirsøknad-flyten gjelder kun ungdomsytelsen. PDP/ABAC krever at
+     * ytelsestype kan utledes for {@code BeskyttetRessursResourceType.FAGSAK},
+     * så vi eksponerer den eksplisitt siden den ikke kan utledes fra
+     * eksisterende fagsak/behandling i dette steget.
+     */
+    @AppAbacAttributt(AppAbacAttributtType.YTELSETYPE)
+    public String getYtelseTypeKode() {
+        return FagsakYtelseType.UNGDOMSYTELSE.getKode();
+    }
 }

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -4585,6 +4585,9 @@
           },
           "journalpostId" : {
             "type" : "string"
+          },
+          "ytelseTypeKode" : {
+            "type" : "string"
           }
         },
         "required" : [ "deltakerIdent", "journalpostId" ],
@@ -4599,6 +4602,9 @@
             "type" : "string"
           },
           "journalpostIdForPapirsøknad" : {
+            "type" : "string"
+          },
+          "ytelseTypeKode" : {
             "type" : "string"
           }
         },


### PR DESCRIPTION
### Behov / Bakgrunn

Journalføring av papirsøknad i prod feilet med:

```
java.lang.IllegalArgumentException: Forventet nøyaktig én fagsakYtelseType, men har: []
    at no.nav.ung.sak.web.server.abac.PdpRequestMapper.map(PdpRequestMapper.java:65)
```

PR #1115 innførte krav om at \`FagsakYtelseType\` må utledes for alle endepunkter med \`BeskyttetRessursResourceType.FAGSAK\`. Ytelsestype utledes fra én av tre kilder: eksisterende behandling, \`@AppAbacAttributt(YTELSETYPE)\` på DTO, eller eksisterende fagsaker via saksnummer.

Papirsøknad-endepunktene (\`steg-2/journalfør-papir-søknad-mot-fagsak\` og \`steg-3/send-inn-papirsøknadopplysninger\`) **oppretter** fagsaken som en del av kallet. Det finnes derfor verken eksisterende fagsak, behandling eller saksnummer å utlede ytelsestype fra på ABAC-tidspunktet — og DTOene manglet \`@AppAbacAttributt(YTELSETYPE)\`.

### Løsning

La til \`@AppAbacAttributt(AppAbacAttributtType.YTELSETYPE)\`-annotert getter på begge DTO-ene som returnerer \`FagsakYtelseType.UNGDOMSYTELSE.getKode()\`. Dette er det etablerte mønstret, brukt bl.a. i \`FinnSak.getYtelseTypeKode()\`.

Hardkodingen av \`UNGDOMSYTELSE\` er trygg fordi \`PapirsøknadHåndteringTjeneste\` selv hardkoder \`FagsakYtelseType.UNGDOMSYTELSE\` i alle kall.

Endrede filer:
- \`kontrakt/.../JournalførPapirSøknadDto.java\`
- \`kontrakt/.../SendInnPapirsøknadopplysningerRequestDto.java\`

### Andre endringer

Ingen.