### PR TITLE
Justerer forsinkelse i avslutt-behandling-task pga sjekk ved avslutning av inntektshendelseabonnement

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/intern/AvsluttBehandlingTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/intern/AvsluttBehandlingTask.java
@@ -13,10 +13,10 @@ import no.nav.k9.prosesstask.api.ProsessTask;
 import no.nav.k9.prosesstask.api.ProsessTaskData;
 
 @ApplicationScoped
-//Bruker lenger enn normal forsinkelse pga abonnement i inntektskomponenten. For tiden får vi ikke avsluttet abonnementet
-//før det er synkronisert mot skatt, noe som tar ca 5 min. Kan justeres tilbake til standard forsinkelse når
-//inntektskomponenten har justert hos seg, eller om vi venter på synkronisering ved opprettelse av abonnement
-@ProsessTask(value = AvsluttBehandlingTask.TASKTYPE, firstDelay = 300, thenDelay = 300)
+// Bruker lenger enn normal forsinkelse pga. abonnement i inntektskomponenten. For tiden får vi ikke avsluttet abonnementet
+// før det er synkronisert mot skatt, noe som tar ca. 5 min. Kan justeres tilbake til standard forsinkelse når
+// inntektskomponenten har justert hos seg, eller om vi venter på synkronisering ved opprettelse av abonnement
+@ProsessTask(value = AvsluttBehandlingTask.TASKTYPE, firstDelay = 5 * 60, thenDelay = 5 * 60)
 @FagsakProsesstaskRekkefølge(gruppeSekvens = true)
 public class AvsluttBehandlingTask extends FagsakProsessTask {
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/intern/AvsluttBehandlingTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/ung/sak/domene/vedtak/intern/AvsluttBehandlingTask.java
@@ -13,7 +13,10 @@ import no.nav.k9.prosesstask.api.ProsessTask;
 import no.nav.k9.prosesstask.api.ProsessTaskData;
 
 @ApplicationScoped
-@ProsessTask(AvsluttBehandlingTask.TASKTYPE)
+//Bruker lenger enn normal forsinkelse pga abonnement i inntektskomponenten. For tiden får vi ikke avsluttet abonnementet
+//før det er synkronisert mot skatt, noe som tar ca 5 min. Kan justeres tilbake til standard forsinkelse når
+//inntektskomponenten har justert hos seg, eller om vi venter på synkronisering ved opprettelse av abonnement
+@ProsessTask(value = AvsluttBehandlingTask.TASKTYPE, firstDelay = 300, thenDelay = 300)
 @FagsakProsesstaskRekkefølge(gruppeSekvens = true)
 public class AvsluttBehandlingTask extends FagsakProsessTask {
 


### PR DESCRIPTION
### Behov / Bakgrunn

Inntektsabonnement kan ikke avsluttes før det er synkronisert mot skatt. Det gjør at avslutt-behandling-tasker for automatiske behandlinger vil feile, og ligge feilende til tidspunkt for automatisk rekjøring av tasker.

https://nav-it.slack.com/archives/C0AFW9RMXC4/p1783515877213769

### Løsning

Setter lenger forsinkelse for rekjøring på denne tasken, slik at abonnementet rekker å bli synkronisert før rekjøring gir opp.

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
