### PR TITLE
Revert "TSFF-2654 - Lanserer varsling av opphør ved maksdato. (#1455)"

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -278,6 +278,8 @@ spec:
       value: "true"
     - name: AKTIVITETSPENGER_ENABLED
       value: "true"
+    - name: VARSEL_OPPHOR_VED_MAKSDATO_ENABLED
+      value: "true"
 
       # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/deploy/prod-gcp.yml
+++ b/deploy/prod-gcp.yml
@@ -272,6 +272,8 @@ spec:
       value: "false"
     - name: PROGRAMPERIODE_ENDRING_ENABLED
       value: "false"
+    - name: VARSEL_OPPHOR_VED_MAKSDATO_ENABLED
+      value: "false"
 
     # Konfigurasjoner
     - name: FLYWAY_REPAIR_ON_FAIL

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoBatchTask.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/revurdering/varselopphorvedmaksdato/VarselOpphørVedMaksdatoBatchTask.java
@@ -2,11 +2,14 @@ package no.nav.ung.ytelse.ungdomsprogramytelsen.revurdering.varselopphorvedmaksd
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
 import no.nav.k9.prosesstask.api.ProsessTask;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
 import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.k9.prosesstask.api.TaskType;
 import no.nav.k9.prosesstask.impl.cron.CronExpression;
 import no.nav.ung.sak.behandling.prosessering.DuplikatbeskyttetBatchTask;
+import no.nav.ung.sak.behandling.revurdering.sats.OpprettRevurderingHøySatsTask;
 
 /**
  * Batchtask som varsler deltakere om opphør ved maksdato 3 uker før maksdato.
@@ -19,18 +22,27 @@ public class VarselOpphørVedMaksdatoBatchTask extends DuplikatbeskyttetBatchTas
 
     public static final String TASKNAME = "batch.varselOpphorVedMaksdato";
 
+    private boolean varselOpphørVedMaksdatoEnabled;
+
     VarselOpphørVedMaksdatoBatchTask() {
         // for CDI proxy
     }
 
     @Inject
-    public VarselOpphørVedMaksdatoBatchTask(ProsessTaskTjeneste prosessTaskTjeneste) {
+    public VarselOpphørVedMaksdatoBatchTask(ProsessTaskTjeneste prosessTaskTjeneste,
+                                            @KonfigVerdi(value = "VARSEL_OPPHOR_VED_MAKSDATO_ENABLED", required = false, defaultVerdi = "false") boolean varselOpphørVedMaksdatoEnabled) {
         super(prosessTaskTjeneste);
+        this.varselOpphørVedMaksdatoEnabled = varselOpphørVedMaksdatoEnabled;
     }
 
     @Override
     protected TaskType getTaskType() {
         return new TaskType(VarselOpphørVedMaksdatoTask.TASKNAME);
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return varselOpphørVedMaksdatoEnabled;
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 0133808abf556abeaf441b8e85d84eb1e22c5e56.

### Behov / Bakgrunn

Det fungerer ikke som det skal i prod, det går ut varsel for personer som ikke skal ha varsel

### Løsning


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
