### PR TITLE
TSFF-2756: Markere innteksrapportering også som ugyldig

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -80,6 +80,10 @@ public class ForvaltningMottattDokumentRestTjeneste {
         JournalpostId journalpostId = dto.journalpostId.getJournalpostId();
         List<MottattDokument> mottattDokuments = mottatteDokumentRepository.hentMottatteDokument(fagsakId, List.of(journalpostId));
 
+        if (mottattDokuments.isEmpty()) {
+            throw new IllegalArgumentException("Fant ingen dokumenter");
+        }
+
         if (mottattDokuments.size() > 1) {
             throw new IllegalArgumentException("Forventet maks 1 dokument");
         }
@@ -99,7 +103,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
         }
 
 
-        String formatertBegrunnelse = "Manuelt markert som ugyldig. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
+        String formatertBegrunnelse = "Markert som ugyldig av teknisk forvaltning. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
         mottattDokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
         mottatteDokumentRepository.oppdater(mottattDokument);
 
@@ -114,6 +118,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
     public record MarkerDokumentUgyldigRequest(
         @Valid
         @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class)
+        @NotNull
         JournalpostId journalpostId,
 
         @StandardAbacAttributt(StandardAbacAttributtType.SAKSNUMMER)

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.ung.sak.web.app.tjenester.forvaltning;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -29,6 +30,8 @@ import no.nav.ung.sak.typer.Saksnummer;
 import no.nav.ung.sak.web.app.tjenester.forvaltning.dump.logg.DiagnostikkFagsakLogg;
 import no.nav.ung.sak.web.server.abac.AbacAttributtEmptySupplier;
 import no.nav.ung.sak.web.server.abac.AbacAttributtSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Set;
@@ -45,6 +48,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
         Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE,
         Brevkode.UNGDOMSYTELSE_INNTEKTRAPPORTERING
     );
+    private static final Logger log = LoggerFactory.getLogger(ForvaltningMottattDokumentRestTjeneste.class);
 
     private FagsakRepository fagsakRepository;
     private MottatteDokumentRepository mottatteDokumentRepository;
@@ -70,7 +74,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
     @Produces(JSON_UTF8)
     @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
     public Response markerMottattDokumentUgyldig(@Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) MarkerDokumentUgyldigRequest dto) {
-        Fagsak fagsak = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer.getVerdi())
+        Fagsak fagsak = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer)
             .orElseThrow(() -> new IllegalArgumentException("Fant ikke fagsak for saksnummer: " + dto.saksnummer.getVerdi()));
         Long fagsakId = fagsak.getId();
         JournalpostId journalpostId = dto.journalpostId.getJournalpostId();
@@ -94,12 +98,15 @@ public class ForvaltningMottattDokumentRestTjeneste {
                 .build();
         }
 
+
         String formatertBegrunnelse = "Manuelt markert som ugyldig. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
         mottattDokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
         mottatteDokumentRepository.oppdater(mottattDokument);
 
         entityManager.persist(new DiagnostikkFagsakLogg(fagsakId, "/marker-ugyldig", formatertBegrunnelse));
         entityManager.flush();
+
+        log.info("Manuelt markert mottatt dokument med journalpostId={} av type {} som ugyldig.", mottattDokument.getJournalpostId().getVerdi(), mottattDokument.getType());
 
         return Response.ok().build();
     }
@@ -109,22 +116,17 @@ public class ForvaltningMottattDokumentRestTjeneste {
         @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class)
         JournalpostId journalpostId,
 
+        @StandardAbacAttributt(StandardAbacAttributtType.SAKSNUMMER)
+        @JsonProperty(value = SaksnummerDto.NAME, required = true)
         @NotNull
         @Valid
-        @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class)
-        SaksnummerDto saksnummer,
+        Saksnummer saksnummer,
 
         @NotNull
         @Valid
         @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class)
         KortTekst begrunnelse
-    ) {
-        @StandardAbacAttributt(StandardAbacAttributtType.SAKSNUMMER)
-        public Saksnummer getSaksnummer() {
-            return saksnummer.getVerdi();
-        }
-
-    }
+    ) {}
 
 
 }

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -115,6 +115,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
         SaksnummerDto saksnummer,
 
         @NotNull
