### PR TITLE
chore: Opprett tasker og periodeutleder for g-regulering av ungdomsprogramytelsen

### DIFF
--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringKandidatUtledningTask.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringKandidatUtledningTask.java
@@ -1,0 +1,65 @@
+package no.nav.ung.sak.ytelse.regulering;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.k9.prosesstask.api.ProsessTask;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskHandler;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+
+@ProsessTask(GReguleringKandidatUtledningTask.TASKTYPE)
+@ApplicationScoped
+public class GReguleringKandidatUtledningTask implements ProsessTaskHandler {
+
+    public static final String TASKTYPE = "gregulering.kandidatUtledning";
+    public static final String YTELSE_TYPE = "ytelseType";
+    public static final String PERIODE_FOM = "fom";
+    public static final String PERIODE_TOM = "tom";
+    public static final String DRYRUN = "dryrun";
+
+    private static final Logger log = LoggerFactory.getLogger(GReguleringKandidatUtledningTask.class);
+    private GReguleringRepository gReguleringRepository;
+
+
+    GReguleringKandidatUtledningTask() {
+        // CDI
+    }
+
+    @Inject
+    public GReguleringKandidatUtledningTask(GReguleringRepository gReguleringRepository) {
+        this.gReguleringRepository = gReguleringRepository;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var ytelseType = FagsakYtelseType.fromString(prosessTaskData.getPropertyValue(YTELSE_TYPE));
+        var fomValue = prosessTaskData.getPropertyValue(PERIODE_FOM);
+        var fom = LocalDate.parse(fomValue);
+        var tomValue = prosessTaskData.getPropertyValue(PERIODE_TOM);
+        var tom = LocalDate.parse(tomValue);
+        var dryRunValue = prosessTaskData.getPropertyValue(DRYRUN);
+        var dryRun = Boolean.parseBoolean(dryRunValue);
+
+        if (erUgyldig(fom, tom)) {
+            throw new IllegalArgumentException("Ugyldig fom eller tom " + fom + " - " + tom);
+        }
+
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
+
+        if (dryRun) {
+            log.info("DRYRUN - Fant {} kandidater til g-regulering for '{}' og perioden '{}'.", gReguleringRepository.dryRun(ytelseType, periode), ytelseType, periode);
+        } else {
+            var antall = gReguleringRepository.startGReguleringForPeriode(ytelseType, periode, fomValue, tomValue);
+            log.info("Fant {} kandidater til g-regulering for '{}' og perioden '{}'. Starter vurdering", antall, ytelseType, periode);
+        }
+    }
+
+    private boolean erUgyldig(LocalDate fom, LocalDate tom) {
+        return fom.getYear() != tom.getYear();
+    }
+}

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringRepository.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringRepository.java
@@ -33,8 +33,7 @@ public class GReguleringRepository {
 
         query.setParameter("ytelseType", Objects.requireNonNull(ytelseType, "ytelseType").getKode());
         query.setParameter("fom", periode.getFomDato() == null ? Tid.TIDENES_BEGYNNELSE : periode.getFomDato());
-        query.setParameter("tom", periode.getTomDato() == null ? Tid.TIDENES_ENDE : periode.getFomDato());
-
+        query.setParameter("tom", periode.getTomDato() == null ? Tid.TIDENES_ENDE : periode.getTomDato());
         return (Long) query.getSingleResult();
     }
 

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringRepository.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringRepository.java
@@ -45,15 +45,10 @@ public class GReguleringRepository {
             insert into prosess_task (id, task_type, task_gruppe, neste_kjoering_etter, task_parametere)
             select nextval('seq_prosess_task'), 'gregulering.kandidatUtprøving',
                    nextval('seq_prosess_task_gruppe'), null,
-                        'fom=""" + fomValue + """
-
-            tom=""" + tomValue + """
-
-            fagsakId=' || f.id || ''
-
-                from fagsak f
-              where f.ytelse_type = :ytelseType
-             and f.periode && daterange(cast(:fom as date), cast(:tom as date), '[]') = true
+                   'fom=' || :fomValue || '\ntom=' || :tomValue || '\nfagsakId=' || f.id
+              from fagsak f
+             where f.ytelse_type = :ytelseType
+               and f.periode && daterange(cast(:fom as date), cast(:tom as date), '[]') = true
             """;
 
         var query = entityManager.createNativeQuery(sql); // NOSONAR
@@ -61,7 +56,8 @@ public class GReguleringRepository {
         query.setParameter("ytelseType", Objects.requireNonNull(ytelseType, "ytelseType").getKode());
         query.setParameter("fom", periode.getFomDato());
         query.setParameter("tom", periode.getTomDato());
-
+        query.setParameter("fomValue", fomValue);
+        query.setParameter("tomValue", tomValue);
 
         return Integer.toUnsignedLong(query.executeUpdate());
     }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringRepository.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/GReguleringRepository.java
@@ -1,0 +1,72 @@
+package no.nav.ung.sak.ytelse.regulering;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import no.nav.k9.felles.konfigurasjon.konfig.Tid;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+
+import java.util.Objects;
+
+@Dependent
+public class GReguleringRepository {
+
+    private EntityManager entityManager;
+
+    @Inject
+    public GReguleringRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public Long dryRun(FagsakYtelseType ytelseType, DatoIntervallEntitet periode) {
+        Query query;
+
+        String sql = """
+            select count(f.saksnummer) from Fagsak f
+             where f.ytelse_type = :ytelseType
+               and f.periode && daterange(cast(:fom as date), cast(:tom as date), '[]') = true
+              """;
+
+        query = entityManager.createNativeQuery(sql); // NOSONAR
+
+        query.setParameter("ytelseType", Objects.requireNonNull(ytelseType, "ytelseType").getKode());
+        query.setParameter("fom", periode.getFomDato() == null ? Tid.TIDENES_BEGYNNELSE : periode.getFomDato());
+        query.setParameter("tom", periode.getTomDato() == null ? Tid.TIDENES_ENDE : periode.getFomDato());
+
+        return (Long) query.getSingleResult();
+    }
+
+    public Long startGReguleringForPeriode(FagsakYtelseType ytelseType, DatoIntervallEntitet periode, String fomValue, String tomValue) {
+        Objects.requireNonNull(periode);
+
+        String sql = """
+            insert into prosess_task (id, task_type, task_gruppe, neste_kjoering_etter, task_parametere)
+            select nextval('seq_prosess_task'), 'gregulering.kandidatUtprøving',
+                   nextval('seq_prosess_task_gruppe'), null,
+                        'fom=""" + fomValue + """
+
+            tom=""" + tomValue + """
+
+            fagsakId=' || f.id || ''
+
+                from fagsak f
+              where f.ytelse_type = :ytelseType
+             and f.periode && daterange(cast(:fom as date), cast(:tom as date), '[]') = true
+            """;
+
+        var query = entityManager.createNativeQuery(sql); // NOSONAR
+
+        query.setParameter("ytelseType", Objects.requireNonNull(ytelseType, "ytelseType").getKode());
+        query.setParameter("fom", periode.getFomDato());
+        query.setParameter("tom", periode.getTomDato());
+
+
+        return Integer.toUnsignedLong(query.executeUpdate());
+    }
+
+
+
+
+}

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/PerioderForGReguleringUtleder.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/PerioderForGReguleringUtleder.java
@@ -13,7 +13,7 @@ public interface PerioderForGReguleringUtleder {
 
     static PerioderForGReguleringUtleder finnTjeneste(FagsakYtelseType fagsakYtelseType, Instance<PerioderForGReguleringUtleder> tjenester) {
         return FagsakYtelseTypeRef.Lookup.find(tjenester, fagsakYtelseType)
-            .orElseThrow(() -> new IllegalStateException("Finner ikke KandidaterForGReguleringTjeneste"));
+            .orElseThrow(() -> new IllegalStateException("Finner ikke PerioderForGReguleringUtleder"));
     }
 
     NavigableSet<DatoIntervallEntitet> utledPerioderForGRegulering(Behandling behandling, DatoIntervallEntitet periode);

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/PerioderForGReguleringUtleder.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/PerioderForGReguleringUtleder.java
@@ -1,0 +1,21 @@
+package no.nav.ung.sak.ytelse.regulering;
+
+import jakarta.enterprise.inject.Instance;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+
+import java.util.NavigableSet;
+
+public interface PerioderForGReguleringUtleder {
+
+
+    static PerioderForGReguleringUtleder finnTjeneste(FagsakYtelseType fagsakYtelseType, Instance<PerioderForGReguleringUtleder> tjenester) {
+        return FagsakYtelseTypeRef.Lookup.find(tjenester, fagsakYtelseType)
+            .orElseThrow(() -> new IllegalStateException("Finner ikke KandidaterForGReguleringTjeneste"));
+    }
+
+    NavigableSet<DatoIntervallEntitet> utledPerioderForGRegulering(Behandling behandling, DatoIntervallEntitet periode);
+
+}

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
@@ -45,9 +45,11 @@ public class VurderGReguleringKandidatTask extends FagsakProsessTask {
 
     @Inject
     public VurderGReguleringKandidatTask(FagsakLåsRepository fagsakLåsRepository,
+                                         no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingLåsRepository behandlingLåsRepository,
                                          @Any Instance<PerioderForGReguleringUtleder> kandidaterForGReguleringTjeneste,
-                                         ProsessTaskTjeneste taskRepository, BehandlingRepository behandlingRepository) {
-        super(fagsakLåsRepository, null);
+                                         ProsessTaskTjeneste taskRepository,
+                                         BehandlingRepository behandlingRepository) {
+        super(fagsakLåsRepository, behandlingLåsRepository);
         this.kandidaterForGReguleringTjeneste = kandidaterForGReguleringTjeneste;
         this.taskRepository = taskRepository;
         this.behandlingRepository = behandlingRepository;

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
@@ -1,0 +1,95 @@
+package no.nav.ung.sak.ytelse.regulering;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import no.nav.k9.prosesstask.api.ProsessTask;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.k9.prosesstask.api.TaskType;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakLåsRepository;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.ung.sak.behandlingslager.task.FagsakProsessTask;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Set;
+
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false) // Trenger ikke blokkere andre tasks på saken
+@ProsessTask(VurderGReguleringKandidatTask.TASKTYPE)
+@ApplicationScoped
+public class VurderGReguleringKandidatTask extends FagsakProsessTask {
+
+    public static final String TASKTYPE = "gregulering.kandidatUtprøving";
+    public static final String PERIODE_FOM = "fom";
+    public static final String PERIODE_TOM = "tom";
+    public static final String PERIODER = "perioder";
+    public static final String BEHANDLINGSKONTROLL_OPPRETT_REVURDERING_ELLER_DIFF_TASK = "behandlingskontroll.opprettRevurderingEllerDiff";
+    public static final String BEHANDLING_ARSAK = "behandlingArsak";
+    private static final Logger log = LoggerFactory.getLogger(VurderGReguleringKandidatTask.class);
+    private Instance<PerioderForGReguleringUtleder> kandidaterForGReguleringTjeneste;
+    private ProsessTaskTjeneste taskRepository;
+    private BehandlingRepository behandlingRepository;
+
+    VurderGReguleringKandidatTask() {
+        // CDI
+    }
+
+    @Inject
+    public VurderGReguleringKandidatTask(FagsakLåsRepository fagsakLåsRepository,
+                                         @Any Instance<PerioderForGReguleringUtleder> kandidaterForGReguleringTjeneste,
+                                         ProsessTaskTjeneste taskRepository, BehandlingRepository behandlingRepository) {
+        super(fagsakLåsRepository, null);
+        this.kandidaterForGReguleringTjeneste = kandidaterForGReguleringTjeneste;
+        this.taskRepository = taskRepository;
+        this.behandlingRepository = behandlingRepository;
+    }
+
+    @Override
+    protected void prosesser(ProsessTaskData prosessTaskData) {
+        var fomProperty = prosessTaskData.getPropertyValue(PERIODE_FOM);
+        if (fomProperty.startsWith("\"")) {
+            fomProperty = fomProperty.substring(1, fomProperty.length() - 1);
+        }
+        var fom = LocalDate.parse(fomProperty);
+        var tomProperty = prosessTaskData.getPropertyValue(PERIODE_TOM);
+        if (tomProperty.startsWith("\"")) {
+            tomProperty = tomProperty.substring(1, tomProperty .length() - 1);
+        }
+        var tom = LocalDate.parse(tomProperty);
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
+
+
+        var sisteBehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(prosessTaskData.getFagsakId()).orElseThrow(() -> new IllegalStateException("Forventer å finne behandling"));
+
+        var perioderSomSkalGReguleres = PerioderForGReguleringUtleder.finnTjeneste(sisteBehandling.getFagsak().getYtelseType(), kandidaterForGReguleringTjeneste)
+            .utledPerioderForGRegulering(sisteBehandling, periode);
+
+        if (!perioderSomSkalGReguleres.isEmpty()) {
+            log.info("Fagsaken skal g-reguleres for følgende perioder " + perioderSomSkalGReguleres);
+            var data =  ProsessTaskData.forTaskType(new TaskType(BEHANDLINGSKONTROLL_OPPRETT_REVURDERING_ELLER_DIFF_TASK));
+            data.setFagsakId(prosessTaskData.getFagsakId());
+            data.setProperty(BEHANDLING_ARSAK, BehandlingÅrsakType.RE_SATS_REGULERING.getKode());
+            var periodeString = lagPeriodeString(perioderSomSkalGReguleres);
+            data.setProperty(PERIODER, periodeString);
+            taskRepository.lagre(data);
+        } else {
+            log.info("Fagsaken trenger IKKE g-reguleres");
+        }
+    }
+
+    private static String lagPeriodeString(Set<DatoIntervallEntitet> perioderSomSkalGReguleres) {
+        return perioderSomSkalGReguleres.stream()
+            .map(p -> p.getFomDato().format(DateTimeFormatter.ISO_DATE) + "/" + p.getTomDato().format(DateTimeFormatter.ISO_DATE))
+            .reduce((s1, s2) -> s1 + "|" + s2)
+            .orElse("");
+    }
+}

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
@@ -57,16 +57,8 @@ public class VurderGReguleringKandidatTask extends FagsakProsessTask {
 
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData) {
-        var fomProperty = prosessTaskData.getPropertyValue(PERIODE_FOM);
-        if (fomProperty.startsWith("\"")) {
-            fomProperty = fomProperty.substring(1, fomProperty.length() - 1);
-        }
-        var fom = LocalDate.parse(fomProperty);
-        var tomProperty = prosessTaskData.getPropertyValue(PERIODE_TOM);
-        if (tomProperty.startsWith("\"")) {
-            tomProperty = tomProperty.substring(1, tomProperty .length() - 1);
-        }
-        var tom = LocalDate.parse(tomProperty);
+        var fom = LocalDate.parse(prosessTaskData.getPropertyValue(PERIODE_FOM));
+        var tom = LocalDate.parse(prosessTaskData.getPropertyValue(PERIODE_TOM));
         var periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
 
 

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/ung/sak/ytelse/regulering/VurderGReguleringKandidatTask.java
@@ -83,7 +83,6 @@ public class VurderGReguleringKandidatTask extends FagsakProsessTask {
     private static String lagPeriodeString(Set<DatoIntervallEntitet> perioderSomSkalGReguleres) {
         return perioderSomSkalGReguleres.stream()
             .map(p -> p.getFomDato().format(DateTimeFormatter.ISO_DATE) + "/" + p.getTomDato().format(DateTimeFormatter.ISO_DATE))
-            .reduce((s1, s2) -> s1 + "|" + s2)
-            .orElse("");
+            .collect(java.util.stream.Collectors.joining("|"));
     }
 }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/beregnytelse/gregulering/UngdomsytelseKandidatForGReguleringUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/beregnytelse/gregulering/UngdomsytelseKandidatForGReguleringUtleder.java
@@ -1,6 +1,7 @@
 package no.nav.ung.ytelse.ungdomsprogramytelsen.beregnytelse.gregulering;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
@@ -25,6 +26,7 @@ public class UngdomsytelseKandidatForGReguleringUtleder implements PerioderForGR
 
     private UngdomsytelseGrunnlagRepository grunnlagRepository;
 
+    @Inject
     public UngdomsytelseKandidatForGReguleringUtleder(UngdomsytelseGrunnlagRepository grunnlagRepository) {
         this.grunnlagRepository = grunnlagRepository;
     }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/beregnytelse/gregulering/UngdomsytelseKandidatForGReguleringUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/beregnytelse/gregulering/UngdomsytelseKandidatForGReguleringUtleder.java
@@ -1,0 +1,57 @@
+package no.nav.ung.ytelse.ungdomsprogramytelsen.beregnytelse.gregulering;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.ytelse.UngdomsytelseGrunnlag;
+import no.nav.ung.sak.behandlingslager.ytelse.UngdomsytelseGrunnlagRepository;
+import no.nav.ung.sak.behandlingslager.ytelse.sats.UngdomsytelseSatser;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.domene.typer.tid.TidslinjeUtil;
+import no.nav.ung.sak.grunnbeløp.Grunnbeløp;
+import no.nav.ung.sak.grunnbeløp.GrunnbeløpTidslinje;
+import no.nav.ung.sak.ytelse.regulering.PerioderForGReguleringUtleder;
+
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.TreeSet;
+
+@ApplicationScoped
+@FagsakYtelseTypeRef(FagsakYtelseType.UNGDOMSYTELSE)
+public class UngdomsytelseKandidatForGReguleringUtleder implements PerioderForGReguleringUtleder {
+
+    private UngdomsytelseGrunnlagRepository grunnlagRepository;
+
+    public UngdomsytelseKandidatForGReguleringUtleder(UngdomsytelseGrunnlagRepository grunnlagRepository) {
+        this.grunnlagRepository = grunnlagRepository;
+    }
+
+    public UngdomsytelseKandidatForGReguleringUtleder() {
+    }
+
+    @Override
+    public NavigableSet<DatoIntervallEntitet> utledPerioderForGRegulering(Behandling behandling, DatoIntervallEntitet periode) {
+        Optional<UngdomsytelseGrunnlag> ungdomsytelseGrunnlag = grunnlagRepository.hentGrunnlag(behandling.getId());
+
+        if (ungdomsytelseGrunnlag.isEmpty()) {
+            return new TreeSet<>();
+        }
+
+        LocalDateTimeline<Grunnbeløp> overlappendeGrunnbeløpTidslinje = GrunnbeløpTidslinje.hentTidslinje().intersection(periode.toLocalDateInterval());
+        LocalDateTimeline<UngdomsytelseSatser> overlappendeSatsTidslinje = ungdomsytelseGrunnlag.get().getSatsTidslinje().intersection(periode.toLocalDateInterval());
+
+        LocalDateTimeline<Boolean> tidslinjeMedDiff = overlappendeSatsTidslinje.combine(overlappendeGrunnbeløpTidslinje,
+                (di, lhs, rhs) -> {
+                    if (rhs == null) {
+                        throw new IllegalStateException("Forventer at grunnbeløptidslinjen eksisterer for hele den overlappende satstidslinjen");
+                    }
+                    return new LocalDateSegment<>(di, lhs.getValue().grunnbeløp().compareTo(rhs.getValue().verdi()) != 0);
+                }, LocalDateTimeline.JoinStyle.LEFT_JOIN)
+            .filterValue(it -> it);
+
+        return TidslinjeUtil.tilDatoIntervallEntiteter(tidslinjeMedDiff);
+    }
+}

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/beregnytelse/gregulering/UngdomsytelseKandidatForGReguleringUtlederTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/beregnytelse/gregulering/UngdomsytelseKandidatForGReguleringUtlederTest.java
@@ -1,0 +1,44 @@
+package no.nav.ung.ytelse.ungdomsprogramytelsen.beregnytelse.gregulering;
+
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.ungdomsytelse.sats.UngdomsytelseSatsType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.ytelse.UngdomsytelseGrunnlag;
+import no.nav.ung.sak.behandlingslager.ytelse.UngdomsytelseGrunnlagRepository;
+import no.nav.ung.sak.behandlingslager.ytelse.sats.UngdomsytelseSatser;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UngdomsytelseKandidatForGReguleringUtlederTest {
+
+    @Test
+    void skal_utlede_avvikende_periode_og_ignorere_match_i_samme_periode() {
+        var grunnlagRepository = mock(UngdomsytelseGrunnlagRepository.class);
+        var grunnlag = mock(UngdomsytelseGrunnlag.class);
+        var behandling = mock(Behandling.class);
+
+        var fom = LocalDate.of(2024, 4, 20);
+        var tom = LocalDate.of(2024, 5, 10);
+        var satser = new UngdomsytelseSatser(BigDecimal.ONE, BigDecimal.valueOf(118620), BigDecimal.ONE, UngdomsytelseSatsType.LAV, 0, 0);
+
+        when(behandling.getId()).thenReturn(1L);
+        when(grunnlagRepository.hentGrunnlag(behandling.getId())).thenReturn(Optional.of(grunnlag));
+        when(grunnlag.getSatsTidslinje()).thenReturn(new LocalDateTimeline<>(List.of(new LocalDateSegment<>(fom, tom, satser))));
+
+        var utleder = new UngdomsytelseKandidatForGReguleringUtleder(grunnlagRepository);
+
+        var resultat = utleder.utledPerioderForGRegulering(behandling, DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom));
+
+        assertThat(resultat).containsExactly(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2024, 5, 1), tom));
+    }
+}


### PR DESCRIPTION
### Behov / Bakgrunn
G-beløpet har endret seg fra 1. mai og vi må revurdere alle saker som overlapper 1. mai og som enda ikkje har fått oppdatert G-beløp

### Løsning
Utleder perioder der grunnbeløp i databasen ikkje stemmer overens med grunnbeløp i koden.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
