### PR TITLE
TSFF-2696: Legger inn gsnitt, som blir brukt av beregning i aktivitetspenger

### DIFF
--- a/domenetjenester/grunnbelop/src/main/java/no/nav/ung/sak/grunnbeløp/GrunnbeløpSnittTidslinje.java
+++ b/domenetjenester/grunnbelop/src/main/java/no/nav/ung/sak/grunnbeløp/GrunnbeløpSnittTidslinje.java
@@ -14,6 +14,7 @@ public class GrunnbeløpSnittTidslinje {
 
     private static final LocalDateTimeline<Grunnbeløp> GRUNNBELØP_SNITT_TIDSLINJE = new LocalDateTimeline<>(
         List.of(
+            new LocalDateSegment<>(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31), new Grunnbeløp(BigDecimal.valueOf(134419))),
             new LocalDateSegment<>(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31), new Grunnbeløp(BigDecimal.valueOf(128116))),
             new LocalDateSegment<>(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), new Grunnbeløp(BigDecimal.valueOf(122225))),
             new LocalDateSegment<>(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 12, 31), new Grunnbeløp(BigDecimal.valueOf(116239))),


### PR DESCRIPTION
### Behov / Bakgrunn
Aktivitetspenger bruker Gsnitt, som også må reguleres.

Tilsvarende justering av grunnbeløpet: https://github.com/navikt/ung-sak/pull/1369
https://www.nav.no/regulering-2026

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
