### PR TITLE
fix: parallelliser revurderingstasks i VarselOpphørVedMaksdatoTask

### DIFF
--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTask.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTask.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static no.nav.ung.sak.behandling.revurdering.OpprettRevurderingEllerOpprettDiffTask.BEHANDLING_ÅRSAK;
@@ -58,21 +59,23 @@ public class VarselOpphørVedMaksdatoTask implements ProsessTaskHandler {
 
         log.info("Fant {} aktuelle fagsaker for ungdomsytelse", aktuelleFagsaker.size());
 
-        ProsessTaskGruppe taskGruppe = new ProsessTaskGruppe();
+        List<ProsessTaskData> revurderingTasker = new ArrayList<>();
 
         for (Fagsak fagsak : aktuelleFagsaker) {
             try {
                 var revurderingTask = opprettTask(fagsak);
                 if (revurderingTask != null) {
-                    taskGruppe.addNesteSekvensiell(revurderingTask);
+                    revurderingTasker.add(revurderingTask);
                 }
             } catch (Exception e) {
                 log.warn("Feil ved vurdering av fagsak {} for opphør ved maksdato-varsel", fagsak.getSaksnummer().getVerdi(), e);
             }
         }
 
-        if (!taskGruppe.getTasks().isEmpty()) {
-            log.info("Oppretter {} revurderinger for varsel om opphør ved maksdato", taskGruppe.getTasks().size());
+        if (!revurderingTasker.isEmpty()) {
+            log.info("Oppretter {} revurderinger for varsel om opphør ved maksdato", revurderingTasker.size());
+            ProsessTaskGruppe taskGruppe = new ProsessTaskGruppe();
+            taskGruppe.addNesteParallell(revurderingTasker);
             prosessTaskTjeneste.lagre(taskGruppe);
         }
     }
@@ -86,6 +89,10 @@ public class VarselOpphørVedMaksdatoTask implements ProsessTaskHandler {
 
         Behandling behandling = sisteBehandling.get();
         var maksdato = ungdomsprogramPeriodeTjeneste.finnPeriodeMaksDato(behandling.getId()).orElse(null);
+        if (maksdato == null) {
+            log.warn("Fagsak {} mangler periodeMaksDato i registergrunnlaget. Hopper over opprettelse av revurdering for opphør ved maksdato-varsel.", fagsak.getSaksnummer().getVerdi());
+            return null;
+        }
 
         log.info("Fagsak {} har periodeMaksDato {} fra register som er innenfor varselvinduet. Oppretter revurdering.", fagsak.getSaksnummer().getVerdi(), maksdato);
 

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTaskTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoTaskTest.java
@@ -86,7 +86,7 @@ class VarselOpphørVedMaksdatoTaskTest {
     }
 
     @Test
-    void skal_opprette_task_nar_maksdato_mangler_i_grunnlaget() {
+    void skal_ikke_opprette_task_nar_maksdato_mangler_i_grunnlaget() {
         var fagsak = lagFagsak(1L, "1234567890123");
         var behandling = lagBehandling(fagsak, 100L);
 
@@ -96,9 +96,7 @@ class VarselOpphørVedMaksdatoTaskTest {
 
         task.doTask(ProsessTaskData.forProsessTask(VarselOpphørVedMaksdatoTask.class));
 
-        var captor = ArgumentCaptor.forClass(ProsessTaskGruppe.class);
-        verify(prosessTaskTjeneste).lagre(captor.capture());
-        assertThat(captor.getValue().getTasks()).hasSize(1);
+        verify(prosessTaskTjeneste, never()).lagre(any(ProsessTaskGruppe.class));
     }
 
     private void mockLøpendeFagsaker(List<Fagsak> fagsaker) {


### PR DESCRIPTION
### Behov / Bakgrunn

`VarselOpphørVedMaksdatoTask` brukte `addNesteSekvensiell` inne i en løkke, som lenket alle ~120 fagsakers `OpprettRevurderingEllerOpprettDiffTask` til én sekvensiell kjede. Feil eller heng i én task blokkerte alle bak, slik at tasks ble stående i KLAR uten å kjøre. Siden ingen behandling ble opprettet, så dedup-spørringen ingenting å ekskludere, og hver batch-kjøring re-selekterte de samme fagsakene og la på nye KLAR-tasks — derav de 10+ duplikatene for samme fagsak.

I tillegg: `opprettTask` kalte `finnPeriodeMaksDato().orElse(null)` og brukte resultatet direkte i periodestreng, noe som ga `"null/null"` som triggerperiode hvis registergrunnlaget mangler maksdato.

### Løsning

- **Parallell kjøring:** Samler revurderingstasks i en `List` og kaller `taskGruppe.addNesteParallell(revurderingTasker)` én gang, speilende mønsteret i `OpprettRevurderingForInntektskontrollTask`. Trygt fordi `OpprettRevurderingEllerOpprettDiffTask` er en `FagsakProsessTask` som tar fagsak-lås — parallelle tasks serialiseres per fagsak, men er uavhengige på tvers.

- **Null-sikring av maksdato:** `opprettTask` returnerer nå `null` + warn-logg  hvis `finnPeriodeMaksDato` er tom, fremfor å opprette en `"null/null"`-periode. Info-loggen «Oppretter revurdering» er flyttet til etter null-sjekken.

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
