### PR TITLE
fix: ignorer opphevet-hendelse når opphørsdato er etter eller lik maksdato.

### DIFF
--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørOpphevetFagsakTilVurderingUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørOpphevetFagsakTilVurderingUtleder.java
@@ -76,7 +76,7 @@ public class UngdomsprogramOpphørOpphevetFagsakTilVurderingUtleder implements F
             Saksnummer saksnummer = relevantFagsak.get().getSaksnummer();
             Optional<Behandling> behandlingOpt = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(relevantFagsak.get().getId());
             if (behandlingOpt.isEmpty()) {
-                logger.info("Det er ingen behandling på sak {}. Ignorerer hendelse {}.", saksnummer, hendelseId);
+                logger.info("Det er ingen behandling på sak {} (fagsakId={}). Ignorerer hendelse {}.", saksnummer, relevantFagsak.get().getId(), hendelseId);
                 continue;
             }
 
@@ -86,7 +86,16 @@ public class UngdomsprogramOpphørOpphevetFagsakTilVurderingUtleder implements F
                 continue;
             }
 
-            var periode = utledPeriode(relevantFagsak.get(), sisteBehandling, tidligereOpphørsdato);
+            var maksDato = ungdomsprogramPeriodeTjeneste.finnPeriodeMaksDato(sisteBehandling.getId())
+                .orElseThrow(() -> new IllegalStateException("Fant ikke periodeMaksDato for behandling %s på sak %s. Kan ikke utlede periode for opphevelse av opphør."
+                    .formatted(sisteBehandling.getId(), saksnummer)));
+            if (!maksDato.isAfter(tidligereOpphørsdato)) {
+                logger.info("PeriodeMaksDato ({}) er ikke etter tidligere opphørsdato ({}) for sak {} (behandling {}) — det er ingen periode å gjenåpne. Ignorerer hendelse {}.",
+                    maksDato, tidligereOpphørsdato, saksnummer, sisteBehandling.getId(), hendelseId);
+                continue;
+            }
+
+            var periode = utledPeriode(tidligereOpphørsdato, maksDato);
             logger.info("Oppretter revurdering for sak {} grunnet opphevelse av opphør fra hendelse {} med tidligere opphørsdato {}.", saksnummer, hendelseId, tidligereOpphørsdato);
             fagsaker.put(relevantFagsak.get(), List.of(new ÅrsakOgPerioder(BehandlingÅrsakType.RE_HENDELSE_OPPHØR_OPPHEVET_UNGDOMSPROGRAM, periode)));
         }
@@ -114,14 +123,10 @@ public class UngdomsprogramOpphørOpphevetFagsakTilVurderingUtleder implements F
 
     /**
      * Perioden som blir gjenåpnet strekker seg fra dagen etter den tidligere opphørsdatoen og frem til
-     * (uendret) periodeMaksDato. periodeMaksDato er kilde til sannhet og forventes alltid å finnes i
-     * grunnlaget på dette tidspunktet — mangler den, er det en feiltilstand som skal feile hardt fremfor
-     * å falle tilbake til en potensielt feil verdi.
+     * (uendret) periodeMaksDato. Kalles kun når maksDato.isAfter(tidligereOpphørsdato) er bekreftet av
+     * kalleren; IllegalStateException her er en ren defensiv backstop.
      */