+        @Valid
         @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class)
         KortTekst begrunnelse
     ) {

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -21,7 +21,6 @@ import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.dokument.DokumentStatus;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
-import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.kontrakt.KortTekst;
 import no.nav.ung.sak.kontrakt.behandling.SaksnummerDto;
@@ -74,25 +73,33 @@ public class ForvaltningMottattDokumentRestTjeneste {
     @Produces(JSON_UTF8)
     @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
     public Response markerMottattDokumentUgyldig(@Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) MarkerDokumentUgyldigRequest dto) {
-        Fagsak fagsak = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer)
-            .orElseThrow(() -> new IllegalArgumentException("Fant ikke fagsak for saksnummer: " + dto.saksnummer.getVerdi()));
-        Long fagsakId = fagsak.getId();
-        JournalpostId journalpostId = dto.journalpostId.getJournalpostId();
+        var fagsakOpt = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer());
+        if (fagsakOpt.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity("Fant ikke fagsak for saksnummer: " + dto.saksnummer().getVerdi())
+                .build();
+        }
+        Long fagsakId = fagsakOpt.get().getId();
+        JournalpostId journalpostId = dto.journalpostId().getJournalpostId();
         List<MottattDokument> mottattDokuments = mottatteDokumentRepository.hentMottatteDokument(fagsakId, List.of(journalpostId));
 
         if (mottattDokuments.isEmpty()) {
-            throw new IllegalArgumentException("Fant ingen dokumenter");
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity("Fant ingen dokumenter for saksnummer " + dto.saksnummer().getVerdi() + " og journalpostId " + journalpostId.getVerdi())
+                .build();
         }
 
         if (mottattDokuments.size() > 1) {
-            throw new IllegalArgumentException("Forventet maks 1 dokument");
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Forventet maks 1 dokument, men fant " + mottattDokuments.size())
+                .build();
         }
 
         MottattDokument mottattDokument = mottattDokuments.getFirst();
 
         if (!TILLATTE_BREVKODER.contains(mottattDokument.getType())) {
             return Response.status(Response.Status.BAD_REQUEST)
-                .entity("Forventet en av brevkodene " + TILLATTE_BREVKODER + ", men dokumentet har: " + mottattDokument.getType())
+                .entity("Dokumentet har brevkode " + mottattDokument.getType() + ", bare dokumenter med brevkodene " + TILLATTE_BREVKODER + " kan settes ugyldige")
                 .build();
         }
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -22,29 +22,32 @@ import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.kontrakt.KortTekst;
 import no.nav.ung.sak.kontrakt.behandling.SaksnummerDto;
-import no.nav.ung.sak.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
 import no.nav.ung.sak.web.app.tjenester.forvaltning.dump.logg.DiagnostikkFagsakLogg;
+import no.nav.ung.sak.web.server.abac.AbacAttributtEmptySupplier;
 import no.nav.ung.sak.web.server.abac.AbacAttributtSupplier;
 
 import java.util.List;
