### PR TITLE
TSFF-2761 - Gjenopptar ytelsen etter opphør.

### DIFF
--- a/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/FinnFagsakerForAktørTjeneste.java
+++ b/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/FinnFagsakerForAktørTjeneste.java
@@ -12,6 +12,7 @@ import no.nav.ung.sak.domene.typer.tid.AbstractLocalDateInterval;
 import no.nav.ung.sak.typer.AktørId;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,6 +66,15 @@ public class FinnFagsakerForAktørTjeneste {
 
     public Optional<Fagsak> hentRelevantFagsakForAktørSomSøker(FagsakYtelseType fagsakYtelseType, AktørId aktør, LocalDate relevantDato) {
         return fagsakRepository.hentForBruker(aktør, fagsakYtelseType).stream().filter(f -> f.getPeriode().overlapper(relevantDato, AbstractLocalDateInterval.TIDENES_ENDE)).findFirst();
+    }
+
+    /**
+     * Fallback for hendelser der relevant dato ligger etter fagsakens nåværende tom-dato.
+     * Brukes for å finne sist aktive fagsak når perioden nylig er forkortet.
+     */
+    public Optional<Fagsak> hentSisteFagsakForAktørSomSøker(FagsakYtelseType fagsakYtelseType, AktørId aktør) {
+        return fagsakRepository.hentForBruker(aktør, fagsakYtelseType).stream()
+            .max(Comparator.comparing((Fagsak f) -> f.getPeriode().getTomDato()).thenComparing(Fagsak::getId));
     }
 
     private boolean finnesSakMedSøker(AktørId søkerAktørId) {

--- a/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/FinnFagsakerForAktørTjeneste.java
+++ b/domenetjenester/hendelsemottak/src/main/java/no/nav/ung/sak/hendelsemottak/tjenester/FinnFagsakerForAktørTjeneste.java
@@ -68,10 +68,6 @@ public class FinnFagsakerForAktørTjeneste {
         return fagsakRepository.hentForBruker(aktør, fagsakYtelseType).stream().filter(f -> f.getPeriode().overlapper(relevantDato, AbstractLocalDateInterval.TIDENES_ENDE)).findFirst();
     }
 
-    /**
-     * Fallback for hendelser der relevant dato ligger etter fagsakens nåværende tom-dato.
-     * Brukes for å finne sist aktive fagsak når perioden nylig er forkortet.
-     */
     public Optional<Fagsak> hentSisteFagsakForAktørSomSøker(FagsakYtelseType fagsakYtelseType, AktørId aktør) {
         return fagsakRepository.hentForBruker(aktør, fagsakYtelseType).stream()
             .max(Comparator.comparing((Fagsak f) -> f.getPeriode().getTomDato()).thenComparing(Fagsak::getId));

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtleder.java
@@ -59,7 +59,12 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtleder implements FagsakerT
         var fagsaker = new HashMap<Fagsak, List<ÅrsakOgPerioder>>();
 
         for (AktørId aktør : aktører) {
-            var relevantFagsak = finnFagsakerForAktørTjeneste.hentRelevantFagsakForAktørSomSøker(FagsakYtelseType.UNGDOMSYTELSE, aktør, opphørsdatoFraHendelse);
+            // Ved gjenopptak kan opphørsdato ligge utenfor nåværende fagsakperiode (som allerede er forkortet),
+            // så vi faller tilbake til siste fagsak for aktør for å sikre at hendelsen fortsatt treffer riktig sak.
+            var relevantFagsak = finnFagsakerForAktørTjeneste
+                .hentRelevantFagsakForAktørSomSøker(FagsakYtelseType.UNGDOMSYTELSE, aktør, opphørsdatoFraHendelse)
+                .or(() -> finnFagsakerForAktørTjeneste.hentSisteFagsakForAktørSomSøker(FagsakYtelseType.UNGDOMSYTELSE, aktør)
+                    .filter(f -> !opphørsdatoFraHendelse.isBefore(f.getPeriode().getFomDato())));
             if (relevantFagsak.isEmpty()) {
                 continue;
             }
@@ -149,10 +154,16 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtleder implements FagsakerT
     private boolean harIngenOppfyltYtelseEtterDato(Behandling behandling, LocalDate opphørsdato, String hendelseId) {
         // Sjekk 1: Hvis opphørsdato == periodeMaksDato er dette en naturlig avslutning
         var maksdato = ungdomsprogramPeriodeTjeneste.finnPeriodeMaksDato(behandling.getId());
+        // Ved naturlig avslutning på maksdato skal hendelsen ignoreres, men hvis tidslinjen i grunnlaget
+        // er kortere enn opphørsdato må vi fortsatt opprette revurdering for å utvide perioden tilbake.
         if (maksdato.isPresent() && maksdato.get().equals(opphørsdato)) {
-            logger.info("Opphørsdato {} == periodeMaksDato fra grunnlag. Naturlig avslutning — ignorerer hendelse {}.",
-                opphørsdato, hendelseId);
-            return true;
+            var ungdomsprogramTidslinje = ungdomsprogramPeriodeTjeneste.finnPeriodeTidslinje(behandling.getId());
+            var trengerUtvidelseAvPeriode = !ungdomsprogramTidslinje.isEmpty() && ungdomsprogramTidslinje.getMaxLocalDate().isBefore(opphørsdato);
+            if (!trengerUtvidelseAvPeriode) {
+                logger.info("Opphørsdato {} == periodeMaksDato fra grunnlag uten behov for utvidelse. Naturlig avslutning — ignorerer hendelse {}.",
+                    opphørsdato, hendelseId);
+                return true;
+            }
         }
 
         // Sjekk 2: Hvis vilkårsresultat finnes og dekker perioden etter opphørsdato med kun ikke-oppfylte utfall

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtleder.java
@@ -6,6 +6,7 @@ import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandling.revurdering.ÅrsakOgPerioder;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
@@ -59,8 +60,6 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtleder implements FagsakerT
         var fagsaker = new HashMap<Fagsak, List<ÅrsakOgPerioder>>();
 
         for (AktørId aktør : aktører) {
-            // Ved gjenopptak kan opphørsdato ligge utenfor nåværende fagsakperiode (som allerede er forkortet),
-            // så vi faller tilbake til siste fagsak for aktør for å sikre at hendelsen fortsatt treffer riktig sak.
             var relevantFagsak = finnFagsakerForAktørTjeneste
                 .hentRelevantFagsakForAktørSomSøker(FagsakYtelseType.UNGDOMSYTELSE, aktør, opphørsdatoFraHendelse)
                 .or(() -> finnFagsakerForAktørTjeneste.hentSisteFagsakForAktørSomSøker(FagsakYtelseType.UNGDOMSYTELSE, aktør)
@@ -86,10 +85,9 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtleder implements FagsakerT
             // Kan også vurdere om vi skal legge inn sjekk på om bruker har utbetaling etter opphørsdato
             Saksnummer saksnummer = relevantFagsak.get().getSaksnummer();
             if (erNyInformasjonIHendelsen(sisteBehandling, opphørsdatoFraHendelse, hendelseId, saksnummer)) {
-                var årsaker = new ArrayList<ÅrsakOgPerioder>();
-                var opphørsÅrsak = new ÅrsakOgPerioder(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM, utledPeriode(relevantFagsak.get(), opphørsdatoFraHendelse));
-                årsaker.add(opphørsÅrsak);
-                fagsaker.put(relevantFagsak.get(), List.of(new ÅrsakOgPerioder(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM, utledPeriode(relevantFagsak.get(), opphørsdatoFraHendelse))));
+                var opphørsÅrsak = new ÅrsakOgPerioder(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM,
+                    utledPeriode(relevantFagsak.get(), opphørsdatoFraHendelse));
+                fagsaker.put(relevantFagsak.get(), List.of(opphørsÅrsak));
             }
         }
 
@@ -152,18 +150,23 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtleder implements FagsakerT
      * Dersom vilkårsresultatet er tomt (vilkår ikke vurdert), antas ytelsen å være aktiv.
      */
     private boolean harIngenOppfyltYtelseEtterDato(Behandling behandling, LocalDate opphørsdato, String hendelseId) {
-        // Sjekk 1: Hvis opphørsdato == periodeMaksDato er dette en naturlig avslutning
+        // Sjekk 1: Hvis opphørsdato == periodeMaksDato kunne dette vært en naturlig avslutning,
+        // men vi må kontrollere om vilkårsperioden for ungdomsprogramvilkåret dekker videre enn maksdato.
         var maksdato = ungdomsprogramPeriodeTjeneste.finnPeriodeMaksDato(behandling.getId());
-        // Ved naturlig avslutning på maksdato skal hendelsen ignoreres, men hvis tidslinjen i grunnlaget
-        // er kortere enn opphørsdato må vi fortsatt opprette revurdering for å utvide perioden tilbake.
         if (maksdato.isPresent() && maksdato.get().equals(opphørsdato)) {
-            var ungdomsprogramTidslinje = ungdomsprogramPeriodeTjeneste.finnPeriodeTidslinje(behandling.getId());
-            var trengerUtvidelseAvPeriode = !ungdomsprogramTidslinje.isEmpty() && ungdomsprogramTidslinje.getMaxLocalDate().isBefore(opphørsdato);
-            if (!trengerUtvidelseAvPeriode) {
-                logger.info("Opphørsdato {} == periodeMaksDato fra grunnlag uten behov for utvidelse. Naturlig avslutning — ignorerer hendelse {}.",
-                    opphørsdato, hendelseId);
-                return true;
+            var vilkårene = vilkårTjeneste.hentHvisEksisterer(behandling.getId());
+            if (vilkårene.isPresent()) {
+                var ungdomsprogramVilkårTimeline = vilkårene.get().getVilkårTimeline(VilkårType.UNGDOMSPROGRAMVILKÅRET);
+                var vilkårsperiodeEtterMaksdato = ungdomsprogramVilkårTimeline.intersection(
+                    new LocalDateInterval(opphørsdato.plusDays(1), LocalDateInterval.TIDENES_ENDE));
+                if (!vilkårsperiodeEtterMaksdato.isEmpty()) {
+                    // Vilkårsperioden strekker seg videre enn maksdato — revurdering nødvendig
+                    return false;
+                }
             }
+            logger.info("Opphørsdato {} == periodeMaksDato fra grunnlag, og vilkårsperioden dekker ikke videre. Naturlig avslutning — ignorerer hendelse {}.",
+                opphørsdato, hendelseId);
+            return true;
         }
 
         // Sjekk 2: Hvis vilkårsresultat finnes og dekker perioden etter opphørsdato med kun ikke-oppfylte utfall

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtleder.java
@@ -156,7 +156,8 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtleder implements FagsakerT
         if (maksdato.isPresent() && maksdato.get().equals(opphørsdato)) {
             var vilkårene = vilkårTjeneste.hentHvisEksisterer(behandling.getId());
             if (vilkårene.isPresent()) {
-                var ungdomsprogramVilkårTimeline = vilkårene.get().getVilkårTimeline(VilkårType.UNGDOMSPROGRAMVILKÅRET);
+                var ungdomsprogramVilkårTimeline = vilkårene.get().getVilkårTimeline(VilkårType.UNGDOMSPROGRAMVILKÅRET)
+                    .filterValue(v -> v.getGjeldendeUtfall() == Utfall.OPPFYLT);
                 var vilkårsperiodeEtterMaksdato = ungdomsprogramVilkårTimeline.intersection(
                     new LocalDateInterval(opphørsdato.plusDays(1), LocalDateInterval.TIDENES_ENDE));
                 if (!vilkårsperiodeEtterMaksdato.isEmpty()) {

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
@@ -10,10 +10,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandling.revurdering.ÅrsakOgPerioder;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.hendelsemottak.tjenester.FinnFagsakerForAktørTjeneste;
 import no.nav.ung.sak.kontrakt.vilkår.VilkårUtfallSamlet;
@@ -135,6 +139,64 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtlederTest {
         var fagsakBehandlingÅrsakTypeMap = utleder.finnFagsakerTilVurdering(new UngdomsprogramOpphørHendelse(builder.build(), OPPHØRSDATO));
 
         assertThat(fagsakBehandlingÅrsakTypeMap.isEmpty()).isTrue();
+    }
+
+    @Test
+    void skal_ikke_returnere_årsak_dersom_kun_ikke_oppfylte_vilkårsperioder_etter_maksdato() {
+        var behandling = scenarioBuilder.lagre(entityManager);
+        scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
+        final var gammelOpphørsdato = OPPHØRSDATO.plusDays(10);
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
+            List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, gammelOpphørsdato))),
+            false,
+            OPPHØRSDATO);
+
+        behandling.avsluttBehandling();
+        entityManager.flush();
+
+        var vilkåreneMock = mock(Vilkårene.class);
+        var ikkeOppfyltPeriode = mock(VilkårPeriode.class);
+        when(ikkeOppfyltPeriode.getGjeldendeUtfall()).thenReturn(Utfall.IKKE_OPPFYLT);
+        when(vilkåreneMock.getVilkårTimeline(VilkårType.UNGDOMSPROGRAMVILKÅRET))
+            .thenReturn(new LocalDateTimeline<>(OPPHØRSDATO.plusDays(1), gammelOpphørsdato, ikkeOppfyltPeriode));
+        when(vilkårTjeneste.hentHvisEksisterer(anyLong())).thenReturn(Optional.of(vilkåreneMock));
+
+        var builder = new HendelseInfo.Builder();
+        builder.leggTilAktør(BRUKER_AKTØR_ID);
+        builder.medHendelseId("1");
+        builder.medOpprettet(LocalDateTime.now());
+        var fagsakBehandlingÅrsakTypeMap = utleder.finnFagsakerTilVurdering(new UngdomsprogramOpphørHendelse(builder.build(), OPPHØRSDATO));
+
+        assertThat(fagsakBehandlingÅrsakTypeMap.isEmpty()).isTrue();
+    }
+
+    @Test
+    void skal_returnere_årsak_dersom_oppfylte_vilkårsperioder_finnes_etter_maksdato() {
+        var behandling = scenarioBuilder.lagre(entityManager);
+        scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
+        final var gammelOpphørsdato = OPPHØRSDATO.plusDays(10);
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
+            List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, gammelOpphørsdato))),
+            false,
+            OPPHØRSDATO);
+
+        behandling.avsluttBehandling();
+        entityManager.flush();
+
+        var vilkåreneMock = mock(Vilkårene.class);
+        var oppfyltPeriode = mock(VilkårPeriode.class);
+        when(oppfyltPeriode.getGjeldendeUtfall()).thenReturn(Utfall.OPPFYLT);
+        when(vilkåreneMock.getVilkårTimeline(VilkårType.UNGDOMSPROGRAMVILKÅRET))
+            .thenReturn(new LocalDateTimeline<>(OPPHØRSDATO.plusDays(1), gammelOpphørsdato, oppfyltPeriode));
+        when(vilkårTjeneste.hentHvisEksisterer(anyLong())).thenReturn(Optional.of(vilkåreneMock));
+
+        var builder = new HendelseInfo.Builder();
+        builder.leggTilAktør(BRUKER_AKTØR_ID);
+        builder.medHendelseId("1");
+        builder.medOpprettet(LocalDateTime.now());
+        var fagsakBehandlingÅrsakTypeMap = utleder.finnFagsakerTilVurdering(new UngdomsprogramOpphørHendelse(builder.build(), OPPHØRSDATO));
+
+        validerHarÅrsak(fagsakBehandlingÅrsakTypeMap, DatoIntervallEntitet.fraOgMedTilOgMed(OPPHØRSDATO.plusDays(1), gammelOpphørsdato));
     }
 
     @Test

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
@@ -138,6 +138,32 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtlederTest {
     }
 
     @Test
+    void skal_returnere_årsak_når_fagsakperiode_er_kortet_ned_og_opphørsdato_settes_til_periodeMaksDato() {
+        var behandling = scenarioBuilder.lagre(entityManager);
+        var fagsak = scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
+        final var gammelOpphørsdato = OPPHØRSDATO.minusDays(10);
+
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
+            List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, gammelOpphørsdato))),
+            false,
+            OPPHØRSDATO);
+
+        // Simuler at fagsaken allerede er forkortet etter tidligere opphør.
+        behandlingRepositoryProvider.getFagsakRepository().oppdaterPeriode(fagsak.getId(), STP, gammelOpphørsdato);
+
+        behandling.avsluttBehandling();
+        entityManager.flush();
+
+        var builder = new HendelseInfo.Builder();
+        builder.leggTilAktør(BRUKER_AKTØR_ID);
+        builder.medHendelseId("1");
+        builder.medOpprettet(LocalDateTime.now());
+        var fagsakBehandlingÅrsakTypeMap = utleder.finnFagsakerTilVurdering(new UngdomsprogramOpphørHendelse(builder.build(), OPPHØRSDATO));
+
+        validerHarÅrsak(fagsakBehandlingÅrsakTypeMap, DatoIntervallEntitet.fraOgMedTilOgMed(gammelOpphørsdato.plusDays(1), OPPHØRSDATO));
+    }
+
+    @Test
     void skal_returnere_årsak_dersom_ungdomsprogramperiode_sluttdato_er_etter_opphørsdato() {
         var behandling = scenarioBuilder.lagre(entityManager);
         scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørFagsakTilVurderingUtlederTest.java
@@ -138,18 +138,18 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtlederTest {
     }
 
     @Test
-    void skal_returnere_årsak_når_fagsakperiode_er_kortet_ned_og_opphørsdato_settes_til_periodeMaksDato() {
+    void skal_returnere_årsak_selv_om_opphørsdato_ikke_treffer_fagsakperiode() {
         var behandling = scenarioBuilder.lagre(entityManager);
         var fagsak = scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
-        final var gammelOpphørsdato = OPPHØRSDATO.minusDays(10);
+        final var tidligereOpphørsdato = OPPHØRSDATO.minusDays(10);
 
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
-            List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, gammelOpphørsdato))),
+            List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, tidligereOpphørsdato))),
             false,
