### PR TITLE
TSFF-2724: Returnerer tomt resultat dersom det ikkje finnes beregningsgrunnlag

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
@@ -118,9 +118,7 @@ public class AktivitetspengerRestTjeneste {
         if (beregningsgrunnlag.isEmpty()) {
             return null;
         }
-        return beregningsgrunnlag
-            .map(grunnlag -> mapTilBeregningsgrunnlagDto(grunnlag, inntektsposter))
-            .orElseThrow(() -> new IllegalStateException("Fant ikke beregningsgrunnlag for behandlingid: " + behandling.getId()));
+        return mapTilBeregningsgrunnlagDto(beregningsgrunnlag.get(), inntektsposter);
     }
 
     private static BeregningsgrunnlagDto mapTilBeregningsgrunnlagDto(Beregningsgrunnlag grunnlag, List<Inntektspost> inntektsposter) {

--- a/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
@@ -36,11 +36,7 @@ import no.nav.ung.ytelse.aktivitetspenger.beregning.beste.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Year;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionType.READ;
@@ -117,8 +113,12 @@ public class AktivitetspengerRestTjeneste {
         Behandling behandling = behandlingRepository.hentBehandling(behandlingUuid.getBehandlingUuid());
         var inntektsposter = beregningTjeneste.hentSigrunInntektsposter(behandling.getId());
 
-        return aktivitetspengerGrunnlagRepository.hentGrunnlag(behandling.getId())
-            .flatMap(AktivitetspengerGrunnlag::getSenesteBeregningsgrunnlag)
+        Optional<Beregningsgrunnlag> beregningsgrunnlag = aktivitetspengerGrunnlagRepository.hentGrunnlag(behandling.getId())
+            .flatMap(AktivitetspengerGrunnlag::getSenesteBeregningsgrunnlag);
+        if (beregningsgrunnlag.isEmpty()) {
+            return null;
+        }
+        return beregningsgrunnlag
             .map(grunnlag -> mapTilBeregningsgrunnlagDto(grunnlag, inntektsposter))
             .orElseThrow(() -> new IllegalStateException("Fant ikke beregningsgrunnlag for behandlingid: " + behandling.getId()));
     }

--- a/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/aktivitetspenger/AktivitetspengerRestTjeneste.java
@@ -2,6 +2,9 @@ package no.nav.ung.sak.web.app.aktivitetspenger;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -105,7 +108,10 @@ public class AktivitetspengerRestTjeneste {
     }
 
     @GET
-    @Operation(description = "Henter beregningsgrunnlag for en aktivitetspengerbehandling", tags = "avp")
+    @Operation(description = "Henter beregningsgrunnlag for en aktivitetspengerbehandling", tags = "avp", responses = {
+        @ApiResponse(responseCode = "200", description = "Beregningsgrunnlag funnet", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = BeregningsgrunnlagDto.class))),
+        @ApiResponse(responseCode = "204", description = "Beregning er ikke kjørt ennå – ingen beregningsgrunnlag tilgjengelig")
+    })
     @BeskyttetRessurs(action = READ, resource = BeskyttetRessursResourceType.FAGSAK)
     @Path(BEREGNINGSGRUNNLAG_PATH)
     @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -6058,7 +6058,7 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6066,7 +6066,10 @@
                 }
               }
             },
-            "description" : "default response"
+            "description" : "Beregningsgrunnlag funnet"
+          },
+          "204" : {
+            "description" : "Beregning er ikke kjørt ennå – ingen beregningsgrunnlag tilgjengelig"
           }
         },
         "tags" : [ "avp" ]


### PR DESCRIPTION
Behov / Bakgrunn
Dersom vi enda ikkje har kommet til beregning ønsker vi å returnere tomt resultat for beregningsgurnnlag i staden for å feile.

Sjekkliste for godkjenner
 Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
 Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
 Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av hvorfor endringen gjøres