### PR TITLE
Skal ikke sende brev ved g-regulering

### DIFF
--- a/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/resultat/DetaljertResultatType.java
+++ b/formidling/src/main/java/no/nav/ung/sak/formidling/vedtak/resultat/DetaljertResultatType.java
@@ -21,8 +21,8 @@ public enum DetaljertResultatType {
     ENDRING_BARN_DØDSFALL("Endring pga dødsfall av barn"),
     ENDRING_DELTAKER_DØDSFALL("Endring pga dødsfall av deltaker"),
     INNVILGELSE_ANNET("Innvilgelse pga annen årsak - se forklaring"),
-    INNVILGET_UTEN_ÅRSAK("Innvilgelse uten behandlingsårsak")
-    ;
+    INNVILGET_UTEN_ÅRSAK("Innvilgelse uten behandlingsårsak"),
+    SATS_REGULERING("Innvilgelse etter G-regulering");
 
     private final String beskrivelse;
 

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/vedtak/SatsReguleringStrategy.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/vedtak/SatsReguleringStrategy.java
@@ -1,7 +1,6 @@
 package no.nav.ung.ytelse.aktivitetspenger.formidling.vedtak;
 
 import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
@@ -17,10 +16,6 @@ import no.nav.ung.sak.formidling.vedtak.resultat.ResultatHelper;
 @FagsakYtelseTypeRef(FagsakYtelseType.AKTIVITETSPENGER)
 public final class SatsReguleringStrategy implements VedtaksbrevInnholdbyggerStrategy {
 
-
-    @Inject
-    public SatsReguleringStrategy() {
-    }
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/vedtak/SatsReguleringStrategy.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/vedtak/SatsReguleringStrategy.java
@@ -1,0 +1,37 @@
+package no.nav.ung.ytelse.aktivitetspenger.formidling.vedtak;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.formidling.vedtak.regler.IngenBrevÅrsakType;
+import no.nav.ung.sak.formidling.vedtak.regler.strategy.VedtaksbrevInnholdbyggerStrategy;
+import no.nav.ung.sak.formidling.vedtak.regler.strategy.VedtaksbrevStrategyResultat;
+import no.nav.ung.sak.formidling.vedtak.resultat.DetaljertResultat;
+import no.nav.ung.sak.formidling.vedtak.resultat.DetaljertResultatType;
+import no.nav.ung.sak.formidling.vedtak.resultat.ResultatHelper;
+
+@Dependent
+@FagsakYtelseTypeRef(FagsakYtelseType.AKTIVITETSPENGER)
+public final class SatsReguleringStrategy implements VedtaksbrevInnholdbyggerStrategy {
+
+
+    @Inject
+    public SatsReguleringStrategy() {
+    }
+
+    @Override
+    public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
+        return VedtaksbrevStrategyResultat.utenBrev(IngenBrevÅrsakType.IKKE_RELEVANT, "Ingen brev ved G-regulering");
+    }
+
+    @Override
+    public boolean skalEvaluere(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
+        var resultatInfo = VedtaksbrevInnholdbyggerStrategy.tilResultatInfo(detaljertResultat);
+        var resultater = new ResultatHelper(resultatInfo);
+        return resultater.innholderBare(DetaljertResultatType.SATS_REGULERING);
+    }
+
+}

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/vedtak/resultat/AktivitetspengerDetaljertResultatForPeriodeUtleder.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/formidling/vedtak/resultat/AktivitetspengerDetaljertResultatForPeriodeUtleder.java
@@ -21,7 +21,8 @@ public class AktivitetspengerDetaljertResultatForPeriodeUtleder implements Detal
         BehandlingÅrsakType.RE_HENDELSE_DØD_BARN, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_BARN_DØDSFALL),
         BehandlingÅrsakType.RE_TRIGGER_BEREGNING_HØY_SATS, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_ØKT_SATS),
         BehandlingÅrsakType.RE_HENDELSE_FØDSEL, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_BARN_FØDSEL),