-            OPPHØRSDATO);
+            OPPHØRSDATO.plusDays(30));
 
-        // Simuler at fagsaken allerede er forkortet etter tidligere opphør.
-        behandlingRepositoryProvider.getFagsakRepository().oppdaterPeriode(fagsak.getId(), STP, gammelOpphørsdato);
+        // Simulerer sak der fagsakperioden ikke overlapper hendelsesdato, men vi fortsatt skal finne siste fagsak.
+        behandlingRepositoryProvider.getFagsakRepository().oppdaterPeriode(fagsak.getId(), STP, tidligereOpphørsdato);
 
         behandling.avsluttBehandling();
         entityManager.flush();
@@ -160,8 +160,9 @@ public class UngdomsprogramOpphørFagsakTilVurderingUtlederTest {
         builder.medOpprettet(LocalDateTime.now());
         var fagsakBehandlingÅrsakTypeMap = utleder.finnFagsakerTilVurdering(new UngdomsprogramOpphørHendelse(builder.build(), OPPHØRSDATO));
 
-        validerHarÅrsak(fagsakBehandlingÅrsakTypeMap, DatoIntervallEntitet.fraOgMedTilOgMed(gammelOpphørsdato.plusDays(1), OPPHØRSDATO));
+        validerHarÅrsak(fagsakBehandlingÅrsakTypeMap, DatoIntervallEntitet.fraOgMedTilOgMed(tidligereOpphørsdato.plusDays(1), OPPHØRSDATO));
     }
