### PR TITLE
TSFF-2654 - Håndter tom endringstidslinje i programperiode-utleder (V2)

### DIFF
--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/ungdomsprogramkontroll/EtterlysningForEndretProgramperiodeResultatUtlederV2.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/ungdomsprogramkontroll/EtterlysningForEndretProgramperiodeResultatUtlederV2.java
@@ -85,12 +85,17 @@ public class EtterlysningForEndretProgramperiodeResultatUtlederV2 {
 
     private static boolean harEndring(UngdomsprogramPeriodeGrunnlag førsteGrunnlag, UngdomsprogramPeriodeGrunnlag andreGrunnlag) {
         LocalDateTimeline<Boolean> endretTidslinje = UngdomsprogramPeriodeTjeneste.finnEndretTidslinje(Optional.of(andreGrunnlag), Optional.of(førsteGrunnlag));
-        if (andreGrunnlag.getPeriodeMaksDato().isPresent() && andreGrunnlag.getPeriodeMaksDato().get().isBefore(endretTidslinje.getMinLocalDate())) {
-            // Hele endringen ligger etter maksdato
-            // dette håndteres av varsel ved opphør på maksdato
+        if (endretTidslinje.isEmpty()) {
             return false;
         }
-        return !endretTidslinje.isEmpty();
+
+        return andreGrunnlag.getPeriodeMaksDato()
+            .filter(maksDato -> {
+                // Hele endringen ligger etter maksdato
+                // dette håndteres av varsel ved opphør på maksdato
+                return maksDato.isBefore(endretTidslinje.getMinLocalDate());
+            })
+            .isEmpty();
     }
 
     private static void validerHøystEnProgramperiode(EndretUngdomsprogramEtterlysningInput input) {

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/ungdomsprogramkontroll/ProgramperiodeendringEtterlysningTjenesteV2Test.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/ungdomsprogramkontroll/ProgramperiodeendringEtterlysningTjenesteV2Test.java
@@ -116,6 +116,24 @@ class ProgramperiodeendringEtterlysningTjenesteV2Test {
     }
 
     @Test
+    void skal_ikke_kaste_ved_tom_endringstidslinje_når_periode_maksdato_er_satt() {
+
+        final var fom = LocalDate.now();
+        final var tom = TIDENES_ENDE;
+        final var periodeMaksDato = fom.plusWeeks(8);
+        ungdomsytelseStartdatoRepository.lagre(behandling.getId(), List.of(new UngdomsytelseSøktStartdato(fom, new JournalpostId("1L"))));
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)), false, periodeMaksDato);
+
+        // lagrer identisk grunnlag på nytt slik at endret tidslinje blir tom, men periodeMaksDato fortsatt er satt
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(), List.of(new UngdomsprogramPeriode(fom, tom)), false, periodeMaksDato);
+
+        programperiodeendringEtterlysningTjeneste.opprettEtterlysningerForProgramperiodeEndring(BehandlingReferanse.fra(behandling));
+
+        final var etterlysninger = etterlysningRepository.hentEtterlysninger(behandling.getId());
+        assertThat(etterlysninger.size()).isEqualTo(0);
+    }
+
+    @Test
     void skal_opprette_etterlysning_for_endret_startdato_endring() {
         final var fom = LocalDate.now();
         final var tom = TIDENES_ENDE;


### PR DESCRIPTION
### Behov / Bakgrunn

I V2-utleder for etterlysning ved endret programperiode kunne `harEndring(...)` kaste `IllegalStateException: Timeline is empty` når `finnEndretTidslinje(...)` returnerte tom tidslinje, samtidig som `periodeMaksDato` var satt. Dette stoppet prosessering i `VURDERKOMPLETT`.

### Løsning

La til tidlig guard i `EtterlysningForEndretProgramperiodeResultatUtlederV2.harEndring(...)`:
- returnerer `false` når endringstidslinjen er tom
- unngår kall til `getMinLocalDate()` på tom tidslinje
- beholder eksisterende logikk for filtrering av endringer etter `periodeMaksDato`

### Andre endringer

La til regresjonstest i `ProgramperiodeendringEtterlysningTjenesteV2Test` som verifiserer at identisk grunnlag med satt `periodeMaksDato` ikke kaster feil og ikke oppretter etterlysning.


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
