### PR TITLE
Legger til nye metoder i PipRestTjeneste for å understøtte tilgangskontroll i ung-tilbake

### DIFF
--- a/behandlingslager/domene/pom.xml
+++ b/behandlingslager/domene/pom.xml
@@ -17,6 +17,10 @@
             <groupId>no.nav.ung.sak</groupId>
             <artifactId>kodeverk</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.ung.sak</groupId>
+            <artifactId>kontrakt</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>no.nav.k9.prosesstask</groupId>

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
@@ -304,17 +304,17 @@ public class PipRepository {
         Query query = entityManager.createNativeQuery(sql, Tuple.class);
         query.setParameter("saksnummer", saksnummer.getVerdi());
         @SuppressWarnings("unchecked")
-        List<Tuple> resulat = query.getResultList();
-        if (resulat.isEmpty()) {
+        List<Tuple> resultat = query.getResultList();
+        if (resultat.isEmpty()) {
             return null;
-        } else if (resulat.size() == 1) {
-            Tuple tuple = resulat.getFirst();
+        } else if (resultat.size() == 1) {
+            Tuple tuple = resultat.getFirst();
             return new FagsakTypeOgStatus(
                 FagsakYtelseType.fraKode(tuple.get("ytelse_type", String.class)),
                 FagsakStatus.fraKode(tuple.get("fagsak_status", String.class))
             );
         } else {
-            throw new IllegalStateException("Forventet 0 eller 1 treff etter saksnummer, men fikk " + resulat.size());
+            throw new IllegalStateException("Forventet 0 eller 1 treff etter saksnummer, men fikk " + resultat.size());
         }
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
@@ -234,13 +234,11 @@ public class PipRepository {
     }
 
     @SuppressWarnings({"unchecked"})
-    public Set<Saksnummer> saksnumreForSøker(Collection<AktørId> aktørId) {
+    public Set<Saksnummer> hentSaksnumreForBruker(Collection<AktørId> aktørId) {
         if (aktørId.isEmpty()) {
             return Collections.emptySet();
         }
-        String sql = "SELECT f.saksnummer " +
-            "from FAGSAK f " +
-            "where f.bruker_aktoer_id in (:aktørId)";
+        String sql = "SELECT f.saksnummer from FAGSAK f where f.bruker_aktoer_id in (:aktørId)";
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("aktørId", aktørId.stream().map(AktørId::getId).collect(Collectors.toList()));
         var result = (List<String>) query.getResultList();
@@ -277,17 +275,6 @@ public class PipRepository {
             .map(this::hentPipDataOgPersonerForFagsak)
             .flatMap(Optional::stream)
             .toList();
-    }
-
-    public Set<Saksnummer> hentSaksnumreForBruker(Collection<AktørId> aktørId) {
-        if (aktørId.isEmpty()) {
-            return Collections.emptySet();
-        }
-        String sql = "SELECT f.saksnummer from FAGSAK f where f.bruker_aktoer_id in (:aktørId)";
-        Query query = entityManager.createNativeQuery(sql);
-        query.setParameter("aktørId", aktørId.stream().map(AktørId::getId).collect(Collectors.toList()));
-        var result = (List<String>) query.getResultList();
-        return result.stream().map(Saksnummer::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Optional<FagsakPipDto> hentPipDataOgPersonerForFagsak(Saksnummer saksnummer) {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
@@ -269,4 +269,64 @@ public class PipRepository {
         query.setParameter("uuider", behandlingsUUIDer);
         return query.getResultStream().collect(Collectors.toCollection(LinkedHashSet::new));
     }
+
+    public List<no.nav.ung.sak.kontrakt.abac.FagsakPipDto> hentPipDataOgPersonerForBrukersFagsaker(AktørId brukerAktørId) {
+        Set<Saksnummer> saksnumre = hentSaksnumreForBruker(Set.of(brukerAktørId));
+        return saksnumre.stream()
+            .map(this::hentPipDataOgPersonerForFagsak)
+            .flatMap(Optional::stream)
+            .toList();
+    }
+
+    public Set<Saksnummer> hentSaksnumreForBruker(Collection<AktørId> aktørId) {
+        if (aktørId.isEmpty()) {
+            return Collections.emptySet();
+        }
+        String sql = "SELECT f.saksnummer from FAGSAK f where f.bruker_aktoer_id in (:aktørId)";
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("aktørId", aktørId.stream().map(AktørId::getId).collect(Collectors.toList()));
+        var result = (List<String>) query.getResultList();
+        return result.stream().map(Saksnummer::new).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public Optional<no.nav.ung.sak.kontrakt.abac.FagsakPipDto> hentPipDataOgPersonerForFagsak(Saksnummer saksnummer) {
+        FagsakTypeOgStatus fagsakTypeOgStatus = hentFagsakTypeOgStatus(saksnummer);
+        if (fagsakTypeOgStatus == null){
+            return Optional.empty();
+        }
+        Set<AktørId> aktørIder = hentAktørIdKnyttetTilFagsaker(Set.of(saksnummer));
+        Set<AktørId> aktørIderForSporingslogg = hentAktørIdForSporingslogg(saksnummer);
+        return Optional.of(new no.nav.ung.sak.kontrakt.abac.FagsakPipDto(
+            saksnummer,
+            aktørIder,
+            aktørIderForSporingslogg,
+            fagsakTypeOgStatus.status(),
+            fagsakTypeOgStatus.ytelseType()
+        ));
+    }
+
+
+    public record FagsakTypeOgStatus(FagsakYtelseType ytelseType, FagsakStatus status) {
+    }
+
+    public FagsakTypeOgStatus hentFagsakTypeOgStatus(Saksnummer saksnummer) {
+        Objects.requireNonNull(saksnummer, "saksnummer");
+
+        String sql = "select ytelse_type, fagsak_status from fagsak where saksnummer = :saksnummer";
+        Query query = entityManager.createNativeQuery(sql, Tuple.class);
+        query.setParameter("saksnummer", saksnummer.getVerdi());
+        @SuppressWarnings("unchecked")
+        List<Tuple> resulat = query.getResultList();
+        if (resulat.isEmpty()) {
+            return null;
+        } else if (resulat.size() == 1) {
+            Tuple tuple = resulat.getFirst();
+            return new FagsakTypeOgStatus(
+                FagsakYtelseType.fraKode(tuple.get("ytelse_type", String.class)),
+                FagsakStatus.fraKode(tuple.get("fagsak_status", String.class))
+            );
+        } else {
+            throw new IllegalStateException("Forventet 0 eller 1 treff etter saksnummer, men fikk " + resulat.size());
+        }
+    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
@@ -293,10 +293,6 @@ public class PipRepository {
         ));
     }
 
-
-    public record FagsakTypeOgStatus(FagsakYtelseType ytelseType, FagsakStatus status) {
-    }
-
     public FagsakTypeOgStatus hentFagsakTypeOgStatus(Saksnummer saksnummer) {
         Objects.requireNonNull(saksnummer, "saksnummer");
 
@@ -316,5 +312,8 @@ public class PipRepository {
         } else {
             throw new IllegalStateException("Forventet 0 eller 1 treff etter saksnummer, men fikk " + resultat.size());
         }
+    }
+
+    public record FagsakTypeOgStatus(FagsakYtelseType ytelseType, FagsakStatus status) {
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/pip/PipRepository.java
@@ -10,6 +10,7 @@ import no.nav.ung.kodeverk.behandling.BehandlingStatus;
 import no.nav.ung.kodeverk.behandling.FagsakStatus;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.ung.sak.kontrakt.abac.FagsakPipDto;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
@@ -270,7 +271,7 @@ public class PipRepository {
         return query.getResultStream().collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    public List<no.nav.ung.sak.kontrakt.abac.FagsakPipDto> hentPipDataOgPersonerForBrukersFagsaker(AktørId brukerAktørId) {
+    public List<FagsakPipDto> hentPipDataOgPersonerForBrukersFagsaker(AktørId brukerAktørId) {
         Set<Saksnummer> saksnumre = hentSaksnumreForBruker(Set.of(brukerAktørId));
         return saksnumre.stream()
             .map(this::hentPipDataOgPersonerForFagsak)
@@ -289,14 +290,14 @@ public class PipRepository {
         return result.stream().map(Saksnummer::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    public Optional<no.nav.ung.sak.kontrakt.abac.FagsakPipDto> hentPipDataOgPersonerForFagsak(Saksnummer saksnummer) {
+    public Optional<FagsakPipDto> hentPipDataOgPersonerForFagsak(Saksnummer saksnummer) {
         FagsakTypeOgStatus fagsakTypeOgStatus = hentFagsakTypeOgStatus(saksnummer);
         if (fagsakTypeOgStatus == null){
             return Optional.empty();
         }
         Set<AktørId> aktørIder = hentAktørIdKnyttetTilFagsaker(Set.of(saksnummer));
         Set<AktørId> aktørIderForSporingslogg = hentAktørIdForSporingslogg(saksnummer);
-        return Optional.of(new no.nav.ung.sak.kontrakt.abac.FagsakPipDto(
+        return Optional.of(new FagsakPipDto(
             saksnummer,
             aktørIder,
             aktørIderForSporingslogg,

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/pip/PipRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/pip/PipRepositoryTest.java
@@ -14,6 +14,7 @@ import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.behandlingslager.fagsak.Journalpost;
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.db.util.Repository;
+import no.nav.ung.sak.kontrakt.abac.FagsakPipDto;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
@@ -116,6 +117,50 @@ public class PipRepositoryTest {
 
         Set<String> resultat2 = pipRepository.hentAksjonspunktTypeForAksjonspunktKoder(List.of(AksjonspunktDefinisjon.OVERSTYRING_AV_INNTEKT.getKode(), AksjonspunktDefinisjon.KONTROLLER_INNTEKT.getKode()));
         assertThat(resultat2).containsOnly("OVST", "MANU");
+    }
+
+    @Test
+    public void skal_hente_pipdata_og_personer_for_fagsak() {
+        AktørId aktørId = AktørId.dummy();
+        Fagsak fagsak = behandlingBuilder.opprettFagsak(FagsakYtelseType.UNGDOMSYTELSE, aktørId);
+
+        Optional<FagsakPipDto> resultat = pipRepository.hentPipDataOgPersonerForFagsak(fagsak.getSaksnummer());
+
+        assertThat(resultat).isPresent();
+        FagsakPipDto pipDto = resultat.get();
+        assertThat(pipDto.saksnummer()).isEqualTo(fagsak.getSaksnummer());
+        assertThat(pipDto.fagsakStatus()).isEqualTo(fagsak.getStatus());
+        assertThat(pipDto.ytelseType()).isEqualTo(FagsakYtelseType.UNGDOMSYTELSE);
+        assertThat(pipDto.aktørIder()).containsOnly(aktørId);
+        assertThat(pipDto.aktørIderForSporingslogg()).containsOnly(aktørId);
+    }
+
+    @Test
+    public void skal_returnere_tomt_resultat_for_fagsak_som_ikke_finnes() {
+        Optional<FagsakPipDto> resultat = pipRepository.hentPipDataOgPersonerForFagsak(new Saksnummer("9999999"));
+        assertThat(resultat).isNotPresent();
+    }
+
+    @Test
+    public void skal_hente_pipdata_og_personer_for_brukers_fagsaker() {
+        AktørId aktørId = AktørId.dummy();
+        Fagsak fagsak1 = behandlingBuilder.opprettFagsak(FagsakYtelseType.UNGDOMSYTELSE, aktørId);
+        Fagsak fagsak2 = behandlingBuilder.opprettFagsak(FagsakYtelseType.AKTIVITETSPENGER, aktørId);
+        @SuppressWarnings("unused")
+        Fagsak fagsakAnnenBruker = new BasicBehandlingBuilder(entityManager).opprettFagsak(FagsakYtelseType.UNGDOMSYTELSE);
+
+        List<FagsakPipDto> resultat = pipRepository.hentPipDataOgPersonerForBrukersFagsaker(aktørId);
+
+        assertThat(resultat).hasSize(2);
+        assertThat(resultat).extracting(FagsakPipDto::saksnummer)
+            .containsExactlyInAnyOrder(fagsak1.getSaksnummer(), fagsak2.getSaksnummer());
+        assertThat(resultat).allSatisfy(pipDto -> assertThat(pipDto.aktørIder()).contains(aktørId));
+    }
+
+    @Test
+    public void skal_returnere_tom_liste_for_bruker_uten_fagsaker() {
+        List<FagsakPipDto> resultat = pipRepository.hentPipDataOgPersonerForBrukersFagsaker(AktørId.dummy());
+        assertThat(resultat).isEmpty();
     }
 }
 

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/pip/PipRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/pip/PipRepositoryTest.java
@@ -81,7 +81,7 @@ public class PipRepositoryTest {
         @SuppressWarnings("unused")
         Fagsak fagsakAnnenAktør = new BasicBehandlingBuilder(entityManager).opprettFagsak(FagsakYtelseType.FORELDREPENGER);
 
-        Set<Saksnummer> resultat = pipRepository.saksnumreForSøker(Collections.singleton(aktørId1));
+        Set<Saksnummer> resultat = pipRepository.hentSaksnumreForBruker(Collections.singleton(aktørId1));
 
         assertThat(resultat).containsOnly(fagsak1.getSaksnummer(), fagsak2.getSaksnummer());
     }

--- a/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/abac/FagsakPipDto.java
+++ b/kontrakt/src/main/java/no/nav/ung/sak/kontrakt/abac/FagsakPipDto.java
@@ -1,0 +1,23 @@
+package no.nav.ung.sak.kontrakt.abac;
+
+
+import no.nav.ung.kodeverk.behandling.FagsakStatus;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.typer.AktørId;
+import no.nav.ung.sak.typer.Saksnummer;
+
+import java.util.Set;
+
+public record FagsakPipDto(
+    Saksnummer saksnummer,
+    Set<AktørId> aktørIder,
+    Set<AktørId> aktørIderForSporingslogg,
+    FagsakStatus fagsakStatus,
+    FagsakYtelseType ytelseType) {
+
+    public FagsakPipDto {
+        if (!aktørIder.containsAll(aktørIderForSporingslogg)) {
+            throw new IllegalArgumentException("Forventet at aktørIderForSporingslogg er et sub-set av aktørIder");
+        }
+    }
+}

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/AppPdpRequestBuilderImpl.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/AppPdpRequestBuilderImpl.java
@@ -238,7 +238,7 @@ public class AppPdpRequestBuilderImpl implements PdpRequestBuilder {
         aktørIdForSaksnummerSøk.addAll(tilAktørId(attributter.getVerdier(AppAbacAttributtType.SAKER_MED_FNR)));
         aktørIdForSaksnummerSøk.addAll(attributter.getVerdier(AppAbacAttributtType.SAKER_MED_AKTØR_ID).stream().map(it -> new AktørId((String) it)).collect(Collectors.toSet()));
 
-        saksnumre.addAll(pipRepository.saksnumreForSøker(tilAktørId(attributter.getVerdier(AppAbacAttributtType.SAKER_MED_FNR))));
+        saksnumre.addAll(pipRepository.hentSaksnumreForBruker(tilAktørId(attributter.getVerdier(AppAbacAttributtType.SAKER_MED_FNR))));
         saksnumre.addAll(pipRepository.saksnumreForJournalpostId(attributter.getVerdier(StandardAbacAttributtType.JOURNALPOST_ID)));
         return saksnumre;
     }

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/PipRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/PipRestTjeneste.java
@@ -62,7 +62,7 @@ public class PipRestTjeneste {
     @Operation(description = "Henter aktørIder, fagsakstatus, ytelsestype, saksnummer fra alle brukers saker", tags = "pip")
     @BeskyttetRessurs(action = READ, resource = BeskyttetRessursResourceType.PIP)
     @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
-    public List<FagsakPipDto> hentPipDataTilknyttetFagsak(@NotNull @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) AktørIdDto brukerAktørId) {
+    public List<FagsakPipDto> hentPipDataOgPersonerForBrukersFagsaker(@NotNull @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) AktørIdDto brukerAktørId) {
         return pipRepository.hentPipDataOgPersonerForBrukersFagsaker(new AktørId(brukerAktørId.getAktorId()));
     }
 

--- a/web/src/main/java/no/nav/ung/sak/web/server/abac/PipRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/server/abac/PipRestTjeneste.java
@@ -6,10 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursResourceType;
@@ -19,12 +16,10 @@ import no.nav.ung.kodeverk.behandling.FagsakStatus;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.sak.behandlingslager.pip.PipBehandlingsData;
 import no.nav.ung.sak.behandlingslager.pip.PipRepository;
-import no.nav.ung.sak.kontrakt.abac.PipAktørerMedSporingslogghintDto;
-import no.nav.ung.sak.kontrakt.abac.PipAktørerMedSporingslogghintDtoV2;
-import no.nav.ung.sak.kontrakt.abac.PipDtoV5;
-import no.nav.ung.sak.kontrakt.abac.PipDtoV6;
+import no.nav.ung.sak.kontrakt.abac.*;
 import no.nav.ung.sak.kontrakt.behandling.BehandlingIdDto;
 import no.nav.ung.sak.kontrakt.behandling.SaksnummerDto;
+import no.nav.ung.sak.kontrakt.person.AktørIdDto;
 import no.nav.ung.sak.typer.AktørId;
 import no.nav.ung.sak.typer.Saksnummer;
 import org.slf4j.Logger;
@@ -42,8 +37,6 @@ import static no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionType.READ;
 @Produces(MediaType.APPLICATION_JSON)
 public class PipRestTjeneste {
 
-    private Logger logger = LoggerFactory.getLogger(PipRestTjeneste.class);
-
     private PipRepository pipRepository;
 
     @Inject
@@ -53,6 +46,24 @@ public class PipRestTjeneste {
 
     public PipRestTjeneste() {
         // Ja gjett tre ganger på hva denne er til for.
+    }
+
+    @GET
+    @Path("/pipdata-for-fagsak")
+    @Operation(description = "Henter aktørIder, fagsakstatus, ytelsestype tilknyttet fra et saksnummer", tags = "pip")
+    @BeskyttetRessurs(action = READ, resource = BeskyttetRessursResourceType.PIP)
+    @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
+    public Optional<FagsakPipDto> hentPipDataTilknyttetFagsak(@NotNull @QueryParam("saksnummer") @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) SaksnummerDto saksnummerDto) {
+        return pipRepository.hentPipDataOgPersonerForFagsak(saksnummerDto.getVerdi());
+    }
+
+    @POST
+    @Path("/pipdata-for-brukers-fagsaker")
+    @Operation(description = "Henter aktørIder, fagsakstatus, ytelsestype, saksnummer fra alle brukers saker", tags = "pip")
+    @BeskyttetRessurs(action = READ, resource = BeskyttetRessursResourceType.PIP)
+    @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
+    public List<FagsakPipDto> hentPipDataTilknyttetFagsak(@NotNull @Valid @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) AktørIdDto brukerAktørId) {
+        return pipRepository.hentPipDataOgPersonerForBrukersFagsaker(new AktørId(brukerAktørId.getAktorId()));
     }
 
     @GET

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -1682,6 +1682,34 @@
         "required" : [ "systemNavn" ],
         "type" : "object"
       },
+      "ung.sak.kontrakt.abac.FagsakPipDto" : {
+        "properties" : {
+          "aktørIder" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "aktørIderForSporingslogg" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "fagsakStatus" : {
+            "$ref" : "#/components/schemas/ung.kodeverk.behandling.FagsakStatus"
+          },
+          "saksnummer" : {
+            "type" : "string"
+          },
+          "ytelseType" : {
+            "$ref" : "#/components/schemas/ung.kodeverk.behandling.FagsakYtelseType"
+          }
+        },
+        "type" : "object"
+      },
       "ung.sak.kontrakt.abac.PipAktørerMedSporingslogghintDto" : {
         "properties" : {
           "aktørIderForSporingslogg" : {
@@ -9531,6 +9559,68 @@
                 "schema" : {
                   "allOf" : [ {
                     "$ref" : "#/components/schemas/ung.sak.kontrakt.abac.PipDtoV6"
+                  } ],
+                  "nullable" : true
+                }
+              }
+            },
+            "description" : "default response"
+          }
+        },
+        "tags" : [ "pip" ]
+      }
+    },
+    "/api/pip/pipdata-for-brukers-fagsaker" : {
+      "post" : {
+        "description" : "Henter aktørIder, fagsakstatus, ytelsestype, saksnummer fra alle brukers saker",
+        "operationId" : "hentPipDataTilknyttetFagsak_1",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ung.sak.kontrakt.person.AktørIdDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/ung.sak.kontrakt.abac.FagsakPipDto"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "default response"
+          }
+        },
+        "tags" : [ "pip" ]
+      }
+    },
+    "/api/pip/pipdata-for-fagsak" : {
+      "get" : {
+        "description" : "Henter aktørIder, fagsakstatus, ytelsestype tilknyttet fra et saksnummer",
+        "operationId" : "hentPipDataTilknyttetFagsak",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "saksnummer",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/ung.sak.kontrakt.behandling.SaksnummerDto"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "allOf" : [ {
+                    "$ref" : "#/components/schemas/ung.sak.kontrakt.abac.FagsakPipDto"
                   } ],
                   "nullable" : true
                 }

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -9573,7 +9573,7 @@
     "/api/pip/pipdata-for-brukers-fagsaker" : {
       "post" : {
         "description" : "Henter aktørIder, fagsakstatus, ytelsestype, saksnummer fra alle brukers saker",
-        "operationId" : "hentPipDataTilknyttetFagsak_1",
+        "operationId" : "hentPipDataOgPersonerForBrukersFagsaker",
         "requestBody" : {
           "content" : {
             "*/*" : {

--- a/web/src/test/java/no/nav/ung/sak/web/server/abac/PdpRequestBuilderTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/server/abac/PdpRequestBuilderTest.java
@@ -96,7 +96,7 @@ public class PdpRequestBuilderTest {
         Set<Saksnummer> saksnumre = new HashSet<>();
         saksnumre.add(SAKSNUMMER_1);
         saksnumre.add(SAKSNUMMER_2);
-        when(pipRepository.saksnumreForSøker(any())).thenReturn(saksnumre);
+        when(pipRepository.hentSaksnumreForBruker(any())).thenReturn(saksnumre);
         Set<AktørId> aktører = new HashSet<>();
         aktører.add(AKTØR_0);
         aktører.add(AKTØR_1);


### PR DESCRIPTION
### Behov / Bakgrunn

Siden det er ulik tilgangskontroll for UNG vs aktivitetspenger, trenger PDP-en å vite hvilken ytelse en sak gjelder, og da må det slås opp i ung-sak.

### Løsning

Legger til nye endepunkt i PIP-tjenesten i ung-sak for å tilby ytelsestype og personer på samme endepunkt. Tilbyr ogå fagsakstatus, siden det kommer til å trengs senere for å støtte tilgang til historiske saker

Legger også til endepunkt for å hente alle brukers saker, det gjør at PDP kan kalle en gang ved søk etter saker

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