+
 
     @Test
     void skal_returnere_årsak_dersom_ungdomsprogramperiode_sluttdato_er_etter_opphørsdato() {


### PR DESCRIPTION
### Behov / Bakgrunn

Ved opphørshendelser fant vi i enkelte saker ingen revurdering etter forrige endring.   Årsaken var at oppslag på relevant fagsak kun ble gjort mot hendelsesdato, og når opphørsdatoen ikke lenger overlappet fagsakperioden traff vi ikke saken i det hele tatt.

### Løsning

- Lagt til fallback-oppslag til siste fagsak for aktør når ordinært dato-basert oppslag ikke gir treff
- Sjekker vurderingen av vilkårsperioder for ungdomsprogramvilkåret ved naturlig avslutning på `periodeMaksDato`
- Sikrer dermed at:
  - vi fortsatt finner riktig fagsak selv om opphørsdato ikke overlapper fagsakperioden
  - vi bruker vilkårsperiodene til å avgjøre om hendelsen faktisk skal føre til revurdering

### Andre endringer

- Ryddet opp i opprettelse av `ÅrsakOgPerioder` i utleder
- Lagt til regresjonstest for scenarioet der opphørsdato ikke treffer fagsakperiode, men siste fagsak likevel skal brukes

Verdikjede-test: https://github.com/navikt/k9-verdikjede/pull/1727

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
