### PR TITLE
TSFF-2621 - feat: legg til maksdato i forlenget periode-brev

### DIFF
--- a/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/ungdomsprogramytelse/forlenget_periode.hbs
+++ b/formidling-pdfgen-templates/src/main/resources/pdfgen/templates/ungdomsprogramytelse/forlenget_periode.hbs
@@ -3,8 +3,8 @@
     {{#> felles/seksjon/hoved }}
         <h1>Du får forlenget perioden med ungdomsprogramytelsen</h1>
         <p>
-            Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen.
-            Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn i åtte nye uker.
+            Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen med inntil 8 nye uker.
+            Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til {{maksdato}}.
         </p>
         <p>Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6.</p>
 

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/dto/ForlengetPeriodeDto.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/dto/ForlengetPeriodeDto.java
@@ -5,5 +5,6 @@ import no.nav.ung.sak.formidling.innhold.TemplateInnholdDto;
 import java.time.LocalDate;
 
 public record ForlengetPeriodeDto(
-    LocalDate fom) implements TemplateInnholdDto {
+    LocalDate fom,
+    LocalDate maksdato) implements TemplateInnholdDto {
 }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/innhold/ForlengetPeriodeInnholdBygger.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/innhold/ForlengetPeriodeInnholdBygger.java
@@ -41,8 +41,11 @@ public class ForlengetPeriodeInnholdBygger implements VedtaksbrevInnholdBygger {
 
         LocalDate forlengetPeriodeFraOgMedDato = FagsakperiodeUtleder.justerTilNesteVirkedag(originalMaksDato.plusDays(1));
 
-        LocalDate nyMaksdato = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId())
-            .flatMap(UngdomsprogramPeriodeGrunnlag::getPeriodeMaksDato)
+        var nyttGrunnlag = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId())
+            .orElseThrow(() -> new IllegalStateException(
+                "Forventet ungdomsprogramPeriodeGrunnlag på behandling=" + behandling.getId()
+                    + " ved bygging av brev for forlenget periode"));
+        LocalDate nyMaksdato = nyttGrunnlag.getPeriodeMaksDato()
             .orElseThrow(() -> new IllegalStateException(
                 "Forventet periodeMaksDato på behandling=" + behandling.getId()
                     + " ved bygging av brev for forlenget periode"));

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/innhold/ForlengetPeriodeInnholdBygger.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/innhold/ForlengetPeriodeInnholdBygger.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.kodeverk.formidling.TemplateType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeGrunnlag;
 import no.nav.ung.sak.behandlingslager.perioder.UngdomsprogramPeriodeRepository;
 import no.nav.ung.sak.formidling.innhold.TemplateInnholdResultat;
 import no.nav.ung.sak.formidling.innhold.VedtaksbrevInnholdBygger;
@@ -40,7 +41,13 @@ public class ForlengetPeriodeInnholdBygger implements VedtaksbrevInnholdBygger {
 
         LocalDate forlengetPeriodeFraOgMedDato = FagsakperiodeUtleder.justerTilNesteVirkedag(originalMaksDato.plusDays(1));
 
+        LocalDate nyMaksdato = ungdomsprogramPeriodeRepository.hentGrunnlag(behandling.getId())
+            .flatMap(UngdomsprogramPeriodeGrunnlag::getPeriodeMaksDato)
+            .orElseThrow(() -> new IllegalStateException(
+                "Forventet periodeMaksDato på behandling=" + behandling.getId()
+                    + " ved bygging av brev for forlenget periode"));
+
         return new TemplateInnholdResultat(TemplateType.FORLENGET_PERIODE,
-            new ForlengetPeriodeDto(forlengetPeriodeFraOgMedDato));
+            new ForlengetPeriodeDto(forlengetPeriodeFraOgMedDato, nyMaksdato));
     }
 }

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
@@ -37,8 +37,8 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
         var forventet = VedtaksbrevVerifikasjon.medHeaderOgFooter(fnr,
             """
                 Du får forlenget perioden med ungdomsprogramytelsen \
-                Fra 1. januar 2026 får du forlenget perioden din med ungdomsprogramytelsen. \
-                Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn i åtte nye uker. \
+                Fra 1. januar 2026 får du forlenget perioden din med ungdomsprogramytelsen med inntil 8 nye uker. \
+                Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til 28. januar 2026. \
                 Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6. \
                 Meld fra til oss hvis du har arbeidsinntekt i tillegg til ungdomsprogramytelsen \
                 Hvis du har en arbeidsinntekt i tillegg til ungdomsprogramytelsen, er det viktig at du sier fra til oss om det. \

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/ForlengetPeriodeTest.java
@@ -21,6 +21,7 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
     private static final LocalDate FOM = LocalDate.of(2025, 1, 1);
     private static final LocalDate OPPRINNELIG_SLUTTDATO = LocalDate.of(2025, 12, 31);
     private static final LocalDate NY_SLUTTDATO = LocalDate.of(2026, 1, 28);
+    private static final LocalDate PERIODE_MAKSDATO = LocalDate.of(2026, 2, 15);
 
     ForlengetPeriodeTest() {
         super(1, "Du får forlenget perioden med ungdomsprogramytelsen");
@@ -38,7 +39,7 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
             """
                 Du får forlenget perioden med ungdomsprogramytelsen \
                 Fra 1. januar 2026 får du forlenget perioden din med ungdomsprogramytelsen med inntil 8 nye uker. \
-                Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til 28. januar 2026. \
+                Du får ytelsen så lenge du deltar i ungdomsprogrammet, men ikke lenger enn til 15. februar 2026. \
                 Vedtaket er gjort etter arbeidsmarkedsloven §§ 12 tredje ledd og 13 fjerde ledd og forskrift om forsøk med ungdomsprogram og ungdomsprogramytelsen § 6. \
                 Meld fra til oss hvis du har arbeidsinntekt i tillegg til ungdomsprogramytelsen \
                 Hvis du har en arbeidsinntekt i tillegg til ungdomsprogramytelsen, er det viktig at du sier fra til oss om det. \
@@ -54,7 +55,7 @@ class ForlengetPeriodeTest extends AbstractUngdomsytelseVedtaksbrevInnholdBygger
 
     private Behandling lagForlengetPeriodeBehandling(LocalDate opprinneligSluttdato, LocalDate nySluttdato) {
         var forrigeBehandlingGrunnlag = FørstegangsbehandlingScenarioer.innvilget19årMedMaksDato(FOM, opprinneligSluttdato);
-        var forlengetPeriodeGrunnlag = EndringProgramPeriodeScenarioer.forlengetPeriode(FOM, opprinneligSluttdato, nySluttdato);
+        var forlengetPeriodeGrunnlag = EndringProgramPeriodeScenarioer.forlengetPeriode(FOM, opprinneligSluttdato, nySluttdato, PERIODE_MAKSDATO);
 
         TestScenarioBuilder builder = TestScenarioBuilder.builderMedSøknad()
             .medBehandlingType(BehandlingType.REVURDERING)

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/EndringProgramPeriodeScenarioer.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/EndringProgramPeriodeScenarioer.java
@@ -220,14 +220,19 @@ public class EndringProgramPeriodeScenarioer {
     /**
      * Scenario der perioden er forlenget fra opprinnlig sluttdato til ny sluttdato.
      *
-     * @param fom               - startdato for programmet
-     * @param opprinneligSluttdato - opprinnlig sluttdato (slik det var i forrige behandling)
-     * @param nySluttdato       - ny sluttdato etter forlengelse
+     * @param fom                    - startdato for programmet
+     * @param opprinneligSluttdato   - opprinnlig sluttdato (slik det var i forrige behandling)
+     * @param nySluttdato            - ny sluttdato etter forlengelse
+     * @param periodeMaksDato        - registerets maksdato (kan avvike fra programperiodens sluttdato)
      */
-    public static UngTestScenario forlengetPeriode(LocalDate fom, LocalDate opprinneligSluttdato, LocalDate nySluttdato) {
+    public static UngTestScenario forlengetPeriode(LocalDate fom,
+                                                   LocalDate opprinneligSluttdato,
+                                                   LocalDate nySluttdato,
+                                                   LocalDate periodeMaksDato) {
         if (!nySluttdato.isAfter(opprinneligSluttdato)) {
             throw new IllegalArgumentException("Ny sluttdato må være etter opprinnelig sluttdato");
         }
+
 
         var nyProgramPeriode = new LocalDateInterval(fom, nySluttdato);
         var satser = new LocalDateTimeline<>(List.of(
@@ -249,6 +254,6 @@ public class EndringProgramPeriodeScenarioer {
                     DatoIntervallEntitet.fra(opprinneligSluttdato.plusDays(1), nySluttdato))
             ),
             Collections.emptyList(),
-            null, null, nySluttdato, true);
+            null, null, periodeMaksDato, true);
     }
 }

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/EndringProgramPeriodeScenarioer.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/scenarioer/EndringProgramPeriodeScenarioer.java
@@ -249,6 +249,6 @@ public class EndringProgramPeriodeScenarioer {
                     DatoIntervallEntitet.fra(opprinneligSluttdato.plusDays(1), nySluttdato))
             ),
             Collections.emptyList(),
-            null, null, null, true);
+            null, null, nySluttdato, true);
     }
 }

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/YtelseVedtaksbrevReglerTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/formidling/vedtak/YtelseVedtaksbrevReglerTest.java
@@ -358,9 +358,10 @@ class YtelseVedtaksbrevReglerTest {
         LocalDate fom = LocalDate.now().minusWeeks(52).plusWeeks(2);
         LocalDate opprinneligSluttdato = fom.plusWeeks(52).minusDays(1);
         LocalDate nySluttdato = opprinneligSluttdato.plusWeeks(8).minusDays(1);
+        LocalDate periodeMaksDato = nySluttdato;
 
         var scenario = KombinasjonScenarioer.leggTilVarselOpphørVedMaksdato(
-            EndringProgramPeriodeScenarioer.forlengetPeriode(fom, opprinneligSluttdato, nySluttdato),
+            EndringProgramPeriodeScenarioer.forlengetPeriode(fom, opprinneligSluttdato, nySluttdato, periodeMaksDato),
             nySluttdato);
         var behandling = lagBehandling(scenario);
 


### PR DESCRIPTION
### Behov / Bakgrunn

Deltaker trenger å vite eksakt når den forlengede perioden utløper.  Maksdato beregnes fra register (260 virkedager ved normal periode, 300 ved forlenget periode) og skal vises i vedtaksbrevet sammen med startdato for forlengelsen.

### Løsning

- **ForlengetPeriodeDto**: Legg til `maksdato: LocalDate` som nytt felt
- **ForlengetPeriodeInnholdBygger**: Hent ny maksdato fra nåværende behandling via `periodeMaksDato` fra register
- **forlenget_periode.hbs**: Oppdater brevteksten til:
  - "Fra {{fom}} får du forlenget perioden din med ungdomsprogramytelsen med inntil 8 nye uker."
  - "Du får ytelsen så lange du deltar i ungdomsprogrammet, men ikke lenger enn til {{maksdato}}."
- **ForlengetPeriodeTest**: Oppdater forventet brevinnhold som verifikasjon

### Andre endringer

- **EndringProgramPeriodeScenarioer.forlengetPeriode()**: Sett `periodeMaksDato` til `nySluttdato` (var `null`)
  slik at testscenarioet leverer fullstendige data til brevbyggeren


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
