### PR TITLE
chore: Toggler på traceparent igjen etter at k9-prosesstask håndterer tidligere ukjent flagg

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/server/jetty/JettyServer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/jetty/JettyServer.java
@@ -131,10 +131,9 @@ public class JettyServer {
         System.setProperty("task.manager.polling.tasks.size", "10");
         System.setProperty("task.manager.polling.scrolling.select.size", "10");
 
-        /* TODO fiks - feiler i dev
         if (ENV.isDev()) {
             System.setProperty("task.manager.auto.traceparent", "true");
-        }*/
+        }
     }
 
     private void konfigurerJndi() throws Exception {


### PR DESCRIPTION
### Behov / Bakgrunn
K9-prosesstask håndterer nå flagget 03 for sampled traces og vi kan skru på igjen traceparent.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