+import java.util.Set;
 
 
-/**
- * DENNE TJENESTEN ER BARE FOR MIDLERTIDIG BEHOV FOR TSFF-2756, OG SKAL AVVIKLES SÅ RASKT SOM MULIG.
- */
-@Path("/TSFF-2756/forvaltning")
+@Path("/forvaltning")
 @ApplicationScoped
 @Transactional
 public class ForvaltningMottattDokumentRestTjeneste {
 
     private static final String JSON_UTF8 = "application/json; charset=UTF-8";
 
+    private static final Set<Brevkode> TILLATTE_BREVKODER = Set.of(
+        Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE,
+        Brevkode.UNGDOMSYTELSE_INNTEKTRAPPORTERING
+    );
+
     private FagsakRepository fagsakRepository;
     private MottatteDokumentRepository mottatteDokumentRepository;
-    private MottatteDokumentTjeneste mottatteDokumentTjeneste;
     private EntityManager entityManager;
 
     public ForvaltningMottattDokumentRestTjeneste() {
@@ -54,21 +57,19 @@ public class ForvaltningMottattDokumentRestTjeneste {
     @Inject
     public ForvaltningMottattDokumentRestTjeneste(FagsakRepository fagsakRepository,
                                                   MottatteDokumentRepository mottatteDokumentRepository,
-                                                  MottatteDokumentTjeneste mottatteDokumentTjeneste,
                                                   EntityManager entityManager) {
         this.fagsakRepository = fagsakRepository;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
-        this.mottatteDokumentTjeneste = mottatteDokumentTjeneste;
         this.entityManager = entityManager;
     }
 
     @POST
-    @Path("ugyldigjor-mottatt-dokument")
+    @Path("/marker-ugyldig")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(description = "ugyldiggjør mottatt dokument ifm TSFF-2756", summary = ("ugyldiggjør mottatt dokument ifm TSFF-2756"), tags = "forvaltning")
+    @Operation(description = "Markerer et mottatt dokument som ugyldig", summary = ("Markerer angitt dokument som ugyldig"), tags = "forvaltning")
     @Produces(JSON_UTF8)
     @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
-    public Response ugyldigjorMottattDokument(@Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) UgyldigjorMottattDokumentRequest dto) {
+    public Response markerMottattDokumentUgyldig(@Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) MarkerDokumentUgyldigRequest dto) {
         Fagsak fagsak = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer.getVerdi())
             .orElseThrow(() -> new IllegalArgumentException("Fant ikke fagsak for saksnummer: " + dto.saksnummer.getVerdi()));
         Long fagsakId = fagsak.getId();
@@ -81,9 +82,9 @@ public class ForvaltningMottattDokumentRestTjeneste {
 
         MottattDokument mottattDokument = mottattDokuments.getFirst();
 
-        if (!Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE.equals(mottattDokument.getType())) {
+        if (!TILLATTE_BREVKODER.contains(mottattDokument.getType())) {
             return Response.status(Response.Status.BAD_REQUEST)
-                .entity("Forventet brevkode " + Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE + ", men dokumentet har: " + mottattDokument.getType())
+                .entity("Forventet en av brevkodene " + TILLATTE_BREVKODER + ", men dokumentet har: " + mottattDokument.getType())
                 .build();
         }
 
@@ -93,20 +94,17 @@ public class ForvaltningMottattDokumentRestTjeneste {
                 .build();
         }
 
-        mottattDokument.setFeilmeldingOgOppdaterStatus("Ugyldiggjort manuelt ifm TSFF-2756");
+        String formatertBegrunnelse = "Manuelt markert som ugyldig. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
+        mottattDokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
         mottatteDokumentRepository.oppdater(mottattDokument);
 
-        entityManager.persist(new DiagnostikkFagsakLogg(
-            fagsakId,
-            "ForvaltningMottattDokumentRestTjeneste.ugyldigjorMottattDokument (midlertidig)",
-            "Patching ifm TSFF-2756. Satt mottatt dokument for journalpost=%s til UGYLDIG."
-                .formatted(journalpostId.getVerdi())
-        ));
+        entityManager.persist(new DiagnostikkFagsakLogg(fagsakId, "/marker-ugyldig", formatertBegrunnelse));
+        entityManager.flush();
 
         return Response.ok().build();
     }
 
-    public record UgyldigjorMottattDokumentRequest(
+    public record MarkerDokumentUgyldigRequest(
         @Valid
         @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class)
         JournalpostId journalpostId,
@@ -114,7 +112,11 @@ public class ForvaltningMottattDokumentRestTjeneste {
         @NotNull
         @Valid
         @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class)
-        SaksnummerDto saksnummer
+        SaksnummerDto saksnummer,
+
+        @NotNull
+        @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class)
+        KortTekst begrunnelse
     ) {
         @StandardAbacAttributt(StandardAbacAttributtType.SAKSNUMMER)
         public Saksnummer getSaksnummer() {

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -5685,8 +5685,11 @@
         },
         "type" : "object"
       },
-      "ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.UgyldigjorMottattDokumentRequest" : {
+      "ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest" : {
         "properties" : {
+          "begrunnelse" : {
+            "type" : "string"
+          },
           "journalpostId" : {
             "type" : "string"
           },
@@ -5694,7 +5697,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "saksnummer" ],
+        "required" : [ "begrunnelse", "saksnummer" ],
         "type" : "object"
       },
       "ung.sak.web.app.tjenester.forvaltning.ForvaltningStatistikkRestTjeneste.AntallDeltakereStatistikk" : {
@@ -6195,32 +6198,6 @@
           }
         },
         "tags" : [ "redirect" ]
-      }
-    },
-    "/api/TSFF-2756/forvaltning/ugyldigjor-mottatt-dokument" : {
-      "post" : {
-        "description" : "ugyldiggjør mottatt dokument ifm TSFF-2756",
-        "operationId" : "ugyldigjorMottattDokument",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.UgyldigjorMottattDokumentRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "default" : {
-            "content" : {
-              "application/json; charset=UTF-8" : { }
-            },
-            "description" : "default response"
-          }
-        },
-        "summary" : "ugyldiggjør mottatt dokument ifm TSFF-2756",
-        "tags" : [ "forvaltning" ]
       }
     },
     "/api/aksjonspunkt" : {
@@ -8518,6 +8495,32 @@
           }
         },
         "tags" : [ "formidling" ]
