### PR TITLE
TSFF-2756 - forvaltningendepunkt for patching av journalpost payload

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/motattdokument/MottatteDokumentRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/motattdokument/MottatteDokumentRepository.java
@@ -1,23 +1,16 @@
 package no.nav.ung.sak.behandlingslager.behandling.motattdokument;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
-
 import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.dokument.DokumentStatus;
 import no.nav.ung.sak.typer.JournalpostId;
+
+import java.util.*;
 
 @Dependent
 public class MottatteDokumentRepository {
@@ -48,6 +41,21 @@ public class MottatteDokumentRepository {
         entityManager.persist(mottattDokument);
         entityManager.flush();
         return mottattDokument;
+    }
+
+    /**
+     * Oppdaterer payload direkte via native spørring. Payload-kolonnen er {@code updatable = false} i JPA-mappingen,
+     * så ordinær persist vil ikke endre den. Payload lagres som large object (oid) i Postgres, så vi binder en Clob
+     * med eksplisitt CLOB-type slik at Hibernate kan utlede riktig JDBC-mapping.
+     */
+    public void oppdaterPayload(Long mottattDokumentId, String payload) {
+        var clob = org.hibernate.Hibernate.getLobHelper().createClob(payload);
+        entityManager.createNativeQuery("update mottatt_dokument set payload = :payload where id = :id")
+            .unwrap(org.hibernate.query.NativeQuery.class)
+            .setParameter("payload", clob, org.hibernate.type.StandardBasicTypes.CLOB)
+            .setParameter("id", mottattDokumentId)
+            .executeUpdate();
+        entityManager.flush();
     }
 
     public Optional<MottattDokument> hentMottattDokument(long mottattDokumentId) {

--- a/fordel/src/main/java/no/nav/ung/fordel/repo/journalpost/JournalpostInnsendingEntitet.java
+++ b/fordel/src/main/java/no/nav/ung/fordel/repo/journalpost/JournalpostInnsendingEntitet.java
@@ -1,23 +1,17 @@
 package no.nav.ung.fordel.repo.journalpost;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
-
-import org.hibernate.annotations.Parameter;
-import org.hibernate.annotations.Type;
-import org.hibernate.usertype.UserTypeLegacyBridge;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
+import org.hibernate.usertype.UserTypeLegacyBridge;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity(name = "JournalpostInnsendingEntitet")
 @Table(name = "FORDEL_JOURNALPOST_INNSENDING")
@@ -110,6 +104,10 @@ public class JournalpostInnsendingEntitet {
 
     public String getPayload() {
         return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
     }
 
     public LocalDateTime getInnsendingstidspunkt() {

--- a/fordel/src/main/java/no/nav/ung/fordel/repo/journalpost/JournalpostMottattEntitet.java
+++ b/fordel/src/main/java/no/nav/ung/fordel/repo/journalpost/JournalpostMottattEntitet.java
@@ -1,17 +1,13 @@
 package no.nav.ung.fordel.repo.journalpost;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import no.nav.ung.kodeverk.behandling.BehandlingTema;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity(name = "JournalpostMottattEntitet")
 @Table(name = "FORDEL_JOURNALPOST_MOTTATT")
@@ -113,6 +109,10 @@ public class JournalpostMottattEntitet {
 
     public String getPayload() {
         return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
     }
 
     public LocalDateTime getMottattTidspunkt() {

--- a/fordel/src/main/java/no/nav/ung/fordel/repo/journalpost/JournalpostRepository.java
+++ b/fordel/src/main/java/no/nav/ung/fordel/repo/journalpost/JournalpostRepository.java
@@ -1,14 +1,5 @@
 package no.nav.ung.fordel.repo.journalpost;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.hibernate.jpa.SpecHints;
-
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -16,6 +7,14 @@ import jakarta.persistence.LockModeType;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
+import org.hibernate.jpa.SpecHints;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Dependent
 public class JournalpostRepository {
@@ -60,6 +59,21 @@ public class JournalpostRepository {
     public void lagreInnsending(JournalpostInnsendingEntitet innsending) {
         entityManager.persist(innsending);
         entityManager.flush();
+    }
+
+    public Optional<JournalpostInnsendingEntitet> finnJournalpostInnsending(JournalpostId journalpostId) {
+        var list = entityManager
+            .createQuery("select j from JournalpostInnsendingEntitet j where j.journalpostId=:journalpostId", JournalpostInnsendingEntitet.class)
+            .setParameter("journalpostId", journalpostId.getVerdi())
+            .getResultList();
+
+        if (list.isEmpty()) {
+            return Optional.empty();
+        } else if (list.size() == 1) {
+            return Optional.of(list.getFirst());
+        } else {
+            throw new IllegalStateException("Fant mer enn ett innslag [" + list.size() + "] for journalpostInnsending: " + journalpostId);
+        }
     }
 
     public List<JournalpostMottattEntitet> markerJournalposterBehandlet(JournalpostId journalpostId) {

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/RestImplementationClasses.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/RestImplementationClasses.java
@@ -9,6 +9,7 @@ import no.nav.ung.sak.web.app.tjenester.behandling.BehandlingBackendRestTjeneste
 import no.nav.ung.sak.web.app.tjenester.behandling.BehandlingRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.aksjonspunkt.AksjonspunktRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.aksjonspunkt.ForvaltningAksjonspunktSammendragRestTjeneste;
+import no.nav.ung.sak.web.app.tjenester.behandling.aktivitetspenger.BostedRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.arbeidsforhold.ArbeidsgiverRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.beregningsresultat.BeregningsresultatRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.historikk.HistorikkRestTjeneste;
@@ -20,7 +21,6 @@ import no.nav.ung.sak.web.app.tjenester.behandling.søknadsfrist.SøknadsfristRe
 import no.nav.ung.sak.web.app.tjenester.behandling.tilbakekreving.TilbakekrevingRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.vedtak.TotrinnskontrollRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.vilkår.ForutgåendeMedlemskapRestTjeneste;
-import no.nav.ung.sak.web.app.tjenester.behandling.aktivitetspenger.BostedRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.behandling.vilkår.VilkårRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.dokument.DokumentRestTjeneste;
 import no.nav.ung.sak.web.app.tjenester.etterlysning.EtterlysningRestTjeneste;
@@ -100,6 +100,7 @@ public class RestImplementationClasses {
         classes.add(ForvaltningPersonRestTjeneste.class);
         classes.add(ForvaltningStatistikkRestTjeneste.class);
         classes.add(ForvaltningProduksjonsstyringRestTjeneste.class);
+        classes.add(ForvaltningMottattDokumentRestTjeneste.class);
         classes.add(DiagnostikkRestTjeneste.class);
         classes.add(RapporteringRestTjeneste.class);
         classes.add(NotatRestTjeneste.class);

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -1,0 +1,162 @@
+package no.nav.ung.sak.web.app.tjenester.forvaltning;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessurs;
+import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionType;
+import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursResourceType;
+import no.nav.k9.felles.sikkerhet.abac.TilpassetAbacAttributt;
+import no.nav.k9.felles.validering.InputValideringRegex;
+import no.nav.k9.oppgave.OppgaveBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.ung.fordel.repo.journalpost.JournalpostRepository;
+import no.nav.ung.kodeverk.dokument.Brevkode;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.kontrakt.behandling.BehandlingIdDto;
+import no.nav.ung.sak.typer.JournalpostId;
+import no.nav.ung.sak.web.app.tjenester.forvaltning.dump.logg.DiagnostikkFagsakLogg;
+import no.nav.ung.sak.web.server.abac.AbacAttributtSupplier;
+
+import java.util.List;
+
+
+/**
+ * DENNE TJENESTEN ER BARE FOR MIDLERTIDIG BEHOV FOR TSFF-2756, OG SKAL AVVIKLES SÅ RASKT SOM MULIG.
+ */
+@Path("/TSFF-2756/forvaltning")
+@ApplicationScoped
+@Transactional
+public class ForvaltningMottattDokumentRestTjeneste {
+
+    private static final String JSON_UTF8 = "application/json; charset=UTF-8";
+
+    private BehandlingRepository behandlingRepository;
+    private MottatteDokumentRepository mottatteDokumentRepository;
+    private EntityManager entityManager;
+    private JournalpostRepository journalpostRepository;
+
+    public ForvaltningMottattDokumentRestTjeneste() {
+        // For Rest-CDI
+    }
+
+    @Inject
+    public ForvaltningMottattDokumentRestTjeneste(BehandlingRepository behandlingRepository,
+                                                  MottatteDokumentRepository mottatteDokumentRepository,
+                                                  EntityManager entityManager,
+                                                  JournalpostRepository journalpostRepository) {
+        this.behandlingRepository = behandlingRepository;
+        this.mottatteDokumentRepository = mottatteDokumentRepository;
+        this.entityManager = entityManager;
+        this.journalpostRepository = journalpostRepository;
+    }
+
+    @POST
+    @Path("oppdater-mottatt-dokument")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(description = "oppdaterer mottatt dokument ifm TSFF-2756", summary = ("oppdaterer mottatt dokument ifm TSFF-2756"), tags = "forvaltning")
+    @Produces(JSON_UTF8)
+    @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
+    public Response oppdaterMottattDokument(@Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) OppdaterMottattDokumentRequest dto) {
+        String nyUttalelse = dto.nyUttalelseFraBruker;
+        if (nyUttalelse == null || nyUttalelse.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("nyUttalelseFraBruker må ha en verdi")
+                .build();
+        }
+
+        Behandling behandling = behandlingRepository.hentBehandling(dto.behandlingId.getId());
+        JournalpostId journalpostId = dto.journalpostId.getJournalpostId();
+        List<MottattDokument> mottattDokuments = mottatteDokumentRepository.hentMottatteDokument(behandling.getFagsakId(), List.of(journalpostId));
+
+        if (mottattDokuments.size() > 1) {
+            throw new IllegalArgumentException("Forventet maks 1 dokument");
+        }
+
+        MottattDokument mottattDokument = mottattDokuments.getFirst();
+
+        // Sjekk at dokumentet er av riktig type
+        if (!Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE.equals(mottattDokument.getType())) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Forventet brevkode " + Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE + ", men dokumentet har: " + mottattDokument.getType())
+                .build();
+        }
+
+        OppgaveBekreftelse oppgaveBekreftelse = JsonUtils.fromString(mottattDokument.getPayload(), OppgaveBekreftelse.class);
+
+        if (!(oppgaveBekreftelse.getBekreftelse() instanceof EndretSluttdatoBekreftelse eksisterendeBekreftelse)) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Forventet bekreftelse av type EndretSluttdatoBekreftelse, men fikk: " + oppgaveBekreftelse.getBekreftelse().getType())
+                .build();
+        }
+
+        if (eksisterendeBekreftelse.getUttalelseFraBruker() != null || !eksisterendeBekreftelse.harUttalelse()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Eksisterende payload har allerede uttalelseFraBruker satt")
+                .build();
+        }
+
+        oppgaveBekreftelse.setBekreftelse(eksisterendeBekreftelse.medUttalelseFraBruker(nyUttalelse));
+        String nyPayload = JsonUtils.toString(oppgaveBekreftelse);
+
+        // Oppdater MottattDokument (payload er updatable=false, så bruk native oppdatering)
+        mottatteDokumentRepository.oppdaterPayload(mottattDokument.getId(), nyPayload);
+
+        // Oppdater JournalpostMottattEntitet
+        journalpostRepository.finnJournalpostMottatt(journalpostId).ifPresent(mottatt -> {
+            mottatt.setPayload(nyPayload);
+            journalpostRepository.lagreMottatt(mottatt);
+        });
+
+        // Oppdater JournalpostInnsendingEntitet
+        journalpostRepository.finnJournalpostInnsending(journalpostId).ifPresent(innsending -> {
+            innsending.setPayload(nyPayload);
+            journalpostRepository.lagreInnsending(innsending);
+        });
+
+        entityManager.persist(new DiagnostikkFagsakLogg(
+            behandling.getFagsakId(),
+            "ForvaltningMottattDokumentRestTjeneste.oppdaterMottattDokument (midlertidig)",
+            "Patching ifm TSFF-2756. Oppdatert uttalelseFraBruker i journalpost=%s payload i 3 tabeller: MOTTATT_DOKUMENT, FORDEL_JOURNALPOST_INNSENDING og FORDEL_JOURNALPOST_MOTTATT"
+                .formatted(journalpostId.getVerdi())
+        ));
+
+        return Response.ok().build();
+    }
+
+    public record OppdaterMottattDokumentRequest(
+        @Valid
+        @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class)
+        JournalpostId journalpostId,
+
+        @JsonProperty(value = "behandlingId", required = true)
+        @NotNull
+        @Valid
+        BehandlingIdDto behandlingId,
+
+        @Valid
+        @Size(max = 4000)
+        @Pattern(regexp = InputValideringRegex.FRITEKST)
+        String nyUttalelseFraBruker
+    ) { }
+
+
+}

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -108,7 +108,12 @@ public class ForvaltningMottattDokumentRestTjeneste {
                 .build();
         }
 
-        if (eksisterendeBekreftelse.getUttalelseFraBruker() != null || !eksisterendeBekreftelse.harUttalelse()) {
+        if (!eksisterendeBekreftelse.harUttalelse()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Eksisterende payload har harUttalelse=false og kan derfor ikke patches")
+                .build();
+        }
+        if (eksisterendeBekreftelse.getUttalelseFraBruker() != null) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity("Eksisterende payload har allerede uttalelseFraBruker satt")
                 .build();

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -5566,6 +5566,24 @@
         },
         "type" : "object"
       },
+      "ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.OppdaterMottattDokumentRequest" : {
+        "properties" : {
+          "behandlingId" : {
+            "type" : "string"
+          },
+          "journalpostId" : {
+            "type" : "string"
+          },
+          "nyUttalelseFraBruker" : {
+            "maxLength" : 4000,
+            "minLength" : 0,
+            "pattern" : "^[\\p{L}\\p{M}\\p{N}\\p{P}\\p{S}\\p{Space}]*$",
+            "type" : "string"
+          }
+        },
+        "required" : [ "behandlingId" ],
+        "type" : "object"
+      },
       "ung.sak.web.app.tjenester.forvaltning.ForvaltningStatistikkRestTjeneste.AntallDeltakereStatistikk" : {
         "properties" : {
           "antallBarn" : {
@@ -6064,6 +6082,32 @@
           }
         },
         "tags" : [ "redirect" ]
+      }
+    },
+    "/api/TSFF-2756/forvaltning/oppdater-mottatt-dokument" : {
+      "post" : {
+        "description" : "oppdaterer mottatt dokument ifm TSFF-2756",
+        "operationId" : "oppdaterMottattDokument",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.OppdaterMottattDokumentRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json; charset=UTF-8" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "oppdaterer mottatt dokument ifm TSFF-2756",
+        "tags" : [ "forvaltning" ]
       }
     },
     "/api/aksjonspunkt" : {

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -7,6 +7,7 @@ import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
 import no.nav.k9.oppgave.OppgaveBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse;
 import no.nav.k9.søknad.JsonUtils;
+import no.nav.ung.fordel.repo.journalpost.JournalpostInnsendingEntitet;
 import no.nav.ung.fordel.repo.journalpost.JournalpostMottattEntitet;
 import no.nav.ung.fordel.repo.journalpost.JournalpostRepository;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
@@ -24,6 +25,7 @@ import no.nav.ung.sak.kontrakt.behandling.BehandlingIdDto;
 import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
+import no.nav.ung.sak.typer.Saksnummer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -99,6 +101,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         // Arrange
         lagreMottattDokument(PAYLOAD_UTEN_UTTALELSE);
         lagreJournalpostMottatt(PAYLOAD_UTEN_UTTALELSE);
+        lagreJournalpostInnsending(PAYLOAD_UTEN_UTTALELSE);
 
         var request = lagRequest(NY_UTTALELSE);
 
@@ -118,6 +121,10 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         var oppdatertJournalpost = journalpostRepository.finnJournalpostMottatt(new JournalpostId(JOURNALPOST_ID));
         assertThat(oppdatertJournalpost).isPresent();
         assertThat(uttalelseAv(oppdatertJournalpost.get().getPayload())).isEqualTo(NY_UTTALELSE);
+
+        var oppdatertInnsending = journalpostRepository.finnJournalpostInnsending(new JournalpostId(JOURNALPOST_ID));
+        assertThat(oppdatertInnsending).isPresent();
+        assertThat(uttalelseAv(oppdatertInnsending.get().getPayload())).isEqualTo(NY_UTTALELSE);
     }
 
     @Test
@@ -203,6 +210,20 @@ class ForvaltningMottattDokumentRestTjenesteTest {
             JournalpostMottattEntitet.Status.UBEHANDLET
         );
         journalpostRepository.lagreMottatt(journalpostMottatt);
+    }
+
+    private void lagreJournalpostInnsending(String payload) {
+        var innsending = new JournalpostInnsendingEntitet(
+            FagsakYtelseType.UNGDOMSYTELSE,
+            new Saksnummer("123456789"),
+            new JournalpostId(JOURNALPOST_ID),
+            fagsak.getAktørId(),
+            Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE,
+            LocalDateTime.now(),
+            payload,
+            JournalpostInnsendingEntitet.Status.UBEHANDLET
+        );
+        journalpostRepository.lagreInnsending(innsending);
     }
 
     private ForvaltningMottattDokumentRestTjeneste.OppdaterMottattDokumentRequest lagRequest(String nyUttalelse) {

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -1,0 +1,218 @@
+package no.nav.ung.sak.web.app.tjenester.forvaltning;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.core.Response;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.k9.oppgave.OppgaveBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.ung.fordel.repo.journalpost.JournalpostMottattEntitet;
+import no.nav.ung.fordel.repo.journalpost.JournalpostRepository;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.kodeverk.dokument.Brevkode;
+import no.nav.ung.kodeverk.dokument.DokumentStatus;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
+import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingLås;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.kontrakt.behandling.BehandlingIdDto;
+import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
+import no.nav.ung.sak.typer.AktørId;
+import no.nav.ung.sak.typer.JournalpostId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(CdiAwareExtension.class)
+@ExtendWith(JpaExtension.class)
+class ForvaltningMottattDokumentRestTjenesteTest {
+
+    private static final String JOURNALPOST_ID = "999001";
+    private static final String NY_UTTALELSE = "Jeg ønsker å forlenge perioden";
+
+    // Payload (OppgaveBekreftelse-wrapper) uten uttalelseFraBruker
+    private static final String PAYLOAD_UTEN_UTTALELSE = """
+        {
+          "bekreftelse": {
+            "type": "UNG_ENDRET_SLUTTDATO",
+            "dataBruktTilUtledning": null,
+            "harUttalelse": true,
+            "nySluttdato": "2026-05-11",
+            "oppgaveReferanse": "13c9da9d-815b-4d67-bfd5-2abba88d2d55",
+            "uttalelseFraBruker": null
+          },
+          "mottattDato": "2026-06-17T10:01:18.283489444Z",
+          "språk": "nb",
+          "søker": { "norskIdentitetsnummer": "13420086762" },
+          "søknadId": "13c9da9d-815b-4d67-bfd5-2abba88d2d55",
+          "versjon": "1.0.0",
+          "kildesystem": "søknadsdialog"
+        }
+        """;
+
+    @Inject
+    private EntityManager entityManager;
+
+    private MottatteDokumentRepository mottatteDokumentRepository;
+    private BehandlingRepository behandlingRepository;
+    private FagsakRepository fagsakRepository;
+    private JournalpostRepository journalpostRepository;
+    private ForvaltningMottattDokumentRestTjeneste tjeneste;
+
+    private final Fagsak fagsak = FagsakBuilder.nyFagsak(FagsakYtelseType.UNGDOMSYTELSE).build();
+    private Behandling behandling;
+
+    @BeforeEach
+    void setup() {
+        mottatteDokumentRepository = new MottatteDokumentRepository(entityManager);
+        behandlingRepository = new BehandlingRepository(entityManager);
+        fagsakRepository = new FagsakRepository(entityManager);
+        journalpostRepository = new JournalpostRepository(entityManager);
+
+        tjeneste = new ForvaltningMottattDokumentRestTjeneste(
+            behandlingRepository,
+            mottatteDokumentRepository,
+            entityManager,
+            journalpostRepository
+        );
+
+        fagsakRepository.opprettNy(fagsak);
+
+        behandling = Behandling.forFørstegangssøknad(fagsak).build();
+        BehandlingLås lås = behandlingRepository.taSkriveLås(behandling);
+        behandlingRepository.lagre(behandling, lås);
+    }
+
+    @Test
+    void skal_oppdatere_uttalelse_i_mottatt_dokument_og_journalpost_mottatt() {
+        // Arrange
+        lagreMottattDokument(PAYLOAD_UTEN_UTTALELSE);
+        lagreJournalpostMottatt(PAYLOAD_UTEN_UTTALELSE);
+
+        var request = lagRequest(NY_UTTALELSE);
+
+        // Act
+        Response response = tjeneste.oppdaterMottattDokument(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        var oppdatertDokument = mottatteDokumentRepository.hentMottatteDokument(
+            fagsak.getId(), List.of(new JournalpostId(JOURNALPOST_ID))).getFirst();
+        assertThat(uttalelseAv(oppdatertDokument.getPayload())).isEqualTo(NY_UTTALELSE);
+
+        var oppdatertJournalpost = journalpostRepository.finnJournalpostMottatt(new JournalpostId(JOURNALPOST_ID));
+        assertThat(oppdatertJournalpost).isPresent();
+        assertThat(uttalelseAv(oppdatertJournalpost.get().getPayload())).isEqualTo(NY_UTTALELSE);
+    }
+
+    @Test
+    void skal_returnere_400_naar_ny_uttalelse_mangler() {
+        // Arrange
+        lagreMottattDokument(PAYLOAD_UTEN_UTTALELSE);
+
+        var request = lagRequest("   ");
+
+        // Act
+        Response response = tjeneste.oppdaterMottattDokument(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    void skal_returnere_400_naar_eksisterende_payload_allerede_har_uttalelse() {
+        // Arrange - lagre dokument der uttalelse allerede er satt
+        var medUttalelse = PAYLOAD_UTEN_UTTALELSE.replace("\"uttalelseFraBruker\": null", "\"uttalelseFraBruker\": \"allerede satt\"");
+        lagreMottattDokument(medUttalelse);
+
+        var request = lagRequest(NY_UTTALELSE);
+
+        // Act
+        Response response = tjeneste.oppdaterMottattDokument(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    void skal_returnere_400_naar_brevkode_er_feil() {
+        // Arrange
+        var feilBrevkodeDokument = new MottattDokument.Builder()
+            .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
+            .medType(Brevkode.UNGDOMSYTELSE_INNTEKTRAPPORTERING)
+            .medMottattDato(LocalDate.now())
+            .medFagsakId(fagsak.getId())
+            .medBehandlingId(behandling.getId())
+            .medPayload(PAYLOAD_UTEN_UTTALELSE)
+            .build();
+        mottatteDokumentRepository.lagre(feilBrevkodeDokument, DokumentStatus.GYLDIG);
+
+        var request = lagRequest(NY_UTTALELSE);
+
+        // Act
+        Response response = tjeneste.oppdaterMottattDokument(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    // --- helpers ---
+
+    private static String uttalelseAv(String payload) {
+        OppgaveBekreftelse ob = JsonUtils.fromString(payload, OppgaveBekreftelse.class);
+        EndretSluttdatoBekreftelse b = ob.getBekreftelse();
+        return b.getUttalelseFraBruker();
+    }
+
+    private void lagreMottattDokument(String payload) {
+        var dokument = new MottattDokument.Builder()
+            .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
+            .medType(Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE)
+            .medMottattDato(LocalDate.now())
+            .medFagsakId(fagsak.getId())
+            .medBehandlingId(behandling.getId())
+            .medPayload(payload)
+            .build();
+        mottatteDokumentRepository.lagre(dokument, DokumentStatus.GYLDIG);
+    }
+
+    private void lagreJournalpostMottatt(String payload) {
+        var journalpostMottatt = new JournalpostMottattEntitet(
+            new JournalpostId(JOURNALPOST_ID),
+            null,
+            new AktørId(fagsak.getAktørId().getId()),
+            Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE.getOffisiellKode(),
+            LocalDateTime.now(),
+            "Varsel uttalelse",
+            payload,
+            JournalpostMottattEntitet.Status.UBEHANDLET
+        );
+        journalpostRepository.lagreMottatt(journalpostMottatt);
+    }
+
+    private ForvaltningMottattDokumentRestTjeneste.OppdaterMottattDokumentRequest lagRequest(String nyUttalelse) {
+        var journalpostIdDto = new JournalpostId(JOURNALPOST_ID);
+
+        return new ForvaltningMottattDokumentRestTjeneste.OppdaterMottattDokumentRequest(
+            journalpostIdDto,
+            new BehandlingIdDto(behandling.getId()),
+            nyUttalelse
+        );
+    }
+}
+


### PR DESCRIPTION
### Behov / Bakgrunn
Etter en kodefeil mangler uttalelseFraBruker i en journalpost i produksjon som må manuelt rettes. Endring i dokarkiv gjøres vha team dokumentløsninger.  

### Løsning
Laget et forvaltningsendepunkt for å legge inn riktig uttalelseFraBruker i 3 tabeller som har dette. Lagt inn valideringer som passer på at ikke feil journalpost blir oppdatert. Denne må revertes etter bruk. 


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