-        BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_DELTAKER_DØDSFALL)
+        BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_DELTAKER_DØDSFALL),
+        BehandlingÅrsakType.RE_SATS_REGULERING, DetaljertResultatInfo.of(DetaljertResultatType.SATS_REGULERING)
     );
 
     @Override

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/regler/strategy/SatsReguleringStrategy.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/regler/strategy/SatsReguleringStrategy.java
@@ -1,0 +1,37 @@
+package no.nav.ung.ytelse.ungdomsprogramytelsen.formidling.vedtak.regler.strategy;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.formidling.vedtak.regler.IngenBrevÅrsakType;
+import no.nav.ung.sak.formidling.vedtak.regler.strategy.VedtaksbrevInnholdbyggerStrategy;
+import no.nav.ung.sak.formidling.vedtak.regler.strategy.VedtaksbrevStrategyResultat;
+import no.nav.ung.sak.formidling.vedtak.resultat.DetaljertResultat;
+import no.nav.ung.sak.formidling.vedtak.resultat.DetaljertResultatType;
+import no.nav.ung.sak.formidling.vedtak.resultat.ResultatHelper;
+
+@Dependent
+@FagsakYtelseTypeRef(FagsakYtelseType.UNGDOMSYTELSE)
+public final class SatsReguleringStrategy implements VedtaksbrevInnholdbyggerStrategy {
+
+
+    @Inject
+    public SatsReguleringStrategy() {
+    }
+
+    @Override
+    public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
+        return VedtaksbrevStrategyResultat.utenBrev(IngenBrevÅrsakType.IKKE_RELEVANT, "Ingen brev ved G-regulering");
+    }
+
+    @Override
+    public boolean skalEvaluere(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {
+        var resultatInfo = VedtaksbrevInnholdbyggerStrategy.tilResultatInfo(detaljertResultat);
+        var resultater = new ResultatHelper(resultatInfo);
+        return resultater.innholderBare(DetaljertResultatType.SATS_REGULERING);
+    }
+
+}

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/regler/strategy/SatsReguleringStrategy.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/regler/strategy/SatsReguleringStrategy.java
@@ -1,7 +1,6 @@
 package no.nav.ung.ytelse.ungdomsprogramytelsen.formidling.vedtak.regler.strategy;
 
 import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
@@ -17,10 +16,6 @@ import no.nav.ung.sak.formidling.vedtak.resultat.ResultatHelper;
 @FagsakYtelseTypeRef(FagsakYtelseType.UNGDOMSYTELSE)
 public final class SatsReguleringStrategy implements VedtaksbrevInnholdbyggerStrategy {
 
-
-    @Inject
-    public SatsReguleringStrategy() {
-    }
 
     @Override
     public VedtaksbrevStrategyResultat evaluer(Behandling behandling, LocalDateTimeline<DetaljertResultat> detaljertResultat) {

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/resultat/UngDetaljertResultatForPeriodeUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/resultat/UngDetaljertResultatForPeriodeUtleder.java
@@ -24,7 +24,8 @@ public class UngDetaljertResultatForPeriodeUtleder implements DetaljertResultatF
         BehandlingÅrsakType.RE_HENDELSE_FØDSEL, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_BARN_FØDSEL),
         BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_DELTAKER_DØDSFALL),
         BehandlingÅrsakType.RE_HENDELSE_FJERN_PERIODE_UNGDOMSPROGRAM, DetaljertResultatInfo.of(DetaljertResultatType.ENDRING_FJERNE_PERIODE),
