### PR TITLE
Øker antallet samtidige brevgenereringer til 4

### DIFF
--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -290,6 +290,8 @@ spec:
       value: "P14D"
     - name: HENT_INNTEKT_HENDElSER_INTERVALL
       value: "PT1M"
+    - name: BREVGENERERING_MAX_ANTALL_SAMTIDIGE
+      value: "4"
 
     # Audit logging
     - name: AUDITLOGGER_ENABLED


### PR DESCRIPTION
### Behov / Bakgrunn

ung-sak logget følgende flere ganger tidligere i dag:

Ventet i X ms på å få semafor for brevbestilling, skjer dette ofte bør semaforens antall og nodens minne økes for bedre ytelse

### Løsning

Oversikt i grafana viser at ung-sak har mye minne å gå på, så øker samtidighet


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
