### PR TITLE
chore: Legger inn cancel-previous for å kansellere gamle jobber. Slår sammen dependabot-verdikjede-jobb, med vanlig verdikjede-tester

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,6 @@ jobs:
       contents: read
       packages: read
     uses: navikt/sif-gha-workflows/.github/workflows/verdikjede-test-v2.yml@main
-    if: ${{github.actor != 'dependabot[bot]'}}
     needs: build-app
     with:
       tag: ${{ needs.build-app.outputs.build-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,26 +75,9 @@ jobs:
     needs: build-app
     with:
       tag: ${{ needs.build-app.outputs.build-version }}
-      suites: "ung,ung-tilbake,frontend-ung,aktivitetspenger"
+      suites: ${{ github.actor == 'dependabot[bot]' && 'ung' || 'ung,ung-tilbake,frontend-ung,aktivitetspenger' }}
       override_image_artifact_name: ${{ github.ref_name != github.event.repository.default_branch && needs.build-app.outputs.image-artifact-name || null }}
       image_version: ${{ needs.build-app.outputs.build-version }}
-
-  verdikjede-tester-dependabot:
-    name: Verdikjedetester Dependabot
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-      packages: read
-    uses: navikt/sif-gha-workflows/.github/workflows/verdikjede-test-v2.yml@main
-    if: ${{github.actor == 'dependabot[bot]'}}
-    needs: build-app
-    with:
-      tag: ${{ needs.build-app.outputs.build-version }}
-      suites: "ung,aktivitetspenger"
-      override_image_artifact_name: ${{ github.ref_name != github.event.repository.default_branch && needs.build-app.outputs.image-artifact-name || null }}
-      image_version: ${{ needs.build-app.outputs.build-version }}
-
 
   deploy-dev:
     name: Deploy dev
@@ -111,12 +94,44 @@ jobs:
       naiserator_file: deploy/dev-gcp.yml
     secrets: inherit
 
+  cancel-previous:
+    permissions:
+      actions: write
+    needs: [ build-typescript-client, deploy-dev, verdikjede-tester ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const currentRun = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const workflowId = currentRun.data.workflow_id;
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              status: 'waiting',
+            });
+            for (const run of runs.data.workflow_runs) {
+              if (run.run_number < currentRun.data.run_number) {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                });
+              }
+            }
+
+
   # Sjekker at ny typescript klient kode for kode som blir rulla ut til prod er kompatibel med k9-sak-web prod versjon.
   # Viss denne feiler er det fare for at frontend vil feile med backend som blir forsøkt rulla ut.
   prod-typescript-check:
     name: Kompileringssjekk k9-sak-web latest_prod
     runs-on: ubuntu-latest
-    needs: [ build-typescript-client, deploy-dev ]
+    needs: [cancel-previous]
     # environment satt her er det som skal ha "protection rule" i github settings hvis man ønsker godkjenning før
     # utrulling til prod. Kan fjernes helt hvis man ønsker automatisk utrulling til prod.
     #


### PR DESCRIPTION
### Behov / Bakgrunn
Ny jobb for kansellering av gamle jobber når endring er klar for prod (deploy til dev og verdikjede-test har gått igjennom)

Bruker samme jobb for verdikjedetesting for dependabot, men tilpasset suite.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
