### PR TITLE
docs(agents): oppdater domeneføringer for forlenget periode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@
 - `migreringer`: Flyway-migreringer og databaseskjema-initialisering.
 - `formidling` og `formidling-pdfgen-templates`: dokumentgenerering.
 
+## Domain Notes: Forlenget periode
+- `UngdomsprogramMaksPeriode` er sentral modell for maks varighet og inneholder `harForlengetPeriode`, `periodeMaksDato` og hjemmel.
+- `periodeMaksDato` fra register er kilde til sannhet for maksdato. Unngaa lokal materialisering av sluttdato for aapne perioder.
+- Hendelsesflyt bruker `UNGDOMSPROGRAM_FORLENGET_PERIODE`.
+- Startpunkt for ny vurdering ved forlenget periode avhenger av endring i `periodeMaksDato` (diff-sporing), ikke kun boolsk flagg.
+- Revurdering ved forlenget periode skal vise triggerperioden (de nye 8 ukene), ikke hele opprinnelig programperiode.
+
 ## Tech Stack
 - Java 25 (hovedkodebase)
 - Java 21 (`kodeverk` og `kontrakt`)
@@ -42,12 +49,14 @@ dev/generate-openapi-ts-client.sh
 - Behold pakke- og navnekonvensjoner under `no.nav.ung.sak.<module>...` (`*Repository`, `*Tjeneste`, `*Steg`).
 - Bruk `Range<LocalDate>` med `@Type(PostgreSQLRangeType.class)` og `columnDefinition = "daterange"` for perioder i JPA-entiteter.
 - I nye Flyway-migreringer skal SQL skrives med lowercase. Eksisterende migreringer trenger ikke omskrives kun for casing.
+- Ved endringer for forlenget periode: oppdater baade hendelser, grunnlagsmodell (`UngdomsprogramMaksPeriode`), startpunktutledning og brev/API i samme leveranse.
 
 ## Boundaries
 ### Always
 - Folg etablerte mønstre i modulen du endrer.
 - Hold endringer smaaa og fokuserte.
 - Kjor relevante tester for berorte moduler.
+- Verifiser kombinasjonsflyt der forlenget periode samhandler med andre revurderingsaarsaker (f.eks. inntektskontroll).
 
 ### Ask First
 - Store refaktoreringer paa tvers av modulgrenser.
@@ -65,3 +74,4 @@ dev/generate-openapi-ts-client.sh
 - `dokumentasjon/arkitekturbeslutninger.md`
 - `migreringer/pom.xml`
 - `web/README.md`
+- PR-historikk for forlenget periode: `https://github.com/navikt/ung-sak/pull/1299`, `https://github.com/navikt/ung-sak/pull/1336`, `https://github.com/navikt/ung-sak/pull/1350`, `https://github.com/navikt/ung-sak/pull/1365`, `https://github.com/navikt/ung-sak/pull/1367`, `https://github.com/navikt/ung-sak/pull/1370`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,4 +74,10 @@ dev/generate-openapi-ts-client.sh
 - `dokumentasjon/arkitekturbeslutninger.md`
 - `migreringer/pom.xml`
 - `web/README.md`
-- PR-historikk for forlenget periode: `https://github.com/navikt/ung-sak/pull/1299`, `https://github.com/navikt/ung-sak/pull/1336`, `https://github.com/navikt/ung-sak/pull/1350`, `https://github.com/navikt/ung-sak/pull/1365`, `https://github.com/navikt/ung-sak/pull/1367`, `https://github.com/navikt/ung-sak/pull/1370`
+- PR-historikk for forlenget periode:
+  - https://github.com/navikt/ung-sak/pull/1299
+  - https://github.com/navikt/ung-sak/pull/1336
+  - https://github.com/navikt/ung-sak/pull/1350
+  - https://github.com/navikt/ung-sak/pull/1365
+  - https://github.com/navikt/ung-sak/pull/1367
+  - https://github.com/navikt/ung-sak/pull/1370


### PR DESCRIPTION
### Behov / Bakgrunn

Bakgrunn er at domenet for forlenget periode har endret seg stegvis gjennom flere PR-er (fra utvidet kvote til forlenget periode, ny grunnlagsmodell med periodeMaksDato som sannhetskilde, og justert startpunktutledning). AGENTS.md manglet disse avklaringene, noe som ga risiko for inkonsistent terminologi og feil implementasjon i senere endringer. Behovet var derfor å oppdatere agent-instruksene slik at nye kodeendringer følger gjeldende domene, hendelsesflyt og kombinasjonsscenarier.

### Løsning

- legg til Domain Notes for forlenget periode i AGENTS.md
- presiser at periodeMaksDato fra register er kilde til sannhet
- dokumenter at startpunktutledning skal styres av endring i periodeMaksDato
- tydeliggjor at revurdering skal vise triggerperioden (nye 8 uker)
- oppdater conventions/boundaries for samordnet endring og kombinasjonsflyt
- legg til key references til PR #1299, #1336, #1350, #1365, #1367, #1370

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
