### PR TITLE
TSFF-2860 - Ignorerer hendelser som ikke kan oversette. 

### DIFF
--- a/fordel/src/main/java/no/nav/ung/domenetjenester/personhendelser/HåndterPdlHendelseTask.java
+++ b/fordel/src/main/java/no/nav/ung/domenetjenester/personhendelser/HåndterPdlHendelseTask.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @ApplicationScoped
 @ProsessTask(HåndterPdlHendelseTask.TASKNAME)
@@ -58,7 +59,14 @@ public class HåndterPdlHendelseTask implements ProsessTaskHandler {
             LOG.info("HendelseId={} er annullert, ignorerer hendelsen", personhendelse.getHendelseId());
             return;
         }
-        final Hendelse oversattHendelse = pdlLeesahOversetter.oversettStøttetPersonhendelse(personhendelse).orElseThrow();
+        Optional<Hendelse> hendelseOpt = pdlLeesahOversetter.oversettStøttetPersonhendelse(personhendelse);
+        if (hendelseOpt.isEmpty()) {
+           LOG.info("Ignorerer hendelseId={} da den ikke kunne oversettes til en støttet hendelse.", personhendelse.getHendelseId());
+           return;
+        }
+
+        final Hendelse oversattHendelse = hendelseOpt.orElseThrow();
+
 
         LOG.info("Håndterer hendelseId={}", oversattHendelse.getHendelseInfo().getHendelseId());
 

--- a/fordel/src/main/java/no/nav/ung/domenetjenester/personhendelser/PdlLeesahOversetter.java
+++ b/fordel/src/main/java/no/nav/ung/domenetjenester/personhendelser/PdlLeesahOversetter.java
@@ -47,6 +47,8 @@ public class PdlLeesahOversetter {
         } else if (PersonhendelseUtils.gjelderForelderBarnRelasjon(personhendelse)) {
             return oversettForelderBarnRelasjon(personhendelse, hendelseInfo);
         }
+
+        logger.info("Støtter ikke hendelser med opplysningstype {}.", personhendelse.getOpplysningstype().toString());
         return Optional.empty();
     }
 
@@ -101,7 +103,7 @@ public class PdlLeesahOversetter {
         String rolleForPerson = forelderBarnRelasjon.getMinRolleForPerson().toString();
 
         if (!PersonhendelseUtils.rolleForPersonErForeldre(personhendelse)) {
-            logger.info("Ignorerer forelderBarnRelasjon fordi rollen for personen verken er far eller mor. rolleForPerson {}. endringstype {}, hendelseId {}", rolleForPerson, hendelseInfo.getHendelseId(), endringstype);
+            logger.info("Ignorerer forelderBarnRelasjon fordi rollen for personen verken er far eller mor. rolleForPerson {}. endringstype {}, hendelseId {}", rolleForPerson, endringstype, hendelseInfo.getHendelseId());
             return Optional.empty();
         }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Vi krever at rollen i PDL hendelser må være FAR, MOR eller MEDMOR, mens i noen tilfeller er rollen BARN, og relatertPersonRolle er FAR/MOR. PDL sender flere slike hendelser med rollene byttet om så slike hendelser kan derfor ignoreres.   

### Løsning
Ignorerer alle hendelser vi ikke kan oversette fordi det er bare de vi kan oversette som vi ønsker å håndtere. Hendelsen kommer til tasken `ung.pdl.hendelseHåndterer` kun hvis det personen hendelsen gjelder er involvert i en sak så det er nyttig å ha en task som forsøker å prosessere. 

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
