### PR TITLE
fix: Send AktørIdDto som JSON-objekt til ung-brukerdialog-api los-sok-ytelse

### DIFF
--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/UngBrukerdialogOppgaveKlient.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/UngBrukerdialogOppgaveKlient.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import no.nav.k9.felles.integrasjon.rest.OidcRestClient;
 import no.nav.k9.felles.integrasjon.rest.ScopedRestIntegration;
 import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
+import no.nav.ung.brukerdialog.kontrakt.AktørIdDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.EndreFristDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.EndreOppgaveStatusDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveRequest;
@@ -83,7 +84,7 @@ public class UngBrukerdialogOppgaveKlient {
         }
     }
 
-    public void løsSøkYtelseOppgave(AktørId aktørId) {
+    public void løsSøkYtelseOppgave(AktørIdDto aktørId) {
         try {
             restClient.post(løsSøkYtelseBaseURI, aktørId);
         } catch (Exception e) {

--- a/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/UngBrukerdialogOppgaveKlientTest.java
+++ b/domenetjenester/etterlysning/src/test/java/no/nav/ung/sak/etterlysning/UngBrukerdialogOppgaveKlientTest.java
@@ -1,0 +1,43 @@
+package no.nav.ung.sak.etterlysning;
+
+import no.nav.k9.felles.integrasjon.rest.OidcRestClient;
+import no.nav.ung.brukerdialog.kontrakt.AktørIdDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class UngBrukerdialogOppgaveKlientTest {
+
+    private OidcRestClient restClient;
+    private UngBrukerdialogOppgaveKlient klient;
+
+    @BeforeEach
+    void setUp() {
+        restClient = mock(OidcRestClient.class);
+        klient = new UngBrukerdialogOppgaveKlient(restClient, "http://localhost:8080");
+    }
+
+    @Test
+    void løsSøkYtelseOppgave_senderAktørIdSomObjektMedFelt() throws Exception {
+        // Arrange
+        var aktørId = new AktørIdDto("1234567890123");
+
+        // Act
+        klient.løsSøkYtelseOppgave(aktørId);
+
+        // Assert
+        ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(restClient).post(any(URI.class), bodyCaptor.capture());
+
+        Object sentBody = bodyCaptor.getValue();
+        assertThat(sentBody).isInstanceOf(AktørIdDto.class);
+        AktørIdDto dto = (AktørIdDto) sentBody;
+        assertThat(dto.getAktorId()).isEqualTo("1234567890123");
+    }
+}
+

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/papirsøknad/PapirsøknadHåndteringTjeneste.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/papirsøknad/PapirsøknadHåndteringTjeneste.java
@@ -5,9 +5,11 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import no.nav.k9.felles.integrasjon.saf.Kanal;
 import no.nav.k9.felles.integrasjon.saf.Tema;
+import no.nav.k9.felles.konfigurasjon.konfig.Tid;
 import no.nav.k9.søknad.JsonUtils;
 import no.nav.k9.søknad.Søknad;
 import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer;
+import no.nav.ung.brukerdialog.kontrakt.AktørIdDto;
 import no.nav.ung.domenetjenester.arkiv.ArkivTjeneste;
 import no.nav.ung.domenetjenester.arkiv.JournalpostInfo;
 import no.nav.ung.domenetjenester.arkiv.journal.TilJournalføringTjeneste;
@@ -18,7 +20,6 @@ import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.dokument.VariantFormat;
 import no.nav.ung.kodeverk.produksjonsstyring.OmrådeTema;
 import no.nav.ung.kodeverk.produksjonsstyring.OrganisasjonsEnhet;
-import no.nav.k9.felles.konfigurasjon.konfig.Tid;
 import no.nav.ung.sak.behandling.FagsakTjeneste;
 import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.ung.sak.behandlingslager.aktør.Personinfo;
@@ -27,19 +28,15 @@ import no.nav.ung.sak.dokument.arkiv.DokumentArkivTjeneste;
 import no.nav.ung.sak.domene.person.pdl.PersoninfoAdapter;
 import no.nav.ung.sak.domene.person.tps.TpsTjeneste;
 import no.nav.ung.sak.etterlysning.UngBrukerdialogOppgaveKlient;
-import no.nav.ung.sak.formidling.dokarkiv.DokArkivKlient;
-import no.nav.ung.sak.typer.AktørId;
-import no.nav.ung.sak.typer.JournalpostId;
-import no.nav.ung.sak.typer.Periode;
-import no.nav.ung.sak.typer.PersonIdent;
-import no.nav.ung.sak.typer.Saksnummer;
 import no.nav.ung.sak.formidling.bestilling.JournalpostType;
+import no.nav.ung.sak.formidling.dokarkiv.DokArkivKlient;
 import no.nav.ung.sak.formidling.dokarkiv.dto.OpprettJournalpostRequest;
 import no.nav.ung.sak.formidling.dokarkiv.dto.OpprettJournalpostRequestBuilder;
 import no.nav.ung.sak.formidling.dokarkiv.dto.OpprettJournalpostResponse;
 import no.nav.ung.sak.formidling.pdfgen.PdfGenKlient;
 import no.nav.ung.sak.mottak.SøknadMottakTjeneste;
 import no.nav.ung.sak.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.ung.sak.typer.*;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.ungdomsprogrammet.UngdomsprogramRegisterKlient;
 
 import java.time.LocalDate;
@@ -135,7 +132,7 @@ public class PapirsøknadHåndteringTjeneste {
         byte[] jsonDokument = lagJsonDokument(deltakerIdent, startdato, deltakelseId, journalpostId);
 
         //Dette kallet er idempotenet. Hvis oppgaven er løst tidligere så vil ikke det feile ved et nytt kall her.
-        oppgaveKlient.løsSøkYtelseOppgave(new no.nav.ung.brukerdialog.typer.AktørId(aktørId.getAktørId()));
+        oppgaveKlient.løsSøkYtelseOppgave(new AktørIdDto(aktørId.getAktørId()));
         return opprettJournalpost(deltakerIdent, deltakerNavn, deltakelseId, pdfDokument, jsonDokument, behandlendeEnhet);
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn

`POST /ung/brukerdialog/intern/api/oppgavebehandling/los-sok-ytelse` returnerer 400.

Endepunktet i `ung-brukerdialog-api` forventer request-body som JSON-objekt `{"aktørId": "<id>"}` (type `AktørIdDto`), men `UngBrukerdialogOppgaveKlient.løsSøkYtelseOppgave` sendte `AktørId`-objektet direkte. Jackson serialiserte dette som en rå JSON-streng, noe som ga deserialiserings­feil og HTTP 400 på mottakersiden.

### Løsning

Wrapper `AktørId` i `AktørIdDto` (fra `no.nav.ung.brukerdialog.kontrakt`) før kall til `restClient.post(...)`, slik at body blir et gyldig JSON-objekt med feltet `aktørId`.

Lagt til enhetstest (`UngBrukerdialogOppgaveKlientTest`) som verifiserer at body som sendes er en `AktørIdDto`-instans med korrekt aktør-ID — ikke en rå streng.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
