### PR TITLE
fix: sett PERIODE_FOM/PERIODE_TOM på child-task for inntektskontroll-batch

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/DuplikatbeskyttetBatchTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/ung/sak/behandling/prosessering/DuplikatbeskyttetBatchTask.java
@@ -58,6 +58,15 @@ public abstract class DuplikatbeskyttetBatchTask implements BatchProsessTaskHand
         return true;
     }
 
+    /**
+     * Kalles etter at child-tasken er opprettet, men før den lagres. Overstyr for å sette
+     * properties på child-tasken (f.eks. periode) som eventuelt {@link #erDuplikat(ProsessTaskData)}
+     * er avhengig av.
+     */
+    protected void leggTilProperties(ProsessTaskData childTask) {
+        // Standard: ingen ekstra properties
+    }
+
     @Override
     public final void doTask(ProsessTaskData prosessTaskData) {
         if (!isEnabled()) {
@@ -72,6 +81,7 @@ public abstract class DuplikatbeskyttetBatchTask implements BatchProsessTaskHand
         }
 
         ProsessTaskData childTask = ProsessTaskData.forTaskType(getTaskType());
+        leggTilProperties(childTask);
         prosessTaskTjeneste.lagre(childTask);
     }
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
@@ -10,11 +10,9 @@ import no.nav.k9.prosesstask.api.TaskType;
 import no.nav.k9.prosesstask.impl.cron.CronExpression;
 import no.nav.ung.sak.behandling.prosessering.DuplikatbeskyttetBatchTask;
 
-import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
 import java.util.Objects;
