### PR TITLE
TSFF-2696: Legger inn og toggler nytt G-beløp for testing av G-justering

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -278,7 +278,8 @@ spec:
       value: "true"
     - name: AKTIVITETSPENGER_ENABLED
       value: "true"
-
+    - name: G_BELOP_2026_VEDTATT
+      value: "true"
 
       # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -273,7 +273,7 @@ spec:
     - name: PROGRAMPERIODE_ENDRING_ENABLED
       value: "false"
     - name: G_BELOP_2026_VEDTATT
-      value: "true"
+      value: "false"
 
     # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -272,6 +272,8 @@ spec:
       value: "false"
     - name: PROGRAMPERIODE_ENDRING_ENABLED
       value: "false"
+    - name: G_BELOP_2026_VEDTATT
+      value: "true"
 
     # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/domenetjenester/grunnbelop/src/main/java/no/nav/ung/sak/grunnbeløp/GrunnbeløpTidslinje.java
+++ b/domenetjenester/grunnbelop/src/main/java/no/nav/ung/sak/grunnbeløp/GrunnbeløpTidslinje.java
@@ -2,21 +2,32 @@ package no.nav.ung.sak.grunnbeløp;
 
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.konfigurasjon.env.Environment;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
 public class GrunnbeløpTidslinje {
+
     /**
      * Tidslinje for grunnbeløpsatser
      */
-    private static final LocalDateTimeline<Grunnbeløp> GRUNNBELØP_TIDSLINJE = new LocalDateTimeline<>(
-        List.of(
-            new LocalDateSegment<>(LocalDate.of(2025, 5, 1), LocalDate.of(2099, 12, 31), new Grunnbeløp(BigDecimal.valueOf(130160))),
-            new LocalDateSegment<>(LocalDate.of(2024, 5, 1), LocalDate.of(2025, 4, 30), new Grunnbeløp(BigDecimal.valueOf(124028))),
-            new LocalDateSegment<>(LocalDate.of(2023, 5, 1), LocalDate.of(2024, 4,30), new Grunnbeløp(BigDecimal.valueOf(118620)))
-        ));
+    private static final LocalDateTimeline<Grunnbeløp> GRUNNBELØP_TIDSLINJE = Environment.current().getProperty("G_BELOP_2026_VEDTATT", Boolean.class, false) ?
+        new LocalDateTimeline<>(
+            List.of(
+                new LocalDateSegment<>(LocalDate.of(2026, 5, 1), LocalDate.of(2099, 12, 31), new Grunnbeløp(BigDecimal.valueOf(136549))),
+                new LocalDateSegment<>(LocalDate.of(2025, 5, 1), LocalDate.of(2026, 4, 30), new Grunnbeløp(BigDecimal.valueOf(130160))),
+                new LocalDateSegment<>(LocalDate.of(2024, 5, 1), LocalDate.of(2025, 4, 30), new Grunnbeløp(BigDecimal.valueOf(124028))),
+                new LocalDateSegment<>(LocalDate.of(2023, 5, 1), LocalDate.of(2024, 4, 30), new Grunnbeløp(BigDecimal.valueOf(118620)))
+            )) :
+        new LocalDateTimeline<>(
+            List.of(
+                new LocalDateSegment<>(LocalDate.of(2025, 5, 1), LocalDate.of(2099, 12, 31), new Grunnbeløp(BigDecimal.valueOf(130160))),
+                new LocalDateSegment<>(LocalDate.of(2024, 5, 1), LocalDate.of(2025, 4, 30), new Grunnbeløp(BigDecimal.valueOf(124028))),
+                new LocalDateSegment<>(LocalDate.of(2023, 5, 1), LocalDate.of(2024, 4, 30), new Grunnbeløp(BigDecimal.valueOf(118620)))
+            ));
 
 
     public static LocalDateTimeline<Grunnbeløp> hentTidslinje() {


### PR DESCRIPTION
### Behov / Bakgrunn
https://www.nav.no/regulering-2026

Det nye grunnbeløpet fra 1. mai 2026 er fastsatt til 136 549 kroner.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
