### PR TITLE
fix: rett opp varsel om opphør ved maksdato

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,19 @@
 - Startpunkt for ny vurdering ved forlenget periode avhenger av endring i `periodeMaksDato` (diff-sporing), ikke kun boolsk flagg.
 - Revurdering ved forlenget periode skal vise triggerperioden (de nye 8 ukene), ikke hele opprinnelig programperiode.
 
+## Domain Notes: Opphør ved maksdato
+- Når ungdomsprogramytelsen nærmer seg maksdato (260/300 virkedager), skal deltaker varsles ~3 uker før og få uttale seg før opphør.
+- Batch `VarselOpphørVedMaksdatoBatchTask` (cron ~07:30) spawner `VarselOpphørVedMaksdatoTask`, som henter løpende `UNGDOMSYTELSE`-fagsaker (`AktuelleFagsakerForMaksdatoVarselRepository`), bruker `periodeMaksDato` fra registergrunnlag (kilde til sannhet) og oppretter revurdering med årsak `RE_VARSEL_OPPHOR_VED_MAKSDATO` innenfor 3-ukers vindu (`MaksdatoOpphørVarslingPeriode.VARSEL_UKER_FØR_MAKSDATO = 3`).
+- Batch-tasker bruker felles baseklasse `DuplikatbeskyttetBatchTask` (unngår duplikate child-tasks på FEILET/KLAR/VETO); delt med inntektskontroll- og høysats-batch.
+- Etterlysning av type `UTTALELSE_OPPHOR_VED_MAKSDATO` opprettes i `VurderKompletthetSteg` via `UngEtterlysningOppretter` -> `MaksdatoEtterlysningTjeneste`. Oppgave til deltaker (`BEKREFT_OPPHOR_VED_MAKSDATO`) lages av `OpphørVedMaksdatoOppgaveOppretter`; behandlingen settes på vent (autopunkt `AUTO_SATT_PÅ_VENT_REVURDERING`).
+- Bruker-svar: `EndringType.OPPHOR_VED_MAKSDATO` og bekreftelse `Bekreftelse.Type.UNG_OPPHOR_VED_MAKSDATO` håndteres av `GenerellOppgaveBekreftelseHåndterer`; etterlysning markeres `MOTTATT_SVAR` -> behandling tas av vent.
+- Overstyring: `ProsessTriggerFilter` filtrerer bort `RE_VARSEL_OPPHOR_VED_MAKSDATO` når forlenget periode (`RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM`) eller manuelt opphør (`RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM`) også finnes. Samme overstyringsprinsipp følges i brevregler (`OpphørVedMaksdatoStrategy`, `OpphørStrategy`, `ForlengetPeriodeStrategy`) og i årsaks-/periodevisning.
+- Naturlig avslutning: `UngdomsprogramOpphørFagsakTilVurderingUtleder` ignorerer opphørshendelse når `opphørsdato == periodeMaksDato` (unngår duplikat revurdering).
+- Brev/kodeverk: `DokumentMalType.OPPHOR_VED_MAKSDATO_DOK`, `TemplateType.OPPHOR_VED_MAKSDATO`, `opphør_ved_maksdato.hbs`, `DetaljertResultatType.OPPHØR_VED_MAKSDATO`, `BehandlingVisningsnavn.OPPHØR_VED_MAKSDATO`, `ÅrsakTilVurdering.OPPHØR_VED_MAKSDATO`. `RE_VARSEL_OPPHOR_VED_MAKSDATO` inngår i `BehandlingÅrsakType.årsakerForInnhentingAvProgramperiode()`.
+- Rent varsel-opphør-løp = behandlingen har **utelukkende** årsak `RE_VARSEL_OPPHOR_VED_MAKSDATO`. Da skal det IKKE trigges inntektskontroll/programperiodeendring-varsling (`UngEtterlysningOppretter`), og `MaksdatoEtterlysningTjeneste` hardfeiler dersom ingen etterlysning ble opprettet — for å hindre vedtak/brev om opphør uten kontradiksjon. Har behandlingen tilleggsårsaker (f.eks. inntektskontroll) eller er overstyrt, kjøres alt som før og det hardfeiles ikke.
+- Dedup i utvelgelsen ekskluderer fagsaker med aktiv `RE_VARSEL_OPPHOR_VED_MAKSDATO`-trigger som overlapper maksdato, OG fagsaker med åpen behandling (status != `AVSLU`/`IVED`) med samme årsak.
+- Ved endringer i opphør-ved-maksdato: hold sammen batch/utvelgelse, etterlysning/varsling, mottak av bekreftelse, startpunkt/steg, brev og dedup i samme leveranse.
+
 ## Tech Stack
 - Java 25 (hovedkodebase)
 - Java 21 (`kodeverk` og `kontrakt`)
@@ -81,3 +94,6 @@ dev/generate-openapi-ts-client.sh
   - https://github.com/navikt/ung-sak/pull/1365
   - https://github.com/navikt/ung-sak/pull/1367
   - https://github.com/navikt/ung-sak/pull/1370
