### PR TITLE
Fjern ${validatedValue} fra @Pattern-meldinger på fritekstfelter

### DIFF
--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/KortTekst.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/KortTekst.java
@@ -4,15 +4,16 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import no.nav.ung.sak.kontrakt.Patterns;
 
 public class KortTekst {
 
     @JsonValue
     @Size(max = 2000)
-    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String tekst;
 
-    public KortTekst(@Size(max = 2000) @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]") String tekst) {
+    public KortTekst(@Size(max = 2000) @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message = Patterns.FRITEKST_MISMATCH_MELDING) String tekst) {
         this.tekst = tekst;
     }
 

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/Patterns.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/Patterns.java
@@ -6,5 +6,7 @@ public final class Patterns {
     public static final String FRITEKSTBREV =
         "^[\\p{Graph}\\p{IsWhite_Space}\\p{Sc}\\p{L}\\p{M}\\p{N}§\\p{Pd}]*$";
 
+    public static final String FRITEKST_MISMATCH_MELDING = "matcher ikke tillatt pattern [{regexp}]";
+
     private Patterns() {}
 }

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/AksjonspunktDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/AksjonspunktDto.java
@@ -34,12 +34,12 @@ public class AksjonspunktDto {
 
     @JsonProperty(value = "begrunnelse")
     @Size(max = 5000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     @JsonProperty(value = "besluttersBegrunnelse")
     @Size(max = 5000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String besluttersBegrunnelse;
 
     @JsonProperty(value = "definisjon")

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/BekreftetAksjonspunktDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/BekreftetAksjonspunktDto.java
@@ -26,7 +26,7 @@ public abstract class BekreftetAksjonspunktDto implements AksjonspunktKode {
 
     @JsonProperty("begrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     protected BekreftetAksjonspunktDto() {

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/OverstyringAksjonspunktDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/aksjonspunkt/OverstyringAksjonspunktDto.java
@@ -29,7 +29,7 @@ public abstract class OverstyringAksjonspunktDto implements AksjonspunktKode, Ov
 
     @JsonProperty("begrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
 

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/behandling/ByttBehandlendeEnhetDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/behandling/ByttBehandlendeEnhetDto.java
@@ -25,7 +25,7 @@ public class ByttBehandlendeEnhetDto {
     @JsonProperty(value = "begrunnelse", required = true)
     @NotNull
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     @JsonProperty(value = "behandlingId", required = true)

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/behandling/HenleggBehandlingDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/behandling/HenleggBehandlingDto.java
@@ -31,7 +31,7 @@ public class HenleggBehandlingDto {
     @JsonProperty(value = "begrunnelse")
     @NotNull
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     @JsonProperty(value = "behandlingId")

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/behandling/revurdering/VarselRevurderingDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/behandling/revurdering/VarselRevurderingDto.java
@@ -28,7 +28,7 @@ public abstract class VarselRevurderingDto extends BekreftetAksjonspunktDto {
     @JsonProperty(value = "fritekst", required = true)
     @NotNull
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String fritekst;
 
     @JsonProperty(value = "sendVarsel", required = true)

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/dokument/BestillBrevDtoGammel.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/dokument/BestillBrevDtoGammel.java
@@ -31,7 +31,7 @@ public class BestillBrevDtoGammel {
 
     @JsonProperty(value = "fritekst")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     public String fritekst;
 
     @JsonProperty(value = "behandlingId", required = true)

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/dokument/FritekstbrevinnholdDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/dokument/FritekstbrevinnholdDto.java
@@ -20,8 +20,8 @@ import no.nav.ung.sak.kontrakt.Patterns;
 )
 @Deprecated
 public record FritekstbrevinnholdDto(
-    @Valid @NotNull @Size(max = 200) @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]") String overskrift,
-    @Valid @NotNull @Size(max = 100000) @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]") String brødtekst) {
+    @Valid @NotNull @Size(max = 200) @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING) String overskrift,
+    @Valid @NotNull @Size(max = 100000) @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING) String brødtekst) {
 
     @JsonCreator
     public FritekstbrevinnholdDto(@JsonProperty("overskrift") String overskrift, @JsonProperty("brødtekst") String brødtekst) {

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/formidling/informasjonsbrev/GenereltFritekstBrevDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/formidling/informasjonsbrev/GenereltFritekstBrevDto.java
@@ -17,12 +17,12 @@ public record GenereltFritekstBrevDto(
     @Valid
     @NotNull
     @Size(max = 200)
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     String overskrift,
 
     @Valid
     @NotNull
     @Size(max = 100000)
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     String brødtekst) implements InformasjonsbrevInnholdDto {
 }

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/formidling/vedtaksbrev/VedtaksbrevValgRequest.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/formidling/vedtaksbrev/VedtaksbrevValgRequest.java
@@ -25,7 +25,7 @@ public record VedtaksbrevValgRequest(
     Boolean hindret,
     Boolean redigert,
 
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     String redigertHtml,
 
     @NotNull

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/notat/EndreNotatDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/notat/EndreNotatDto.java
@@ -27,7 +27,7 @@ public record EndreNotatDto(
 
     @JsonProperty(value = "notatTekst", required = true)
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     String notatTekst,
 
     @StandardAbacAttributt(StandardAbacAttributtType.SAKSNUMMER)

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/notat/NotatDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/notat/NotatDto.java
@@ -30,7 +30,7 @@ public record NotatDto(
 
         @JsonProperty(value = "notatTekst")
         @Size(max = 4000)
-        @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+        @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
         @NotNull
         String notatTekst,
 

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/notat/OpprettNotatDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/notat/OpprettNotatDto.java
@@ -24,7 +24,7 @@ public record OpprettNotatDto(
 
     @JsonProperty(value = "notatTekst", required = true)
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     @NotNull
     String notatTekst,
 

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknad/SøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknad/SøknadDto.java
@@ -22,7 +22,7 @@ public class SøknadDto {
 
     @JsonProperty(value = "begrunnelseForSenInnsending")
     @Size(max = 5000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelseForSenInnsending;
 
     /**

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknadsfrist/AvklarteOpplysninger.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknadsfrist/AvklarteOpplysninger.java
@@ -31,7 +31,7 @@ public class AvklarteOpplysninger {
 
     @JsonProperty("begrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     @JsonProperty(value = "opprettetAv")

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknadsfrist/aksjonspunkt/AvklartKravDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/søknadsfrist/aksjonspunkt/AvklartKravDto.java
@@ -38,7 +38,7 @@ public class AvklartKravDto {
 
     @JsonProperty("begrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     public AvklartKravDto() {

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vedtak/AksjonspunktGodkjenningDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vedtak/AksjonspunktGodkjenningDto.java
@@ -39,7 +39,7 @@ public class AksjonspunktGodkjenningDto {
     @JsonInclude(value = Include.NON_EMPTY)
     @JsonProperty(value = "begrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     @JsonProperty(value = "godkjent", required = true)

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vedtak/TotrinnskontrollAksjonspunkterDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vedtak/TotrinnskontrollAksjonspunkterDto.java
@@ -63,7 +63,7 @@ public class TotrinnskontrollAksjonspunkterDto {
     @JsonInclude(value = Include.NON_EMPTY)
     @JsonProperty(value = "besluttersBegrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String besluttersBegrunnelse;
 
     @JsonProperty(value = "totrinnskontrollGodkjent")

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vedtak/VedtaksbrevOverstyringDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vedtak/VedtaksbrevOverstyringDto.java
@@ -23,12 +23,12 @@ public abstract class VedtaksbrevOverstyringDto extends BekreftetAksjonspunktDto
 
     @JsonProperty(value = "fritekstBrev")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String fritekstBrev;
 
     @JsonProperty(value = "overskrift")
     @Size(max = 200)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String overskrift;
 
     @JsonProperty(value = "skalBrukeOverstyrendeFritekstBrev", required = true)

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vilkår/VilkårPeriodeDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vilkår/VilkårPeriodeDto.java
@@ -60,12 +60,12 @@ public class VilkårPeriodeDto {
 
     @JsonProperty("begrunnelse")
     @Size(max = 4000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String begrunnelse;
 
     @JsonProperty("fritekstVurderingBrev")
     @Size(max = 10000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String fritekstVurderingBrev;
 
     /**

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vilkår/VilkårPeriodeVurderingDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/vilkår/VilkårPeriodeVurderingDto.java
@@ -30,13 +30,13 @@ public record VilkårPeriodeVurderingDto(
     @NotNull
     @Size(min = 3, max = 5000)
     @Valid
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     String begrunnelse,
 
     @JsonProperty("fritekstVurderingBrev")
     @Size(max = 10000)
     @Valid
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     String fritekstVurderingBrev
 ) {
 

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/økonomi/tilbakekreving/TilbakekrevingValgDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/økonomi/tilbakekreving/TilbakekrevingValgDto.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.ung.kodeverk.økonomi.tilbakekreving.TilbakekrevingVidereBehandling;
+import no.nav.ung.sak.kontrakt.Patterns;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -26,7 +27,7 @@ public class TilbakekrevingValgDto {
 
     @JsonProperty(value = "varseltekst")
     @Size(max = 12000)
-    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{P}\\p{N}]+$", message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{P}\\p{N}]+$", message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String varseltekst;
 
     @JsonProperty(value = "videreBehandling")

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/økonomi/tilbakekreving/VarseltekstDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/økonomi/tilbakekreving/VarseltekstDto.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import no.nav.ung.sak.kontrakt.Patterns;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -18,7 +19,7 @@ public class VarseltekstDto {
     @JsonProperty(value = "varseltekst", required = true)
     @NotNull
     @Size(max = 4000)
-    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{P}\\p{N}]+$", message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{P}\\p{N}]+$", message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String varseltekst;
 
     public VarseltekstDto(String varseltekst) {

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/økonomi/tilbakekreving/VurderFeilutbetalingDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/økonomi/tilbakekreving/VurderFeilutbetalingDto.java
@@ -24,7 +24,7 @@ public class VurderFeilutbetalingDto extends BekreftetAksjonspunktDto {
 
     @JsonProperty(value = "varseltekst")
     @Size(max = 12000)
-    @Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
     private String varseltekst;
 
     @JsonProperty(value = "videreBehandling", required = true)

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/los/MerknadEndretDto.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/los/MerknadEndretDto.java
@@ -34,7 +34,7 @@ public record MerknadEndretDto(
 
     @JsonProperty(value = "fritekst")
     @Size(max = 500)
-    @Pattern(regexp = Patterns.FRITEKSTBREV, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+    @Pattern(regexp = Patterns.FRITEKSTBREV, message = Patterns.FRITEKST_MISMATCH_MELDING)
     @Valid
     String fritekst,
 


### PR DESCRIPTION
### Behov / Bakgrunn

Bean Validation interpolerer `${validatedValue}` i `@Pattern`-meldinger, noe som betyr at hele feltinnholdet kan ende opp i applikasjonslogger ved valideringsfeil. For fritekstfelter (begrunnelse, notat, varseltekst, etc.) kan dette eksponere sensitive opplysninger som helseinformasjon og personlige forhold.

### Løsning

Introduserer `Patterns.FRITEKST_MISMATCH`-konstant med generisk feilmelding uten `${validatedValue}`. Bean Validation inkluderer allerede feltnavnet i `ConstraintViolation.getPropertyPath()`, så meldingen trenger ikke gjenta det.

**Eksempel:**
```java
// Før:
@Pattern(regexp = Patterns.FRITEKST, message = "[${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
private String begrunnelse;

// Etter:
@Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH)
private String begrunnelse;
```

Fordelen med en konstant er at meldingen kun defineres ett sted og kan endres uten å røre mange filer.

### Andre endringer

Ingen.

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres