### PR TITLE
Workaround for ikke-kritisk kall som feiler mot microsoft graph

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/saksbehandler/SaksbehandlerRestTjeneste.java
@@ -26,11 +26,10 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.kontrakt.behandling.BehandlingUuidDto;
 import no.nav.ung.sak.kontrakt.saksbehandler.SaksbehandlerDto;
 import no.nav.ung.sak.web.server.abac.AbacAttributtSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -40,8 +39,8 @@ import static no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionType.READ;
 @ApplicationScoped
 @Transactional
 public class SaksbehandlerRestTjeneste {
-    public static final String SAKSBEHANDLER_PATH = "/saksbehandler";
-    private static final long CACHE_ELEMENT_LIVE_TIME_MS = TimeUnit.MILLISECONDS.convert(480, TimeUnit.MINUTES);
+
+    private static final Logger logger = LoggerFactory.getLogger(SaksbehandlerRestTjeneste.class);
 
     private MicrosoftGraphTjeneste microsoftGraphTjeneste;
 
@@ -105,8 +104,13 @@ public class SaksbehandlerRestTjeneste {
         unikeIdenter.remove(systembruker); //bare relevant lokat
         unikeIdenter.remove(appName);
 
-        Map<String, String> identTilNavn = microsoftGraphTjeneste.navnPåNavAnsatte(unikeIdenter);
-
+        Map<String, String> identTilNavn;
+        try {
+             identTilNavn = microsoftGraphTjeneste.navnPåNavAnsatte(unikeIdenter);
+        } catch (Exception e) {
+            logger.warn("Feil ved henting av navn for saksbehandlere fra Microsoft Graph. Returnerer tomt liste.", e);
+            identTilNavn = Collections.emptyMap();
+        }
         return new SaksbehandlerDto(identTilNavn);
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Kallet for å hente saksbehandlere fra microsoft graph feiler, som hindrer saksbehandling. Dette er ikke kritisk for saksbehandling, så ignorerer kallet om det feiler

### Løsning


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