-    private DatoIntervallEntitet utledPeriode(Fagsak fagsak, Behandling behandling, LocalDate tidligereOpphørsdato) {
-        var tom = ungdomsprogramPeriodeTjeneste.finnPeriodeMaksDato(behandling.getId())
-            .orElseThrow(() -> new IllegalStateException("Fant ikke periodeMaksDato for behandling %s på sak %s. Kan ikke utlede periode for opphevelse av opphør."
-                .formatted(behandling.getUuid(), fagsak.getSaksnummer())));
+    private DatoIntervallEntitet utledPeriode(LocalDate tidligereOpphørsdato, LocalDate tom) {
         if (!tom.isAfter(tidligereOpphørsdato)) {
             throw new IllegalStateException("Maksdato/tom (%s) er ikke etter tidligere opphørsdato (%s) — hendelsen burde ha blitt ignorert."
                 .formatted(tom, tidligereOpphørsdato));

--- a/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørOpphevetFagsakTilVurderingUtlederTest.java
+++ b/ytelse-ungdomsprogramytelsen/src/test/java/no/nav/ung/ytelse/ungdomsprogramytelsen/hendelsehåndtering/UngdomsprogramOpphørOpphevetFagsakTilVurderingUtlederTest.java
@@ -76,6 +76,20 @@ class UngdomsprogramOpphørOpphevetFagsakTilVurderingUtlederTest {
     }
 
     @Test
+    void skal_kaste_exception_dersom_periodemaksdato_mangler() {
+        var behandling = scenarioBuilder.lagre(entityManager);
+        scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
+        // Ingen periodegrunnlag lagret -> finnPeriodeMaksDato returnerer empty -> feiltilstand
+        behandling.avsluttBehandling();
+
+        var hendelse = lagHendelse(BRUKER_AKTØR_ID, TIDLIGERE_OPPHØRSDATO);
+
+        assertThatThrownBy(() -> utleder.finnFagsakerTilVurdering(hendelse))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("periodeMaksDato");
+    }
+
+    @Test
     void skal_ikke_returnere_årsak_dersom_perioden_allerede_er_gjenåpnet() {
         var behandling = scenarioBuilder.lagre(entityManager);
         scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
@@ -113,10 +127,10 @@ class UngdomsprogramOpphørOpphevetFagsakTilVurderingUtlederTest {
     }
 
     @Test
-    void skal_kaste_exception_dersom_maksdato_ikke_er_etter_tidligere_opphørsdato() {
+    void skal_ignorere_hendelse_dersom_maksdato_ikke_er_etter_tidligere_opphørsdato() {
         var behandling = scenarioBuilder.lagre(entityManager);
         scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
-        // periodeMaksDato er (feilaktig) ikke etter tidligere opphørsdato -- hendelsen burde vært ignorert av kilden
+        // periodeMaksDato er lik opphørsdato — opphøret er allerede ved maksdato, ingenting å gjenåpne
         ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
             List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, TIDLIGERE_OPPHØRSDATO))),
             false,
@@ -125,9 +139,27 @@ class UngdomsprogramOpphørOpphevetFagsakTilVurderingUtlederTest {
         behandling.avsluttBehandling();
 
         var hendelse = lagHendelse(BRUKER_AKTØR_ID, TIDLIGERE_OPPHØRSDATO);
+        var resultat = utleder.finnFagsakerTilVurdering(hendelse);
 
-        assertThatThrownBy(() -> utleder.finnFagsakerTilVurdering(hendelse))
-            .isInstanceOf(IllegalStateException.class);
+        assertThat(resultat.isEmpty()).isTrue();
+    }
+
+    @Test
+    void skal_ignorere_hendelse_dersom_maksdato_er_før_tidligere_opphørsdato() {
+        var behandling = scenarioBuilder.lagre(entityManager);
+        scenarioBuilder.lagreFagsak(behandlingRepositoryProvider);
+        // periodeMaksDato er før opphørsdato — opphøret peker forbi maksdato, ingenting å gjenåpne
+        ungdomsprogramPeriodeRepository.lagre(behandling.getId(),
+            List.of(new UngdomsprogramPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(STP, TIDLIGERE_OPPHØRSDATO))),
+            false,
+            TIDLIGERE_OPPHØRSDATO.minusDays(1));
+
+        behandling.avsluttBehandling();
+
+        var hendelse = lagHendelse(BRUKER_AKTØR_ID, TIDLIGERE_OPPHØRSDATO);
+        var resultat = utleder.finnFagsakerTilVurdering(hendelse);
+
+        assertThat(resultat.isEmpty()).isTrue();
     }
 
     private static UngdomsprogramOpphørOpphevetHendelse lagHendelse(AktørId aktørId, LocalDate tidligereOpphørsdato) {


### PR DESCRIPTION
### Behov / Bakgrunn

`UNGDOMSPROGRAM_OPPHØR_OPPHEVET`-hendelsen kastet `IllegalStateException` når `tidligereOpphørsdato >= periodeMaksDato` (f.eks. opphørsdato 2026-07-31, maksdato 2026-07-30). Feilen kom fra en defensiv assertion i `utledPeriode` som forventet at tilfellet skulle vært filtrert bort tidligere — men det manglet en sjekk som faktisk gjorde det.

Logghendelse:

[Fikk uventet feil: Maksdato/tom (2026-07-30) er ikke etter tidligere opphørsdato (2026-07-31) — hendelsen burde ha blitt ignorert.](https://logs.az.nav.no/app/discover?security_tenant=navlogs#/doc/c4992d50-be41-11f0-aab5-1ff58dd1d822/.ds-logs.nais-000226?id=jltop58B6FmXpRTc6M75)

### Løsning

Lagt til eksplisitt pre-sjekk i `finnFagsakerTilVurdering`: dersom `periodeMaksDato` ikke er etter `tidligereOpphørsdato`, er det ingen periode å gjenåpne og hendelsen ignoreres med logg. `IllegalStateException` i `utledPeriode` er beholdt som defensiv backstop.

### Andre endringer

- Manglende `periodeMaksDato` endret fra stille skip til hard feil (`orElseThrow`) — alle fagsaker skal ha maksdato, og mangler den er det en reell feiltilstand.
- Forbedret logging i skip-cases: fagsakId og behandling-id logges nå konsekvent.
- Tester oppdatert: to nye skip-tester (`maksDato == opphørsdato`, `maksDato < opphørsdato`) erstatter den gamle "expect exception"-testen, og ny test verifiserer at manglende `periodeMaksDato` kaster `IllegalStateException`.


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