-import java.util.function.Predicate;
 
 
 /**
@@ -54,19 +52,16 @@ public class OpprettRevurderingForInntektskontrollBatchTask extends Duplikatbesk
 
     @Override
     protected void leggTilProperties(ProsessTaskData childTask) {
-        var now = LocalDate.now();
-        var forrigeMåned = now.minusMonths(1);
-        var fom = forrigeMåned.withDayOfMonth(1);
-        var tom = forrigeMåned.with(TemporalAdjusters.lastDayOfMonth());
-        childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
-        childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_TOM, tom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        var forrigeMåned = YearMonth.now().minusMonths(1);
+        childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM, forrigeMåned.atDay(1).format(DateTimeFormatter.ISO_LOCAL_DATE));
+        childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_TOM, forrigeMåned.atEndOfMonth().format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 
     @Override
     protected boolean erDuplikat(ProsessTaskData data) {
-        var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
+        var forrigeMåned = YearMonth.now().minusMonths(1);
         return Objects.equals(
             data.getPropertyValue(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM),
-            fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+            forrigeMåned.atDay(1).format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
@@ -13,6 +13,7 @@ import no.nav.ung.sak.behandling.prosessering.DuplikatbeskyttetBatchTask;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 
@@ -51,11 +52,19 @@ public class OpprettRevurderingForInntektskontrollBatchTask extends Duplikatbesk
         return new TaskType(OpprettRevurderingForInntektskontrollTask.TASKNAME);
     }
 
+    @Override
+    protected void leggTilProperties(ProsessTaskData childTask) {
+        var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
+        var tom = LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_TOM, tom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+    }
 
     @Override
     protected boolean erDuplikat(ProsessTaskData data) {
         var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
-        return data.getPropertyValue(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM)
-            .equals(fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        return Objects.equals(
+            data.getPropertyValue(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM),
+            fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTask.java
@@ -54,8 +54,10 @@ public class OpprettRevurderingForInntektskontrollBatchTask extends Duplikatbesk
 
     @Override
     protected void leggTilProperties(ProsessTaskData childTask) {
-        var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
-        var tom = LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        var now = LocalDate.now();
+        var forrigeMåned = now.minusMonths(1);
+        var fom = forrigeMåned.withDayOfMonth(1);
+        var tom = forrigeMåned.with(TemporalAdjusters.lastDayOfMonth());
         childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
         childTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_TOM, tom.format(DateTimeFormatter.ISO_LOCAL_DATE));
     }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTaskTest.java
@@ -35,10 +35,11 @@ class OpprettRevurderingForInntektskontrollBatchTaskTest {
 
     @Test
     void skal_sette_periode_fom_og_tom_på_child_task() {
-        batchTask.doTask(new ProsessTaskData("batch.opprettRevurderingForInntektskontrollBatch"));
+        var now = LocalDate.now();
+        var forventetFom = now.minusMonths(1).withDayOfMonth(1);
+        var forventetTom = now.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
 
-        var forventetFom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
-        var forventetTom = LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        batchTask.doTask(new ProsessTaskData(OpprettRevurderingForInntektskontrollBatchTask.TASKNAME));
 
         ArgumentCaptor<ProsessTaskData> captor = ArgumentCaptor.forClass(ProsessTaskData.class);
         verify(prosessTaskTjeneste).lagre(captor.capture());

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTaskTest.java
@@ -1,0 +1,81 @@
+package no.nav.ung.sak.behandling.revurdering.inntektskontroll;
+
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskStatus;
+import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OpprettRevurderingForInntektskontrollBatchTaskTest {
+
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    private OpprettRevurderingForInntektskontrollBatchTask batchTask;
+
+    @BeforeEach
+    void setUp() {
+        prosessTaskTjeneste = mock(ProsessTaskTjeneste.class);
+        batchTask = new OpprettRevurderingForInntektskontrollBatchTask(prosessTaskTjeneste, "0 0 7 8 * *");
+
+        when(prosessTaskTjeneste.finnAlle(eq(OpprettRevurderingForInntektskontrollTask.TASKNAME), any(ProsessTaskStatus.class)))
+            .thenReturn(List.of());
+    }
+
+    @Test
+    void skal_sette_periode_fom_og_tom_på_child_task() {
+        batchTask.doTask(new ProsessTaskData("batch.opprettRevurderingForInntektskontrollBatch"));
+
+        var forventetFom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
+        var forventetTom = LocalDate.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+
+        ArgumentCaptor<ProsessTaskData> captor = ArgumentCaptor.forClass(ProsessTaskData.class);
+        verify(prosessTaskTjeneste).lagre(captor.capture());
+
+        var childTask = captor.getValue();
+        assertThat(childTask.getTaskType()).isEqualTo(OpprettRevurderingForInntektskontrollTask.TASKNAME);
+        assertThat(childTask.getPropertyValue(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM))
+            .isEqualTo(forventetFom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        assertThat(childTask.getPropertyValue(OpprettRevurderingForInntektskontrollTask.PERIODE_TOM))
+            .isEqualTo(forventetTom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+    }
+
+    @Test
+    void skal_ikke_opprette_duplikat_når_feilet_task_for_samme_periode_finnes() {
+        var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
+        var eksisterendeTask = new ProsessTaskData(OpprettRevurderingForInntektskontrollTask.TASKNAME);
+        eksisterendeTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
+
+        when(prosessTaskTjeneste.finnAlle(OpprettRevurderingForInntektskontrollTask.TASKNAME, ProsessTaskStatus.FEILET))
+            .thenReturn(List.of(eksisterendeTask));
+
+        batchTask.doTask(new ProsessTaskData("batch.opprettRevurderingForInntektskontrollBatch"));
+
+        verify(prosessTaskTjeneste, org.mockito.Mockito.never()).lagre(any(ProsessTaskData.class));
+    }
+
+    @Test
+    void skal_ikke_feile_når_eksisterende_task_mangler_periode_property() {
+        // Regresjonstest: eksisterende feilede tasks kan mangle PERIODE_FOM (bug fikset i samme endring
+        // som denne testen), erDuplikat skal håndtere det uten NPE.
+        var eksisterendeTaskUtenPeriode = new ProsessTaskData(OpprettRevurderingForInntektskontrollTask.TASKNAME);
+
+        when(prosessTaskTjeneste.finnAlle(OpprettRevurderingForInntektskontrollTask.TASKNAME, ProsessTaskStatus.FEILET))
+            .thenReturn(List.of(eksisterendeTaskUtenPeriode));
+
+        batchTask.doTask(new ProsessTaskData("batch.opprettRevurderingForInntektskontrollBatch"));
+
+        verify(prosessTaskTjeneste).lagre(any(ProsessTaskData.class));
+    }
+}

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/ung/sak/behandling/revurdering/inntektskontroll/OpprettRevurderingForInntektskontrollBatchTaskTest.java
@@ -7,9 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,9 +34,9 @@ class OpprettRevurderingForInntektskontrollBatchTaskTest {
 
     @Test
     void skal_sette_periode_fom_og_tom_på_child_task() {
-        var now = LocalDate.now();
-        var forventetFom = now.minusMonths(1).withDayOfMonth(1);
-        var forventetTom = now.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+        var forrigeMåned = YearMonth.now().minusMonths(1);
+        var forventetFom = forrigeMåned.atDay(1);
+        var forventetTom = forrigeMåned.atEndOfMonth();
 
         batchTask.doTask(new ProsessTaskData(OpprettRevurderingForInntektskontrollBatchTask.TASKNAME));
 
@@ -54,7 +53,7 @@ class OpprettRevurderingForInntektskontrollBatchTaskTest {
 
     @Test
     void skal_ikke_opprette_duplikat_når_feilet_task_for_samme_periode_finnes() {
-        var fom = LocalDate.now().minusMonths(1).withDayOfMonth(1);
+        var fom = YearMonth.now().minusMonths(1).atDay(1);
         var eksisterendeTask = new ProsessTaskData(OpprettRevurderingForInntektskontrollTask.TASKNAME);
         eksisterendeTask.setProperty(OpprettRevurderingForInntektskontrollTask.PERIODE_FOM, fom.format(DateTimeFormatter.ISO_LOCAL_DATE));
 


### PR DESCRIPTION
### Behov / Bakgrunn

Tasken `batch.opprettRevurderingForInntektskontroll` feilet med `NullPointerException` ved parsing av `PERIODE_FOM`. Refaktoreringen til felles `DuplikatbeskyttetBatchTask` (#1333) opprettet child-tasken generisk uten å sette periode-properties (`PERIODE_FOM`/`PERIODE_TOM`), som `OpprettRevurderingForInntektskontrollTask` er avhengig av for å utlede kontrollperioden.

### Løsning

- Innført hook `leggTilProperties(ProsessTaskData)` i `DuplikatbeskyttetBatchTask`, kalt før lagring, slik at subklasser kan sette egne properties på child-tasken.
- `OpprettRevurderingForInntektskontrollBatchTask` overstyrer denne og setter `PERIODE_FOM`/`PERIODE_TOM` (gjenoppretter oppførselen fra før refaktoreringen).
- Gjort `erDuplikat` null-safe (`Objects.equals`) for å unngå ny NPE mot eksisterende `FEILET`-tasks fra prod som mangler property.
- Lagt til `OpprettRevurderingForInntektskontrollBatchTaskTest` med regresjonstest for scenarioet (properties settes korrekt, duplikatsjekk fungerer, og håndtering av gamle tasks uten property).

### Andre endringer

- Verifisert at øvrige subklasser av `DuplikatbeskyttetBatchTask` (høysats aktivitetspenger, høysats revurdering, varsel opphør ved maksdato) ikke er berørt av samme mangel — deres worker-tasker leser ikke properties fra input-`ProsessTaskData`, men utleder dato/tilstand ved kjøretidspunkt.
- Ingen migrasjons-, API- eller kontraktendringer.


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
