### PR TITLE
TSFF-2621 - Presisering av forlenget periode i brevet.

### DIFF
--- a/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/ungdomsprogramytelse/forlenget_periode.hbs
+++ b/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/ungdomsprogramytelse/forlenget_periode.hbs
@@ -1,9 +1,9 @@
 {{#> felles/base}}
 
     {{#> felles/seksjon/hoved }}
-        <h1>Du får forlenget ungdomsprogramytelse</h1>
+        <h1>Du får forlenget perioden med ungdomsprogramytelsen</h1>
         <p>
-            Fra {{fom}} får du forlenget ungdomsprogramytelsen din.
+            Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen.
             Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn i åtte nye uker.
         </p>
         <p>Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6.</p>

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
@@ -23,7 +23,7 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
     private static final LocalDate NY_SLUTTDATO = LocalDate.of(2026, 1, 28);
 
     ForlengetPeriodeTest() {
-        super(1, "Du får forlenget ungdomsprogramytelse");
+        super(1, "Du får forlenget perioden med ungdomsprogramytelsen");
     }
 
     @DisplayName("Forlenget periode gir korrekt brev")
@@ -36,8 +36,8 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
 
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             """
-                Du får forlenget ungdomsprogramytelse \
-                Fra 1. januar 2026 får du forlenget ungdomsprogramytelsen din. \
+                Du får forlenget perioden med ungdomsprogramytelsen \
+                Fra 1. januar 2026 får du forlenget perioden din med ungdomsprogramytelsen. \
                 Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn i åtte nye uker. \
                 Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6. \
                 Meld fra til oss hvis du har arbeidsinntekt i tillegg til ungdomsprogramytelsen \
@@ -48,7 +48,7 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
         assertThatHtml(generertBrev.dokument().html())
             .asPlainTextIsEqualTo(forventet)
             .containsHtmlSubSequenceOnce(
-                "<h1>Du får forlenget ungdomsprogramytelse</h1>"
+                "<h1>Du får forlenget perioden med ungdomsprogramytelsen</h1>"
             );
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn

Brevteksten for forlenget ungdomsprogramytelse måtte presiseres språklig. Overskriften skulle oppdateres fra `Du får forlenget ungdomsprogramytelse` til `Du får forlenget perioden med ungdomsprogramytelsen`, og første setning i brødteksten skulle inkludere ordet «perioden».

### Løsning

Oppdaterte brevmalen `forlenget_periode.hbs` med ny overskrift og ny første setning: `Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen.`

Oppdaterte `ForlengetPeriodeTest` slik at forventet tekst, overskrift og HTML-assert matcher ny ordlyd.

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