+      }
+    },
+    "/api/forvaltning/marker-ugyldig" : {
+      "post" : {
+        "description" : "Markerer et mottatt dokument som ugyldig",
+        "operationId" : "markerMottattDokumentUgyldig",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json; charset=UTF-8" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Markerer angitt dokument som ugyldig",
+        "tags" : [ "forvaltning" ]
       }
     },
     "/api/forvaltning/person/finnAktørerKobletTilSammeSakSomAktør" : {

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -5697,7 +5697,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "begrunnelse", "saksnummer" ],
+        "required" : [ "begrunnelse", "journalpostId", "saksnummer" ],
         "type" : "object"
       },
       "ung.sak.web.app.tjenester.forvaltning.ForvaltningStatistikkRestTjeneste.AntallDeltakereStatistikk" : {

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -15,8 +15,8 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.kontrakt.KortTekst;
 import no.nav.ung.sak.kontrakt.behandling.SaksnummerDto;
-import no.nav.ung.sak.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
@@ -34,7 +34,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
 
     private static final String JOURNALPOST_ID = "999001";
     private static final Saksnummer SAKSNUMMER = new Saksnummer("123456789");
-    private static final String FEILMELDING = "Ugyldiggjort manuelt ifm TSFF-2756";
+    private static final String FEILMELDING = "Jira sak: ABCD-1234";
 
     @Inject
     private EntityManager entityManager;
@@ -42,7 +42,6 @@ class ForvaltningMottattDokumentRestTjenesteTest {
     private MottatteDokumentRepository mottatteDokumentRepository;
     private BehandlingRepository behandlingRepository;
     private FagsakRepository fagsakRepository;
-    private MottatteDokumentTjeneste mottatteDokumentTjeneste;
     private ForvaltningMottattDokumentRestTjeneste tjeneste;
 
     private final Fagsak fagsak = FagsakBuilder.nyFagsak(FagsakYtelseType.UNGDOMSYTELSE).medSaksnummer(SAKSNUMMER).build();
@@ -53,12 +52,10 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         mottatteDokumentRepository = new MottatteDokumentRepository(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
         fagsakRepository = new FagsakRepository(entityManager);
-        mottatteDokumentTjeneste = new MottatteDokumentTjeneste(mottatteDokumentRepository);
 
         tjeneste = new ForvaltningMottattDokumentRestTjeneste(
             fagsakRepository,
             mottatteDokumentRepository,
-            mottatteDokumentTjeneste,
             entityManager
         );
 
@@ -77,7 +74,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         var request = lagRequest();
 
         // Act
-        Response response = tjeneste.ugyldigjorMottattDokument(request);
+        Response response = tjeneste.markerMottattDokumentUgyldig(request);
 
         // Assert
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
@@ -87,7 +84,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
 
         var oppdatert = mottatteDokumentRepository.hentMottattDokument(dokumentId).orElseThrow();
         assertThat(oppdatert.getStatus()).isEqualTo(DokumentStatus.UGYLDIG);
-        assertThat(oppdatert.getFeilmelding()).isEqualTo(FEILMELDING);
+        assertThat(oppdatert.getFeilmelding()).isEqualTo("Manuelt markert som ugyldig. Begrunnelse: " + FEILMELDING);
 
         Long antallDiagnostikk = entityManager.createQuery(
                 "select count(d) from DiagnostikkFagsakLogg d where d.fagsakId = :fagsakId", Long.class)
@@ -97,11 +94,39 @@ class ForvaltningMottattDokumentRestTjenesteTest {
     }
 
     @Test
+    void skal_sette_inntektrapportering_dokument_til_ugyldig() {
+        // Arrange
+        var dokument = new MottattDokument.Builder()
+            .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
+            .medType(Brevkode.UNGDOMSYTELSE_INNTEKTRAPPORTERING)
+            .medMottattDato(LocalDate.now())
+            .medFagsakId(fagsak.getId())
+            .medBehandlingId(behandling.getId())
+            .build();
+        var dokumentId = mottatteDokumentRepository.lagre(dokument, DokumentStatus.MOTTATT).getId();
+
+        var request = lagRequest();
+
+        // Act
+        Response response = tjeneste.markerMottattDokumentUgyldig(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        var oppdatert = mottatteDokumentRepository.hentMottattDokument(dokumentId).orElseThrow();
+        assertThat(oppdatert.getStatus()).isEqualTo(DokumentStatus.UGYLDIG);
+        assertThat(oppdatert.getFeilmelding()).isEqualTo("Manuelt markert som ugyldig. Begrunnelse: " + FEILMELDING);
+    }
+
+    @Test
     void skal_returnere_400_naar_brevkode_er_feil() {
         // Arrange
         var feilBrevkodeDokument = new MottattDokument.Builder()
             .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
-            .medType(Brevkode.UNGDOMSYTELSE_INNTEKTRAPPORTERING)
+            .medType(Brevkode.UNGDOMSYTELSE_SOKNAD)
             .medMottattDato(LocalDate.now())
             .medFagsakId(fagsak.getId())
             .medBehandlingId(behandling.getId())
@@ -111,7 +136,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         var request = lagRequest();
 
         // Act
-        Response response = tjeneste.ugyldigjorMottattDokument(request);
+        Response response = tjeneste.markerMottattDokumentUgyldig(request);
 
         // Assert
         assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
@@ -132,7 +157,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         var request = lagRequest();
 
         // Act
-        Response response = tjeneste.ugyldigjorMottattDokument(request);
+        Response response = tjeneste.markerMottattDokumentUgyldig(request);
 
         // Assert
         assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
@@ -151,12 +176,13 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         return mottatteDokumentRepository.lagre(dokument, DokumentStatus.MOTTATT).getId();
     }
 
-    private ForvaltningMottattDokumentRestTjeneste.UgyldigjorMottattDokumentRequest lagRequest() {
+    private ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest lagRequest() {
         var journalpostIdDto = new JournalpostId(JOURNALPOST_ID);
 
-        return new ForvaltningMottattDokumentRestTjeneste.UgyldigjorMottattDokumentRequest(
+        return new ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest(
             journalpostIdDto,
-            new SaksnummerDto(SAKSNUMMER)
+            new SaksnummerDto(SAKSNUMMER),
+            new KortTekst(FEILMELDING)
         );
     }
 }

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -16,7 +16,6 @@ import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
 import no.nav.ung.sak.kontrakt.KortTekst;
-import no.nav.ung.sak.kontrakt.behandling.SaksnummerDto;
 import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
@@ -181,7 +180,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
 
         return new ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest(
             journalpostIdDto,
-            new SaksnummerDto(SAKSNUMMER),
+            SAKSNUMMER,
             new KortTekst(FEILMELDING)
         );
     }

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -83,7 +83,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
 
         var oppdatert = mottatteDokumentRepository.hentMottattDokument(dokumentId).orElseThrow();
         assertThat(oppdatert.getStatus()).isEqualTo(DokumentStatus.UGYLDIG);
-        assertThat(oppdatert.getFeilmelding()).isEqualTo("Manuelt markert som ugyldig. Begrunnelse: " + FEILMELDING);
+        assertThat(oppdatert.getFeilmelding()).isEqualTo("Markert som ugyldig av teknisk forvaltning. Begrunnelse: " + FEILMELDING);
 
         Long antallDiagnostikk = entityManager.createQuery(
                 "select count(d) from DiagnostikkFagsakLogg d where d.fagsakId = :fagsakId", Long.class)
@@ -117,7 +117,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
 
         var oppdatert = mottatteDokumentRepository.hentMottattDokument(dokumentId).orElseThrow();
         assertThat(oppdatert.getStatus()).isEqualTo(DokumentStatus.UGYLDIG);
-        assertThat(oppdatert.getFeilmelding()).isEqualTo("Manuelt markert som ugyldig. Begrunnelse: " + FEILMELDING);
+        assertThat(oppdatert.getFeilmelding()).isEqualTo("Markert som ugyldig av teknisk forvaltning. Begrunnelse: " + FEILMELDING);
     }
 
     @Test


### PR DESCRIPTION
### Behov / Bakgrunn
01.07.2026 ble laget oppgave om rapportering av inntekt som bruker svarte på. Dette dokumentet blokkert av tidligere feilede uttalelse. 08.07.2026 fullførte behandlingen uten rapporteringen med ingen inntekt. Da bruker også forsøkte å rapportere ingen inntekt så ble resultatet riktig. Det nye dokumentet kan derfor ignoreres slik at det ikke sperrer for fremtidige dokumenter.  

### Løsning
Åpnet opp for markere inntektsrapportering som ugyldig. 

### Andre endringer
Omgjort driftendepunktet til å ikke være midlertidig lenger da dette er også støttet i k9-sak og vil antageligvis bli behov for i fremtidien. 

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
