### PR TITLE
TSFF-2843: Vurdering av bostedsfakta skal ikke totrinnsgodkjennes

### DIFF
--- a/kodeverk/src/main/java/no/nav/ung/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/kodeverk/src/main/java/no/nav/ung/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -94,7 +94,7 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
 
     VURDER_FAKTA_OM_BOSTED(AksjonspunktKodeDefinisjon.VURDER_FAKTA_OM_BOSTED,
         AksjonspunktType.LOKALKONTOR_MANUELL, "Vurder fakta om bosted", BehandlingStatus.UTREDES, BehandlingStegType.VURDER_FAKTA_OM_BOSTED,
-        UTEN_VILKÅR, SkjermlenkeType.BOSTEDSVILKÅR, TOTRINN, AVVENTER_SAKSBEHANDLER),
+        UTEN_VILKÅR, SkjermlenkeType.BOSTEDSVILKÅR, ENTRINN, AVVENTER_SAKSBEHANDLER),
     VURDER_BOSTEDVILKÅR(AksjonspunktKodeDefinisjon.VURDER_BOSTEDVILKÅR_KODE,
         AksjonspunktType.LOKALKONTOR_MANUELL, "Manuell vurdering av bostedsvilkåret (årsak: Annet)", BehandlingStatus.UTREDES, BehandlingStegType.VURDER_BOSTEDVILKÅR,
         VilkårType.BOSTEDSVILKÅR, SkjermlenkeType.BOSTEDSVILKÅR, TOTRINN, AVVENTER_SAKSBEHANDLER),


### PR DESCRIPTION
### Behov / Bakgrunn
Det er ikke krav til 2-trinnskontroll for steget “årsak og varsel”, det er kun Vilkårsvirdering som skal til beslutter når det har blitt vurdert et vilkår/aksjonspunkt. 

### Løsning
Setter aksjonspunktet til ENTRINN

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
