### PR TITLE
feat: legg til maksdato i forlenget periode-brev

### DIFF
--- a/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/ungdomsprogramytelse/forlenget_periode.hbs
+++ b/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/ungdomsprogramytelse/forlenget_periode.hbs
@@ -3,8 +3,8 @@
     {{#> felles/seksjon/hoved }}
         <h1>Du får forlenget perioden med ungdomsprogramytelsen</h1>
         <p>
-            Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen.
-            Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn i åtte nye uker.
+            Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen med inntil 8 nye uker.
+            Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til {{maksdato}}.
         </p>
         <p>Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6.</p>
 

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/dto/ForlengetPeriodeDto.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/dto/ForlengetPeriodeDto.java
@@ -5,5 +5,6 @@ import no.nav.ung.sak.formidling.innhold.TemplateInnholdDto;
 import java.time.LocalDate;
 
 public record ForlengetPeriodeDto(
-    LocalDate fom) implements TemplateInnholdDto {
+    LocalDate fom,
+    LocalDate maksdato) implements TemplateInnholdDto {
 }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/innhold/ForlengetPeriodeInnholdBygger.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/innhold/ForlengetPeriodeInnholdBygger.java
@@ -40,7 +40,14 @@ public class ForlengetPeriodeInnholdBygger implements VedtaksbrevInnholdBygger {
 
         LocalDate forlengetPeriodeFraOgMedDato = FagsakperiodeUtleder.justerTilNesteVirkedag(originalMaksDato.plusDays(1));
 
+        // Hent ny maksdato (etter 8 uker / 300 virkedager) fra registeret på nåværende behandling
+        LocalDate nyMaksdato = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId())
+            .flatMap(gr -> gr.getPeriodeMaksDato())
+            .orElseThrow(() -> new IllegalStateException(
+                "Forventet periodeMaksDato på behandling=" + behandling.getId()
+                    + " ved bygging av brev for forlenget periode"));
+
         return new TemplateInnholdResultat(TemplateType.FORLENGET_PERIODE,
-            new ForlengetPeriodeDto(forlengetPeriodeFraOgMedDato));
+            new ForlengetPeriodeDto(forlengetPeriodeFraOgMedDato, nyMaksdato));
     }
 }

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
@@ -37,8 +37,8 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             """
                 Du får forlenget perioden med ungdomsprogramytelsen \
-                Fra 1. januar 2026 får du forlenget perioden din med ungdomsprogramytelsen. \
-                Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn i åtte nye uker. \
+                Fra 1. januar 2026 får du forlenget perioden din med ungdomsprogramytelsen med inntil 8 nye uker. \
+                Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til 28. januar 2026. \
                 Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6. \
                 Meld fra til oss hvis du har arbeidsinntekt i tillegg til ungdomsprogramytelsen \
                 Hvis du har en arbeidsinntekt i tillegg til ungdomsprogramytelsen, er det viktig at du sier fra til oss om det. \


### PR DESCRIPTION
## Beskrivelse
Oppdaterer brevet "Forlenget periode" for ungdomsprogramytelsen med ny formulering som inkluderer maksdato.

### Endringer
- **Brevtekst**: Endrer fra "…men ikke lenger enn i åtte nye uker" til "…med inntil 8 nye uker. Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til [maksdato]."
- **DTO**: Legger til `maksdato`-felt i `ForlengetPeriodeDto`
- **Builder**: `ForlengetPeriodeInnholdBygger` hentet ny maksdato fra nåværende behandling (fra register via `periodeMaksDato`)
- **Template**: Oppdater `forlenget_periode.hbs` for å vise `{{maksdato}}`
- **Test**: Oppdater `ForlengetPeriodeTest` med forventet brevinnhold som inkluderer maksdato

### Bakgrunn
Bruksbehandlere trenger å vite eksakt når perioden utløper. Maksdato beregnes fra register (260 virkedager ved normal periode, 300 ved forlenget periode) og formatteres likt som øvrige brevfelter (f.eks. "28. januar 2026").

### Testing
- Kjør `mvn test -pl ytelse-ungdomsprogramytelsen -Dtest=ForlengetPeriodeTest` for å verifisere brevinnhold
- Lokale tester krever PostgreSQL schema `ung_sak_unit`