-        BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM, DetaljertResultatInfo.of(DetaljertResultatType.FORLENGET_PERIODE)
+        BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM, DetaljertResultatInfo.of(DetaljertResultatType.FORLENGET_PERIODE),
+        BehandlingÅrsakType.RE_SATS_REGULERING, DetaljertResultatInfo.of(DetaljertResultatType.SATS_REGULERING)
     );
 
 

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/SatsEndringScenarioer.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/SatsEndringScenarioer.java
@@ -1,0 +1,44 @@
+package no.nav.ung.ytelse.ungdomsprogramytelsen.formidling.scenarioer;
+
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriode;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.test.util.behandling.ungdomsprogramytelse.UngTestScenario;
+import no.nav.ung.sak.trigger.Trigger;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class SatsEndringScenarioer {
+
+    /**
+     * G-regulering
+     */
+    public static UngTestScenario gRegulsering(LocalDate fom) {
+        var p = new LocalDateInterval(fom, fom.plusYears(1));
+        var satser = new LocalDateTimeline<>(List.of(
+            new LocalDateSegment<>(fom, p.getTomDato(), BrevScenarioerUtils.lavSatsBuilder(fom).build())
+        ));
+
+        var programPerioder = List.of(new UngdomsprogramPeriode(p.getFomDato(), p.getTomDato()));
+
+        return new UngTestScenario(
+            BrevScenarioerUtils.DEFAULT_NAVN,
+            programPerioder,
+            satser,
+            BrevScenarioerUtils.uttaksPerioder(p),
+            BrevScenarioerUtils.tilkjentYtelsePerioder(satser, new LocalDateInterval(fom, fom.plusMonths(1).minusDays(1))),
+            new LocalDateTimeline<>(p, Utfall.OPPFYLT),
+            new LocalDateTimeline<>(p, Utfall.OPPFYLT),
+            fom.minusYears(19).plusDays(42),
+            List.of(p.getFomDato()),
+            Set.of(new Trigger(BehandlingÅrsakType.RE_SATS_REGULERING, DatoIntervallEntitet.fra(p.getFomDato(), p.getTomDato()))),
+            Collections.emptyList(), null, null);
+    }
+}

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/SatsEndringScenarioer.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/SatsEndringScenarioer.java
@@ -20,7 +20,7 @@ public class SatsEndringScenarioer {
     /**
      * G-regulering
      */
-    public static UngTestScenario gRegulsering(LocalDate fom) {
+    public static UngTestScenario gRegulering(LocalDate fom) {
         var p = new LocalDateInterval(fom, fom.plusYears(1));
         var satser = new LocalDateTimeline<>(List.of(
             new LocalDateSegment<>(fom, p.getTomDato(), BrevScenarioerUtils.lavSatsBuilder(fom).build())

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/YtelseVedtaksbrevReglerTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/YtelseVedtaksbrevReglerTest.java
@@ -149,6 +149,24 @@ class YtelseVedtaksbrevReglerTest {
 
     }
 
+
+    @Test
+    void skal_gi_ingen_brev_ved_g_regulering() {
+        LocalDate fom = LocalDate.of(2024, 12, 1);
+        var behandling = lagBehandling(SatsEndringScenarioer.gRegulsering(fom));
+
+        BehandlingVedtaksbrevResultat totalresultater = vedtaksbrevRegler.kjør(behandling.getId());
+        assertThat(totalresultater.harBrev()).isFalse();
+
+        assertThat(totalresultater.ingenBrevResultater()).hasSize(1);
+
+        var regelResulat = totalresultater.ingenBrevResultater().getFirst();
+        assertThat(regelResulat.ingenBrevÅrsakType()).isEqualTo(IngenBrevÅrsakType.IKKE_RELEVANT);
+
+        assertThat(regelResulat.forklaring()).containsIgnoringCase("ingen brev");
+
+    }
+
     @Test
     void skal_gi_tomt_brev_som_må_redigeres_ved_avslag_aldersvilkår() {
         LocalDate fom = LocalDate.of(2025, 8, 1);

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/YtelseVedtaksbrevReglerTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/YtelseVedtaksbrevReglerTest.java
@@ -153,7 +153,7 @@ class YtelseVedtaksbrevReglerTest {
     @Test
     void skal_gi_ingen_brev_ved_g_regulering() {
         LocalDate fom = LocalDate.of(2024, 12, 1);
-        var behandling = lagBehandling(SatsEndringScenarioer.gRegulsering(fom));
+        var behandling = lagBehandling(SatsEndringScenarioer.gRegulering(fom));
 
         BehandlingVedtaksbrevResultat totalresultater = vedtaksbrevRegler.kjør(behandling.getId());
         assertThat(totalresultater.harBrev()).isFalse();


### PR DESCRIPTION
### Behov / Bakgrunn

G-regulering skal ikke ha brev

### Løsning

Ved G-regulering så utledes ingen brev fra brevregel strategiene

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
