### PR TITLE
TSFF-2654 - Lanserer varsling av opphør ved maksdato.

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -278,8 +278,6 @@ spec:
       value: "true"
     - name: AKTIVITETSPENGER_ENABLED
       value: "true"
-    - name: VARSEL_OPPHOR_VED_MAKSDATO_ENABLED
-      value: "true"
 
       # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -272,8 +272,6 @@ spec:
       value: "false"
     - name: PROGRAMPERIODE_ENDRING_ENABLED
       value: "false"
-    - name: VARSEL_OPPHOR_VED_MAKSDATO_ENABLED
-      value: "false"
 
     # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoBatchTask.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoBatchTask.java
@@ -2,14 +2,11 @@ package no.nav.ung.ytelse.ungdomsprogramytelsen.revurdering.varselopphorvedmaksd
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.k9.prosesstask.api.ProsessTask;
-import no.nav.k9.prosesstask.api.ProsessTaskData;
 import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.k9.prosesstask.api.TaskType;
 import no.nav.k9.prosesstask.impl.cron.CronExpression;
 import no.nav.ung.sak.behandling.prosessering.DuplikatbeskyttetBatchTask;
-import no.nav.ung.sak.behandling.revurdering.sats.OpprettRevurderingHøySatsTask;
 
 /**
  * Batchtask som varsler deltakere om opphør ved maksdato 3 uker før maksdato.
@@ -22,27 +19,18 @@ public class VarselOpphørVedMaksdatoBatchTask extends DuplikatbeskyttetBatchTas
 
     public static final String TASKNAME = "batch.varselOpphorVedMaksdato";
 
-    private boolean varselOpphørVedMaksdatoEnabled;
-
     VarselOpphørVedMaksdatoBatchTask() {
         // for CDI proxy
     }
 
     @Inject
-    public VarselOpphørVedMaksdatoBatchTask(ProsessTaskTjeneste prosessTaskTjeneste,
-                                            @KonfigVerdi(value = "VARSEL_OPPHOR_VED_MAKSDATO_ENABLED", required = false, defaultVerdi = "false") boolean varselOpphørVedMaksdatoEnabled) {
+    public VarselOpphørVedMaksdatoBatchTask(ProsessTaskTjeneste prosessTaskTjeneste) {
         super(prosessTaskTjeneste);
-        this.varselOpphørVedMaksdatoEnabled = varselOpphørVedMaksdatoEnabled;
     }
 
     @Override
     protected TaskType getTaskType() {
         return new TaskType(VarselOpphørVedMaksdatoTask.TASKNAME);
-    }
-
-    @Override
-    protected boolean isEnabled() {
-        return varselOpphørVedMaksdatoEnabled;
     }
 
     @Override


### PR DESCRIPTION
### Behov / Bakgrunn

Når sluttdato for ungdomsprogrammet nærmer seg, skal systemet automatisk opprette en behandling og sende forhåndsvarsel til deltaker, slik at opphør kan ferdigstilles.


### Løsning
- Aktiverer og fjerner feature flag for varsling av opphør ved maksdato.


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
