### PR TITLE
Fjerner vedtak-footer fra oversendt-brev

### DIFF
--- a/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/klage/oversendt.hbs
+++ b/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/klage/oversendt.hbs
@@ -14,6 +14,6 @@
         Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via <a title="nav.no ettersendelse" href="https://klage.nav.no/nb/ettersendelse/klage/SYKDOM_I_FAMILIEN">klage.nav.no/nb/ettersendelse/klage/SYKDOM_I_FAMILIEN</a>. Velg NAV-enhet: {{ettersendelsesenhet}}.
     </p>
 
-    {{> felles/footer/footer-vedtak}}
+    {{> felles/footer/footer}}
 
 {{/felles/base}}

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/VedtaksbrevVerifikasjon.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/VedtaksbrevVerifikasjon.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 
 public class VedtaksbrevVerifikasjon {
 
-    private static final String STANDARD_HEADER_FOOTER = """
+    private static final String VEDTAK_HEADER_FOOTER = """
         Brev for ungdomsprogramytelsen %s \
         Til: %s \
         Fødselsnummer: %s \
@@ -27,10 +27,24 @@ public class VedtaksbrevVerifikasjon {
         %s \
         side av""";
 
+    private static final String HEADER_FOOTER = """
+        Brev for ungdomsprogramytelsen %s \
+        Til: %s \
+        Fødselsnummer: %s \
+        %s\
+        Trenger du mer informasjon? \
+        Du finner mer informasjon på nav.no/ungdomsprogrammet. \
+        På nav.no/kontakt kan du chatte eller skrive til oss. \
+        Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09:00-15:00. \
+        Med vennlig hilsen \
+        Nav Tiltak Oslo \
+        %s \
+        side av""";
+
     public static String medHeaderOgFooter(String fnr, String body) {
         LocalDate brevdato = LocalDate.now();
 
-        return STANDARD_HEADER_FOOTER
+        return VEDTAK_HEADER_FOOTER
             .formatted(
                 BrevTestUtils.brevDatoString(brevdato),
                 BrevScenarioerUtils.DEFAULT_NAVN,
@@ -41,7 +55,7 @@ public class VedtaksbrevVerifikasjon {
 
     public static String medHeaderOgFooterManuell(String fnr, String body) {
         LocalDate brevdato = LocalDate.now();
-        return STANDARD_HEADER_FOOTER
+        return VEDTAK_HEADER_FOOTER
             .formatted(
                 BrevTestUtils.brevDatoString(brevdato),
                 BrevScenarioerUtils.DEFAULT_NAVN,
@@ -52,7 +66,18 @@ public class VedtaksbrevVerifikasjon {
 
     public static String medHeaderOgFooterManuellUtenBeslutter(String fnr, String body) {
         LocalDate brevdato = LocalDate.now();
-        return STANDARD_HEADER_FOOTER
+        return VEDTAK_HEADER_FOOTER
+            .formatted(
+                BrevTestUtils.brevDatoString(brevdato),
+                BrevScenarioerUtils.DEFAULT_NAVN,
+                fnr,
+                body,
+                BrevScenarioerUtils.DEFAULT_SAKSBEHANDLER_NAVN);
+    }
+
+    public static String medOversendtHeaderOgFooterManuellUtenBeslutter(String fnr, String body) {
+        LocalDate brevdato = LocalDate.now();
+        return HEADER_FOOTER
             .formatted(
                 BrevTestUtils.brevDatoString(brevdato),
                 BrevScenarioerUtils.DEFAULT_NAVN,

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/klage/KlageOversendtTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/klage/KlageOversendtTest.java
@@ -10,6 +10,8 @@ import no.nav.ung.sak.test.util.behandling.ungdomsprogramytelse.TestScenarioBuil
 import no.nav.ung.sak.test.util.behandling.ungdomsprogramytelse.UngKlageTestScenario;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.DisplayName;
+
 import static no.nav.ung.ytelse.ungdomsprogramytelsen.formidling.HtmlAssert.assertThatHtml;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +29,7 @@ class KlageOversendtTest extends AbstractKlageVedtaksbrevInnholdByggerTest {
 
         var klage = KlageScenarioer.lagKlageBehandling(ungTestRepositories, klageScenario);
 
-        var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooterManuellUtenBeslutter(fnr,
+        var forventet = VedtaksbrevVerifikasjon.medOversendtHeaderOgFooterManuellUtenBeslutter(fnr,
             """
                 Vi har sendt saken til NAV Klageinstans \
                 Vi har vurdert klagen på vedtaket om ungdomsprogramytelse, og kommet fram til at vedtaket ikke \
@@ -52,6 +54,21 @@ class KlageOversendtTest extends AbstractKlageVedtaksbrevInnholdByggerTest {
 
     }
 
+
+    @Override
+    @Test
+    @DisplayName("Verifiserer formatering på overskrifter")
+    void verifiserOverskrifter() {
+        var behandling = lagScenarioForFellesTester();
+
+        GenerertBrev brev = vedtaksbrevTjeneste.forhåndsvis(behandling.getId(), true);
+
+        var brevtekst = brev.dokument().html();
+
+        assertThatHtml(brevtekst).containsHtmlSubSequenceOnce(
+            "<h2>Trenger du mer informasjon?</h2>"
+        );
+    }
 
     @Override
     protected Behandling lagScenarioForFellesTester() {


### PR DESCRIPTION
### Behov / Bakgrunn
Brev om oversendelse til klageenheten er kun et informasjonsbrev, ikke et vedtasksbrev
https://nav-it.slack.com/archives/D0102PKVC0G/p1779888656694409

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
