### PR TITLE
Fix: Bytter ut link for ettersendelse til klager på ung

### DIFF
--- a/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/klage/oversendt.hbs
+++ b/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/klage/oversendt.hbs
@@ -11,7 +11,7 @@
     {{safe fritekst}}
 
     <p>
-        Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via <a title="nav.no ettersendelse" href="https://klage.nav.no/nb/ettersendelse/klage/SYKDOM_I_FAMILIEN">klage.nav.no/nb/ettersendelse/klage/SYKDOM_I_FAMILIEN</a>. Velg NAV-enhet: {{ettersendelsesenhet}}.
+        Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via <a title="nav.no ettersendelse" href="https://klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse">klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse</a>. Velg NAV-enhet: {{ettersendelsesenhet}}.
     </p>
 
     {{> felles/footer/footer}}

--- a/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/klage/oversendt.hbs
+++ b/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/klage/oversendt.hbs
@@ -11,7 +11,7 @@
     {{safe fritekst}}
 
     <p>
-        Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via <a title="nav.no ettersendelse" href="https://klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse">klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse</a>. Velg NAV-enhet: {{ettersendelsesenhet}}.
+        Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via <a title="klage.nav.no ettersendelse" href="https://klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse">klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse</a>. Velg NAV-enhet: {{ettersendelsesenhet}}.
     </p>
 
     {{> felles/footer/footer}}

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/klage/KlageOversendtTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/klage/KlageOversendtTest.java
@@ -37,7 +37,7 @@ class KlageOversendtTest extends AbstractKlageVedtaksbrevInnholdByggerTest {
                 de har mottatt saken. Du finner oversikt over saksbehandlingstidene på nav.no/saksbehandlingstider. \
                 Dette har vi lagt vekt på i vurderingen vår \
                 FRITEKST I BREV \
-                Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via klage.nav.no/nb/ettersendelse/klage/SYKDOM_I_FAMILIEN. Velg NAV-enhet: NAV Klageinstans Sør. \
+                Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via klage.nav.no/nb/ettersendelse/klage/ungdomsprogrammet/begrunnelse. Velg NAV-enhet: NAV Klageinstans Sør. \
                 """);
 
 


### PR DESCRIPTION
### Behov / Bakgrunn
Oppdatere link for ettersendelser til klager på ungdomsprgammet.
https://nav-it.slack.com/archives/D0102PKVC0G/p1779954313090849

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