+- PR-historikk for opphør ved maksdato:
+  - https://github.com/navikt/ung-sak/pull/1333
+  - https://github.com/navikt/ung-sak/pull/1449

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggerFilter.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggerFilter.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.trigger;
 
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -15,10 +16,19 @@ public final class ProsessTriggerFilter {
     private ProsessTriggerFilter() {
     }
 
+    /**
+     * Returnerer true dersom behandlingen er overstyrt av forlenget periode eller manuelt opphør.
+     * Disse hendelsene endrer selve periode-/maksdato-grunnlaget (utvider maksdato, eller setter tom < maksdato),
+     * og kan derfor legitimt gjøre at varsel om opphør ved maksdato ikke lenger er relevant eller skal avbrytes.
+     * Andre tilleggsårsaker (f.eks. inntektskontroll) endrer ikke dette grunnlaget, og overstyrer derfor ikke varselet.
+     */
+    public static boolean erOverstyrtAvAnnenHendelse(Collection<BehandlingÅrsakType> årsaker) {
+        return årsaker.stream().anyMatch(OVERSTYRER_VARSEL_OPPHØR_VED_MAKSDATO::contains);
+    }
+
     public static List<Trigger> forKravperioder(List<Trigger> triggere) {
-        boolean varselOpphørVedMaksdatoErOverstyrt = triggere.stream()
-            .map(Trigger::getÅrsak)
-            .anyMatch(OVERSTYRER_VARSEL_OPPHØR_VED_MAKSDATO::contains);
+        boolean varselOpphørVedMaksdatoErOverstyrt = erOverstyrtAvAnnenHendelse(
+            triggere.stream().map(Trigger::getÅrsak).toList());
 
         if (!varselOpphørVedMaksdatoErOverstyrt) {
             return triggere;

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggerFilter.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggerFilter.java
@@ -2,7 +2,6 @@ package no.nav.ung.sak.trigger;
 
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -14,14 +13,6 @@ public final class ProsessTriggerFilter {
     );
 
     private ProsessTriggerFilter() {
-    }
-
-    /**
-     * Returnerer true dersom varsel om opphør ved maksdato er overstyrt av en annen årsak
-     * (forlenget periode eller manuelt opphør). I slike tilfeller skal det ikke sendes varsel om opphør ved maksdato.
-     */
-    public static boolean erVarselOpphørVedMaksdatoOverstyrt(Collection<BehandlingÅrsakType> årsaker) {
-        return årsaker.stream().anyMatch(OVERSTYRER_VARSEL_OPPHØR_VED_MAKSDATO::contains);
     }
 
     public static List<Trigger> forKravperioder(List<Trigger> triggere) {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggerFilter.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggerFilter.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.trigger;
 
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -13,6 +14,14 @@ public final class ProsessTriggerFilter {
     );
 
     private ProsessTriggerFilter() {
+    }
+
+    /**
+     * Returnerer true dersom varsel om opphør ved maksdato er overstyrt av en annen årsak
+     * (forlenget periode eller manuelt opphør). I slike tilfeller skal det ikke sendes varsel om opphør ved maksdato.
+     */
+    public static boolean erVarselOpphørVedMaksdatoOverstyrt(Collection<BehandlingÅrsakType> årsaker) {
+        return årsaker.stream().anyMatch(OVERSTYRER_VARSEL_OPPHØR_VED_MAKSDATO::contains);
     }
 
     public static List<Trigger> forKravperioder(List<Trigger> triggere) {

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggerFilterTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggerFilterTest.java
@@ -57,24 +57,4 @@ class ProsessTriggerFilterTest {
             .extracting(Trigger::getÅrsak)
             .containsExactly(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO);
     }
-
-    @Test
-    void erVarselOpphørVedMaksdatoOverstyrt_skal_vaere_true_ved_forlenget_periode() {
-        assertThat(ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(List.of(
-            BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO,
-            BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM))).isTrue();
-    }
-
-    @Test
-    void erVarselOpphørVedMaksdatoOverstyrt_skal_vaere_true_ved_opphor() {
-        assertThat(ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(List.of(
-            BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM))).isTrue();
-    }
-
-    @Test
-    void erVarselOpphørVedMaksdatoOverstyrt_skal_vaere_false_for_rent_varsel_opphor() {
-        assertThat(ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(List.of(
-            BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO))).isFalse();
-    }
 }
-

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggerFilterTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggerFilterTest.java
@@ -57,5 +57,24 @@ class ProsessTriggerFilterTest {
             .extracting(Trigger::getÅrsak)
             .containsExactly(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO);
     }
+
+    @Test
+    void erVarselOpphørVedMaksdatoOverstyrt_skal_vaere_true_ved_forlenget_periode() {
+        assertThat(ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(List.of(
+            BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO,
+            BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM))).isTrue();
+    }
+
+    @Test
+    void erVarselOpphørVedMaksdatoOverstyrt_skal_vaere_true_ved_opphor() {
+        assertThat(ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(List.of(
+            BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM))).isTrue();
+    }
+
+    @Test
+    void erVarselOpphørVedMaksdatoOverstyrt_skal_vaere_false_for_rent_varsel_opphor() {
+        assertThat(ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(List.of(
+            BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO))).isFalse();
+    }
 }
 

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggerFilterTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggerFilterTest.java
@@ -57,4 +57,43 @@ class ProsessTriggerFilterTest {
             .extracting(Trigger::getÅrsak)
             .containsExactly(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO);
     }
+
+    @Test
+    void skal_beholde_varsel_opphor_ved_maksdato_nar_kun_ikke_overstyrende_tilleggsarsak_finnes() {
+        var dato = LocalDate.now();
+        var triggere = List.of(
+            new Trigger(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO, DatoIntervallEntitet.fraOgMedTilOgMed(dato, dato)),
+            new Trigger(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT, DatoIntervallEntitet.fraOgMedTilOgMed(dato, dato))
+        );
+
+        var resultat = ProsessTriggerFilter.forKravperioder(triggere);
+
+        assertThat(resultat)
+            .extracting(Trigger::getÅrsak)
+            .contains(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO, BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT);
+    }
+
+    @Test
+    void skal_fjerne_varsel_opphor_ved_maksdato_nar_begge_overstyrende_arsaker_finnes_samtidig() {
+        var dato = LocalDate.now();
+        var triggere = List.of(
+            new Trigger(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO, DatoIntervallEntitet.fraOgMedTilOgMed(dato, dato)),
+            new Trigger(BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM, DatoIntervallEntitet.fraOgMedTilOgMed(dato.plusDays(1), dato.plusDays(10))),
+            new Trigger(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM, DatoIntervallEntitet.fraOgMedTilOgMed(dato.plusDays(11), dato.plusDays(20)))
+        );
+
+        var resultat = ProsessTriggerFilter.forKravperioder(triggere);
+
+        assertThat(resultat)
+            .extracting(Trigger::getÅrsak)
+            .doesNotContain(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO)
+            .contains(BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM, BehandlingÅrsakType.RE_HENDELSE_OPPHØR_UNGDOMSPROGRAM);
+    }
+
+    @Test
+    void skal_returnere_tom_liste_naar_ingen_triggere_finnes() {
+        var resultat = ProsessTriggerFilter.forKravperioder(List.of());
+
+        assertThat(resultat).isEmpty();
+    }
 }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/AktuelleFagsakerForMaksdatoVarselRepository.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/AktuelleFagsakerForMaksdatoVarselRepository.java
@@ -47,6 +47,9 @@ public class AktuelleFagsakerForMaksdatoVarselRepository {
      * I tillegg sjekkes det på om fagsaken har en tidligere behandling med prosesstrigger for RE_VARSEL_OPPHOR_VED_MAKSDATO med periode som overlapper gjeldende maksdato.
      * Dersom det finnes en slik behandling er det sendt varsel tidligere og vi skal ikke sende på nytt.
      *
+     * Det ekskluderes også fagsaker som allerede har en åpen (ikke avsluttet/iverksatt) behandling med årsak RE_VARSEL_OPPHOR_VED_MAKSDATO,
+     * slik at vi ikke oppretter duplikate behandlinger mens en varselbehandling er under arbeid.
+     *
      */
     @SuppressWarnings("unchecked")
     public List<Fagsak> hentFagsakerRelevantForMaksdatoVarsel() {
@@ -91,6 +94,15 @@ public class AktuelleFagsakerForMaksdatoVarselRepository {
                           where b3.fagsak_id = f.id
                             and pt.arsak = :varselOpphorArsak
                             and pt.periode && daterange(cast(mp.periode_maks_dato as date), cast(mp.periode_maks_dato as date), '[]')
+                      )
+                      and not exists (
+                          select 1
+                          from behandling b4
+                          inner join behandling_arsak ba
+                              on ba.behandling_id = b4.id
+                          where b4.fagsak_id = f.id
+                            and ba.behandling_arsak_type = :varselOpphorArsak
+                            and b4.behandling_status not in ('AVSLU', 'IVED')
                       )
                     group by mp.periode_maks_dato
                     having max(p.tom) >= mp.periode_maks_dato

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTask.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTask.java
@@ -67,7 +67,7 @@ public class VarselOpphørVedMaksdatoTask implements ProsessTaskHandler {
                     taskGruppe.addNesteSekvensiell(revurderingTask);
                 }
             } catch (Exception e) {
-                log.warn("Feil ved vurdering av fagsak {} for opphør ved maksdato-varsel", fagsak.getId(), e);
+                log.warn("Feil ved vurdering av fagsak {} for opphør ved maksdato-varsel", fagsak.getSaksnummer().getVerdi(), e);
             }
         }
 
@@ -78,7 +78,8 @@ public class VarselOpphørVedMaksdatoTask implements ProsessTaskHandler {
     }
 
     private ProsessTaskData opprettTask(Fagsak fagsak) {
-        var sisteBehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId());
+        Long fagsakId = fagsak.getId();
+        var sisteBehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId);
         if (sisteBehandling.isEmpty()) {
             return null;
         }
@@ -86,12 +87,12 @@ public class VarselOpphørVedMaksdatoTask implements ProsessTaskHandler {
         Behandling behandling = sisteBehandling.get();
         var maksdato = ungdomsprogramPeriodeTjeneste.finnPeriodeMaksDato(behandling.getId()).orElse(null);
 
-        log.info("Fagsak {} har periodeMaksDato {} fra register som er innenfor varselvinduet. Oppretter revurdering.", fagsak.getId(), maksdato);
+        log.info("Fagsak {} har periodeMaksDato {} fra register som er innenfor varselvinduet. Oppretter revurdering.", fagsak.getSaksnummer().getVerdi(), maksdato);
 
         var ønsketPeriode = maksdato + "/" + maksdato;
         var ønsketÅrsak = BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO.getKode();
         ProsessTaskData tilVurderingTask = ProsessTaskData.forProsessTask(OpprettRevurderingEllerOpprettDiffTask.class);
-        tilVurderingTask.setFagsakId(fagsak.getId());
+        tilVurderingTask.setFagsakId(fagsakId);
         tilVurderingTask.setProperty(PERIODER, ønsketPeriode);
         tilVurderingTask.setProperty(BEHANDLING_ÅRSAK, ønsketÅrsak);
         return tilVurderingTask;

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/UngEtterlysningOppretter.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/UngEtterlysningOppretter.java
@@ -2,9 +2,11 @@ package no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandling.BehandlingReferanse;
 import no.nav.ung.sak.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.domene.behandling.steg.kompletthet.EtterlysningOppretter;
 import no.nav.ung.sak.domene.behandling.steg.kompletthet.registerinntektkontroll.KontrollerInntektEtterlysningTjeneste;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.maksdato.MaksdatoEtterlysningTjeneste;
@@ -17,21 +19,34 @@ public class UngEtterlysningOppretter implements EtterlysningOppretter {
     private KontrollerInntektEtterlysningTjeneste kontrollerInntektEtterlysningTjeneste;
     private ProgramperiodeendringEtterlysningTjeneste programperiodeendringEtterlysningTjeneste;
     private MaksdatoEtterlysningTjeneste maksdatoEtterlysningTjeneste;
+    private BehandlingRepository behandlingRepository;
 
     public UngEtterlysningOppretter() {
     }
 
     @Inject
-    public UngEtterlysningOppretter(KontrollerInntektEtterlysningTjeneste kontrollerInntektEtterlysningTjeneste, ProgramperiodeendringEtterlysningTjeneste programperiodeendringEtterlysningTjeneste, MaksdatoEtterlysningTjeneste maksdatoEtterlysningTjeneste) {
+    public UngEtterlysningOppretter(KontrollerInntektEtterlysningTjeneste kontrollerInntektEtterlysningTjeneste, ProgramperiodeendringEtterlysningTjeneste programperiodeendringEtterlysningTjeneste, MaksdatoEtterlysningTjeneste maksdatoEtterlysningTjeneste, BehandlingRepository behandlingRepository) {
         this.kontrollerInntektEtterlysningTjeneste = kontrollerInntektEtterlysningTjeneste;
         this.programperiodeendringEtterlysningTjeneste = programperiodeendringEtterlysningTjeneste;
         this.maksdatoEtterlysningTjeneste = maksdatoEtterlysningTjeneste;
+        this.behandlingRepository = behandlingRepository;
     }
 
     @Override
     public void opprettEtterlysninger(BehandlingReferanse behandlingReferanse) {
+        // Rene varsel-om-opphør-ved-maksdato-behandlinger skal kun varsle om opphør, og ikke trigge
+        // inntektskontroll eller programperiodeendring-varsling som del av opphørsløpet.
+        if (erRentVarselOpphørVedMaksdatoLøp(behandlingReferanse)) {
+            maksdatoEtterlysningTjeneste.opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(behandlingReferanse);
+            return;
+        }
         kontrollerInntektEtterlysningTjeneste.opprettEtterlysninger(behandlingReferanse);
         programperiodeendringEtterlysningTjeneste.opprettEtterlysningerForProgramperiodeEndring(behandlingReferanse);
         maksdatoEtterlysningTjeneste.opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(behandlingReferanse);
+    }
+
+    private boolean erRentVarselOpphørVedMaksdatoLøp(BehandlingReferanse behandlingReferanse) {
+        var årsaker = behandlingRepository.hentBehandling(behandlingReferanse.getBehandlingId()).getBehandlingÅrsakerTyper();
+        return !årsaker.isEmpty() && årsaker.stream().allMatch(å -> å == BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO);
     }
 }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
@@ -19,7 +19,6 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.domene.typer.tid.JsonObjectMapper;
 import no.nav.ung.sak.etterlysning.AvbrytEtterlysningTask;
 import no.nav.ung.sak.etterlysning.OpprettEtterlysningTask;
-import no.nav.ung.sak.trigger.ProsessTriggerFilter;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.EtterlysningOgGrunnlag;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.EtterlysningStatusOgType;
 import org.slf4j.Logger;
@@ -105,10 +104,11 @@ public class MaksdatoEtterlysningTjeneste {
             logger.warn("Feil ved lagring av sporing for etterlysning opphør ved maksdato", e);
         }
 
-        // Sikkerhetsnett: et rent varsel-om-opphør-ved-maksdato-løp (ikke overstyrt av forlenget periode/opphør)
+        // Sikkerhetsnett: et rent varsel-om-opphør-ved-maksdato-løp (behandlingen har KUN denne årsaken)
         // må ha opprettet en etterlysning slik at behandlingen settes på vent og deltaker varsles før vedtak/brev om opphør.
         // Dersom det ikke finnes noen etterlysning av denne typen her, ville behandlingen gått videre til opphør uten kontradiksjon.
-        if (!ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(behandling.getBehandlingÅrsakerTyper())) {
+        // Har behandlingen andre årsaker i tillegg (f.eks. inntektskontroll eller forlenget periode/opphør), skal den ikke hardfeile her.
+        if (erKunVarselOpphørVedMaksdato(behandling)) {
             var etterlysningForMaksdato = etterlysningRepository.hentSisteEtterlysning(
                 behandlingReferanse.getBehandlingId(), EtterlysningType.UTTALELSE_OPPHOR_VED_MAKSDATO,
                 EtterlysningStatus.VENTER, EtterlysningStatus.OPPRETTET, EtterlysningStatus.MOTTATT_SVAR, EtterlysningStatus.UTLØPT);
@@ -121,6 +121,10 @@ public class MaksdatoEtterlysningTjeneste {
 
     }
 
+    private static boolean erKunVarselOpphørVedMaksdato(Behandling behandling) {
+        var årsaker = behandling.getBehandlingÅrsakerTyper();
+        return !årsaker.isEmpty() && årsaker.stream().allMatch(å -> å == BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO);
+    }
 
     /**
      * Avbryter eksisterende etterlysning for opphør ved maksdato.
@@ -175,4 +179,3 @@ public class MaksdatoEtterlysningTjeneste {
 
 
 }
-

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
@@ -109,10 +109,12 @@ public class MaksdatoEtterlysningTjeneste {
         // Dersom det ikke finnes noen etterlysning av denne typen her, ville behandlingen gått videre til opphør uten kontradiksjon.
         // Har behandlingen andre årsaker i tillegg (f.eks. inntektskontroll eller forlenget periode/opphør), skal den ikke hardfeile her.
         if (erKunVarselOpphørVedMaksdato(behandling)) {
-            var etterlysningForMaksdato = etterlysningRepository.hentSisteEtterlysning(
-                behandlingReferanse.getBehandlingId(), EtterlysningType.UTTALELSE_OPPHOR_VED_MAKSDATO,
-                EtterlysningStatus.VENTER, EtterlysningStatus.OPPRETTET, EtterlysningStatus.MOTTATT_SVAR, EtterlysningStatus.UTLØPT);
-            if (etterlysningForMaksdato.isEmpty()) {
+            boolean harEtterlysning = switch (resultat) {
+                case OPPRETT_ETTERLYSNING, ERSTATT_EKSISTERENDE -> true;
+                case INGEN_ENDRING -> eksisterende.isPresent();
+                case AVBRYT_ETTERLYSNING -> false;
+            };
+            if (!harEtterlysning) {
                 throw new IllegalStateException("Forventet etterlysning om opphør ved maksdato for behandling "
                     + behandlingReferanse.getBehandlingId() + ", men ingen ble opprettet (resultat=" + resultat + "). "
                     + "Behandlingen skal ikke gå videre til vedtak/brev om opphør uten at deltaker er varslet.");

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
@@ -19,6 +19,7 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.domene.typer.tid.JsonObjectMapper;
 import no.nav.ung.sak.etterlysning.AvbrytEtterlysningTask;
 import no.nav.ung.sak.etterlysning.OpprettEtterlysningTask;
+import no.nav.ung.sak.trigger.ProsessTriggerFilter;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.EtterlysningOgGrunnlag;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.EtterlysningStatusOgType;
 import org.slf4j.Logger;
@@ -102,6 +103,20 @@ public class MaksdatoEtterlysningTjeneste {
             ));
         } catch (IOException e) {
             logger.warn("Feil ved lagring av sporing for etterlysning opphør ved maksdato", e);
+        }
+
+        // Sikkerhetsnett: et rent varsel-om-opphør-ved-maksdato-løp (ikke overstyrt av forlenget periode/opphør)
+        // må ha opprettet en etterlysning slik at behandlingen settes på vent og deltaker varsles før vedtak/brev om opphør.
+        // Dersom det ikke finnes noen etterlysning av denne typen her, ville behandlingen gått videre til opphør uten kontradiksjon.
+        if (!ProsessTriggerFilter.erVarselOpphørVedMaksdatoOverstyrt(behandling.getBehandlingÅrsakerTyper())) {
+            var etterlysningForMaksdato = etterlysningRepository.hentSisteEtterlysning(
+                behandlingReferanse.getBehandlingId(), EtterlysningType.UTTALELSE_OPPHOR_VED_MAKSDATO,
+                EtterlysningStatus.VENTER, EtterlysningStatus.OPPRETTET, EtterlysningStatus.MOTTATT_SVAR, EtterlysningStatus.UTLØPT);
+            if (etterlysningForMaksdato.isEmpty()) {
+                throw new IllegalStateException("Forventet etterlysning om opphør ved maksdato for behandling "
+                    + behandlingReferanse.getBehandlingId() + ", men ingen ble opprettet (resultat=" + resultat + "). "
+                    + "Behandlingen skal ikke gå videre til vedtak/brev om opphør uten at deltaker er varslet.");
+            }
         }
 
     }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjeneste.java
@@ -19,6 +19,7 @@ import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.domene.typer.tid.JsonObjectMapper;
 import no.nav.ung.sak.etterlysning.AvbrytEtterlysningTask;
 import no.nav.ung.sak.etterlysning.OpprettEtterlysningTask;
+import no.nav.ung.sak.trigger.ProsessTriggerFilter;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.EtterlysningOgGrunnlag;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.EtterlysningStatusOgType;
 import org.slf4j.Logger;
@@ -104,11 +105,13 @@ public class MaksdatoEtterlysningTjeneste {
             logger.warn("Feil ved lagring av sporing for etterlysning opphør ved maksdato", e);
         }
 
-        // Sikkerhetsnett: et rent varsel-om-opphør-ved-maksdato-løp (behandlingen har KUN denne årsaken)
-        // må ha opprettet en etterlysning slik at behandlingen settes på vent og deltaker varsles før vedtak/brev om opphør.
-        // Dersom det ikke finnes noen etterlysning av denne typen her, ville behandlingen gått videre til opphør uten kontradiksjon.
-        // Har behandlingen andre årsaker i tillegg (f.eks. inntektskontroll eller forlenget periode/opphør), skal den ikke hardfeile her.
-        if (erKunVarselOpphørVedMaksdato(behandling)) {
+        // Sikkerhetsnett: varsel om opphør ved maksdato må ha resultert i en etterlysning, med mindre behandlingen
+        // er overstyrt av forlenget periode/manuelt opphør. Disse hendelsene endrer selve periode-/maksdato-grunnlaget,
+        // og kan derfor legitimt gjøre at varsel ikke lenger er relevant eller skal avbrytes (se ProsessTriggerFilter).
+        // Andre tilleggsårsaker (f.eks. inntektskontroll) påvirker ikke dette grunnlaget, så manglende etterlysning
+        // i den kombinasjonen indikerer fortsatt en feil og skal hardfeile, slik at behandlingen ikke går videre
+        // til vedtak/brev om opphør uten at deltaker er varslet.
+        if (!ProsessTriggerFilter.erOverstyrtAvAnnenHendelse(behandling.getBehandlingÅrsakerTyper())) {
             boolean harEtterlysning = switch (resultat) {
                 case OPPRETT_ETTERLYSNING, ERSTATT_EKSISTERENDE -> true;
                 case INGEN_ENDRING -> eksisterende.isPresent();
@@ -123,10 +126,6 @@ public class MaksdatoEtterlysningTjeneste {
 
     }
 
-    private static boolean erKunVarselOpphørVedMaksdato(Behandling behandling) {
-        var årsaker = behandling.getBehandlingÅrsakerTyper();
-        return !årsaker.isEmpty() && årsaker.stream().allMatch(å -> å == BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO);
-    }
 
     /**
      * Avbryter eksisterende etterlysning for opphør ved maksdato.

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/AktuelleFagsakerForMaksdatoVarselRepositoryTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/AktuelleFagsakerForMaksdatoVarselRepositoryTest.java
@@ -4,6 +4,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
 import no.nav.ung.kodeverk.behandling.BehandlingType;
+import no.nav.ung.kodeverk.behandling.BehandlingStatus;
 import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
@@ -166,6 +167,22 @@ class AktuelleFagsakerForMaksdatoVarselRepositoryTest {
         assertThat(fagsaker)
             .extracting(f -> f.getId())
             .contains(behandling.getFagsakId());
+    }
+
+    @Test
+    void skal_ikke_returnere_fagsak_nar_det_finnes_aapen_behandling_med_varsel_opphor_arsak() {
+        var maksdato = LocalDate.now().plusWeeks(2);
+        var behandling = TestScenarioBuilder.builderMedSøknad()
+            .medBehandlingÅrsak(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO)
+            .medBehandlingStatus(BehandlingStatus.UTREDES)
+            .lagre(entityManager);
+        lagreUngdomsprogramGrunnlag(behandling, maksdato, maksdato);
+
+        var fagsaker = repository.hentFagsakerRelevantForMaksdatoVarsel();
+
+        assertThat(fagsaker)
+            .extracting(f -> f.getId())
+            .doesNotContain(behandling.getFagsakId());
     }
 
     private void lagreUngdomsprogramGrunnlag(Behandling behandling, LocalDate tom, LocalDate maksdato) {

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTaskTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTaskTest.java
@@ -10,6 +10,7 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.typer.AktørId;
+import no.nav.ung.sak.typer.Saksnummer;
 import no.nav.ung.ytelse.ungdomsprogramytelsen.ungdomsprogrammet.UngdomsprogramPeriodeTjeneste;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,6 +108,7 @@ class VarselOpphørVedMaksdatoTaskTest {
     private Fagsak lagFagsak(Long id, String aktørId) {
         var fagsak = mock(Fagsak.class);
         when(fagsak.getId()).thenReturn(id);
+        when(fagsak.getSaksnummer()).thenReturn(new Saksnummer("SAK" + id));
         when(fagsak.getAktørId()).thenReturn(new AktørId(aktørId));
         when(fagsak.getPeriode()).thenReturn(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2025, 1, 1), LocalDate.of(2026, 12, 31)));
         when(fagsak.getYtelseType()).thenReturn(FagsakYtelseType.UNGDOMSYTELSE);

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/UngEtterlysningOppretterTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/UngEtterlysningOppretterTest.java
@@ -1,0 +1,65 @@
+package no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet;
+
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.sak.behandling.BehandlingReferanse;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.domene.behandling.steg.kompletthet.registerinntektkontroll.KontrollerInntektEtterlysningTjeneste;
+import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.maksdato.MaksdatoEtterlysningTjeneste;
+import no.nav.ung.ytelse.ungdomsprogramytelsen.vurderkompletthet.ungdomsprogramkontroll.ProgramperiodeendringEtterlysningTjeneste;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UngEtterlysningOppretterTest {
+
+    private static final Long BEHANDLING_ID = 123L;
+
+    private final KontrollerInntektEtterlysningTjeneste kontrollerInntektEtterlysningTjeneste = mock(KontrollerInntektEtterlysningTjeneste.class);
+    private final ProgramperiodeendringEtterlysningTjeneste programperiodeendringEtterlysningTjeneste = mock(ProgramperiodeendringEtterlysningTjeneste.class);
+    private final MaksdatoEtterlysningTjeneste maksdatoEtterlysningTjeneste = mock(MaksdatoEtterlysningTjeneste.class);
+    private final BehandlingRepository behandlingRepository = mock(BehandlingRepository.class);
+
+    private final Behandling behandling = mock(Behandling.class);
+    private final BehandlingReferanse behandlingReferanse = mock(BehandlingReferanse.class);
+
+    private UngEtterlysningOppretter oppretter;
+
+    @BeforeEach
+    void setUp() {
+        oppretter = new UngEtterlysningOppretter(kontrollerInntektEtterlysningTjeneste, programperiodeendringEtterlysningTjeneste, maksdatoEtterlysningTjeneste, behandlingRepository);
+        when(behandlingReferanse.getBehandlingId()).thenReturn(BEHANDLING_ID);
+        when(behandlingRepository.hentBehandling(BEHANDLING_ID)).thenReturn(behandling);
+    }
+
+    @Test
+    void skalIkkeTriggeInntektskontrollEllerProgramperiodeendring_forRentVarselOpphørVedMaksdatoLøp() {
+        when(behandling.getBehandlingÅrsakerTyper()).thenReturn(List.of(BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO));
+
+        oppretter.opprettEtterlysninger(behandlingReferanse);
+
+        verify(maksdatoEtterlysningTjeneste).opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(behandlingReferanse);
+        verify(kontrollerInntektEtterlysningTjeneste, never()).opprettEtterlysninger(behandlingReferanse);
+        verify(programperiodeendringEtterlysningTjeneste, never()).opprettEtterlysningerForProgramperiodeEndring(behandlingReferanse);
+    }
+
+    @Test
+    void skalTriggeAlleEtterlysninger_nårBehandlingHarAndreÅrsaker() {
+        when(behandling.getBehandlingÅrsakerTyper()).thenReturn(List.of(
+            BehandlingÅrsakType.RE_VARSEL_OPPHOR_VED_MAKSDATO,
+            BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT));
+
+        oppretter.opprettEtterlysninger(behandlingReferanse);
+
+        verify(kontrollerInntektEtterlysningTjeneste).opprettEtterlysninger(behandlingReferanse);
+        verify(programperiodeendringEtterlysningTjeneste).opprettEtterlysningerForProgramperiodeEndring(behandlingReferanse);
+        verify(maksdatoEtterlysningTjeneste).opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(behandlingReferanse);
+    }
+}
+

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjenesteTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjenesteTest.java
@@ -10,6 +10,7 @@ import no.nav.ung.kodeverk.varsel.EtterlysningStatus;
 import no.nav.ung.kodeverk.varsel.EtterlysningType;
 import no.nav.ung.sak.behandling.BehandlingReferanse;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.behandling.sporing.BehandingprosessSporingRepository;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
@@ -128,6 +129,24 @@ class MaksdatoEtterlysningTjenesteTest {
 
         var etterlysninger = etterlysningRepository.hentEtterlysninger(behandling.getId());
         assertThat(etterlysninger).isEmpty();
+    }
+
+    @Test
+    void skalIkkeHardfeile_nårVarselOpphørHarTilleggsårsakOgIngenEtterlysning() {
+        // Behandling har RE_VARSEL_OPPHOR_VED_MAKSDATO + en tilleggsårsak (ikke rent løp) → skal ikke hardfeile
+        // selv om maksdato er utenfor varslingsvinduet og ingen etterlysning opprettes.
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        BehandlingÅrsak.builder(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT).buildFor(behandling);
+        behandlingRepository.lagre(behandling, lås);
+
+        var fom = LocalDate.now().minusMonths(6);
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
+            List.of(new UngdomsprogramPeriode(fom, MAKSDATO_UTENFOR_VARSLINGSVINDU)),
+            false, MAKSDATO_UTENFOR_VARSLINGSVINDU);
+
+        tjeneste.opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(BehandlingReferanse.fra(behandling));
+
+        assertThat(etterlysningRepository.hentEtterlysninger(behandling.getId())).isEmpty();
     }
 
     @Test

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjenesteTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjenesteTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(JpaExtension.class)
@@ -114,13 +115,16 @@ class MaksdatoEtterlysningTjenesteTest {
     }
 
     @Test
-    void skalIkkeOppretteEtterlysning_nårMaksdatoUtenforVarslingsvindu() {
+    void skalHardfeile_nårVarselOpphørÅrsakOgIngenEtterlysningOpprettet() {
+        // Behandling har RE_VARSEL_OPPHOR_VED_MAKSDATO, men maksdato er utenfor varslingsvinduet slik at ingen
+        // etterlysning opprettes. Da skal behandlingen hardfeile slik at den ikke går videre til vedtak uten varsel.
         var fom = LocalDate.now().minusMonths(6);
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
             List.of(new UngdomsprogramPeriode(fom, MAKSDATO_UTENFOR_VARSLINGSVINDU)),
             false, MAKSDATO_UTENFOR_VARSLINGSVINDU);
 
-        tjeneste.opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(BehandlingReferanse.fra(behandling));
+        assertThatThrownBy(() -> tjeneste.opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(BehandlingReferanse.fra(behandling)))
+            .isInstanceOf(IllegalStateException.class);
 
         var etterlysninger = etterlysningRepository.hentEtterlysninger(behandling.getId());
         assertThat(etterlysninger).isEmpty();

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjenesteTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/vurderkompletthet/maksdato/MaksdatoEtterlysningTjenesteTest.java
@@ -132,11 +132,32 @@ class MaksdatoEtterlysningTjenesteTest {
     }
 
     @Test
-    void skalIkkeHardfeile_nårVarselOpphørHarTilleggsårsakOgIngenEtterlysning() {
-        // Behandling har RE_VARSEL_OPPHOR_VED_MAKSDATO + en tilleggsårsak (ikke rent løp) → skal ikke hardfeile
-        // selv om maksdato er utenfor varslingsvinduet og ingen etterlysning opprettes.
+    void skalHardfeile_nårVarselOpphørHarIkkeOverstyrendeTilleggsårsakOgIngenEtterlysning() {
+        // Behandling har RE_VARSEL_OPPHOR_VED_MAKSDATO + inntektskontroll (ikke overstyrende årsak).
+        // Inntektskontroll påvirker ikke periode-/maksdato-grunnlaget, så manglende etterlysning her
+        // indikerer fortsatt en feil og skal hardfeile.
         var lås = behandlingRepository.taSkriveLås(behandling);
         BehandlingÅrsak.builder(BehandlingÅrsakType.RE_KONTROLL_REGISTER_INNTEKT).buildFor(behandling);
+        behandlingRepository.lagre(behandling, lås);
+
+        var fom = LocalDate.now().minusMonths(6);
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
+            List.of(new UngdomsprogramPeriode(fom, MAKSDATO_UTENFOR_VARSLINGSVINDU)),
+            false, MAKSDATO_UTENFOR_VARSLINGSVINDU);
+
+        assertThatThrownBy(() -> tjeneste.opprettEtterlysningForOpphørVedMaksdatoDersomRelevant(BehandlingReferanse.fra(behandling)))
+            .isInstanceOf(IllegalStateException.class);
+
+        assertThat(etterlysningRepository.hentEtterlysninger(behandling.getId())).isEmpty();
+    }
+
+    @Test
+    void skalIkkeHardfeile_nårVarselOpphørErOverstyrtAvForlengetPeriodeOgIngenEtterlysning() {
+        // Behandling har RE_VARSEL_OPPHOR_VED_MAKSDATO + forlenget periode (overstyrende årsak).
+        // Forlenget periode endrer selve periode-/maksdato-grunnlaget, og kan derfor legitimt gjøre
+        // at varsel ikke lenger er relevant. Skal ikke hardfeile.
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        BehandlingÅrsak.builder(BehandlingÅrsakType.RE_HENDELSE_FORLENGET_PERIODE_UNGDOMSPROGRAM).buildFor(behandling);
         behandlingRepository.lagre(behandling, lås);
 
         var fom = LocalDate.now().minusMonths(6);


### PR DESCRIPTION
## Behov / Bakgrunn

Batch for varsel om opphør ved maksdato oppførte seg feil i Q:

- Behandlinger med årsak `RE_VARSEL_OPPHOR_VED_MAKSDATO` trigget **inntektskontroll** utilsiktet, og opprettet inntektsoppgaver tilbake i tid. Det skal ikke utføres etterkontroll som del av opphørsløpet.
- I minst ett tilfelle gikk behandlingen videre til **vedtak og brev om opphør uten at deltaker først ble varslet** og uten at behandlingen ble satt på vent — deltakers rett til kontradiksjon ble ikke ivaretatt.
- Antall aktuelle fagsaker var **økende** siden deploy (113 → 121), et tegn på at samme fagsaker ble re-selektert daglig og at det kunne opprettes duplikate behandlinger.

### Løsning

- **Ingen inntektskontroll i rent opphørsløp:** `UngEtterlysningOppretter` hopper over inntektskontroll og programperiodeendring-varsling når behandlingen *kun* har årsak `RE_VARSEL_OPPHOR_VED_MAKSDATO`. Har behandlingen andre årsaker i tillegg, kjøres alt som før.
- **Hardfeil hindrer vedtak uten kontradiksjon:** `MaksdatoEtterlysningTjeneste` kaster nå feil i et rent varsel-opphør-løp (behandlingen har *utelukkende* årsak `RE_VARSEL_OPPHOR_VED_MAKSDATO`) dersom det ikke finnes en `UTTALELSE_OPPHOR_VED_MAKSDATO`-etterlysning. Behandlinger med tilleggsårsaker (f.eks. inntektskontroll) eller som er overstyrt av forlenget periode/opphør hardfeiler ikke. Sjekken godtar `OPPRETTET/VENTER/MOTTATT_SVAR/UTLØPT`, slik at re-kjøringer etter at deltaker har svart ikke feiler.
- **Strammere dedup:** `AktuelleFagsakerForMaksdatoVarselRepository` ekskluderer også fagsaker som allerede har en **åpen** (status ≠ `AVSLU`/`IVED`) behandling med årsak `RE_VARSEL_OPPHOR_VED_MAKSDATO`, for å unngå duplikate behandlinger mens en varselbehandling er under arbeid.

### Andre endringer

- Nye/oppdaterte enhetstester: `UngEtterlysningOppretterTest` (ingen inntektskontroll ved rent opphørsløp), `MaksdatoEtterlysningTjenesteTest` (hardfeil kun ved rent løp; ingen hardfeil ved tilleggsårsak), samt dedup-test i `AktuelleFagsakerForMaksdatoVarselRepositoryTest`.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
