### PR TITLE
Inkluder startdato og søknadsperioder i feilmelding ved manglende match

### DIFF
--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/perioder/UngdomsytelseProsessTriggerPeriodeUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/perioder/UngdomsytelseProsessTriggerPeriodeUtleder.java
@@ -13,6 +13,7 @@ import no.nav.ung.sak.trigger.ProsessTriggere;
 import no.nav.ung.sak.trigger.ProsessTriggereRepository;
 import no.nav.ung.sak.trigger.Trigger;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Set;
@@ -54,12 +55,13 @@ public class UngdomsytelseProsessTriggerPeriodeUtleder implements ProsessTrigger
         // så vi begresenser det her til programperiode
         if (årsak == BehandlingÅrsakType.NY_SØKT_PERIODE) {
             var søknadsperioder = ungdomsytelseSøknadsperiodeTjeneste.utledPeriode(behandligId);
+            String triggerperiodeFomDato = p.getPeriode().getFomDato().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"));
             return søknadsperioder.stream()
                 .filter(it -> it.getTomDato().isAfter(p.getPeriode().getFomDato()))
                 .min(Comparator.naturalOrder())
-.orElseThrow(() -> new IllegalStateException("Hadde startdato som ikke kunne matches med søknadsperiode. behandlingId=" + behandligId
-    + ", trigger-startdato=" + p.getPeriode().getFomDato().format(java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy"))
-    + ", kjente søknadsperioder=" + søknadsperioder))
+                .orElseThrow(() -> new IllegalStateException("Hadde startdato som ikke kunne matches med søknadsperiode. behandlingId=" + behandligId
+                    + ", trigger-startdato=" + triggerperiodeFomDato
+                    + ", kjente søknadsperioder=" + søknadsperioder))
                 .toLocalDateInterval();
 
         }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/perioder/UngdomsytelseProsessTriggerPeriodeUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/perioder/UngdomsytelseProsessTriggerPeriodeUtleder.java
@@ -53,10 +53,12 @@ public class UngdomsytelseProsessTriggerPeriodeUtleder implements ProsessTrigger
         // For nye søknader så vil triggerperioden være uendelig fordi vi ikke vet sluttdato ved oppretting av trigger,
         // så vi begresenser det her til programperiode
         if (årsak == BehandlingÅrsakType.NY_SØKT_PERIODE) {
-            return ungdomsytelseSøknadsperiodeTjeneste.utledPeriode(behandligId).stream()
+            var søknadsperioder = ungdomsytelseSøknadsperiodeTjeneste.utledPeriode(behandligId);
+            return søknadsperioder.stream()
                 .filter(it -> it.getTomDato().isAfter(p.getPeriode().getFomDato()))
                 .min(Comparator.naturalOrder())
-                .orElseThrow(() -> new IllegalStateException("Hadde startdato som ikke kunne matches med søknadsperiode"))
+                .orElseThrow(() -> new IllegalStateException("Hadde startdato som ikke kunne matches med søknadsperiode. Trigger-startdato="
+                    + p.getPeriode().getFomDato() + ", kjente søknadsperioder=" + søknadsperioder))
                 .toLocalDateInterval();
 
         }

--- a/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/perioder/UngdomsytelseProsessTriggerPeriodeUtleder.java
+++ b/ytelse-ungdomsprogramytelsen/src/main/java/no/nav/ung/ytelse/ungdomsprogramytelsen/perioder/UngdomsytelseProsessTriggerPeriodeUtleder.java
@@ -57,8 +57,9 @@ public class UngdomsytelseProsessTriggerPeriodeUtleder implements ProsessTrigger
             return søknadsperioder.stream()
                 .filter(it -> it.getTomDato().isAfter(p.getPeriode().getFomDato()))
                 .min(Comparator.naturalOrder())
-                .orElseThrow(() -> new IllegalStateException("Hadde startdato som ikke kunne matches med søknadsperiode. Trigger-startdato="
-                    + p.getPeriode().getFomDato() + ", kjente søknadsperioder=" + søknadsperioder))
+.orElseThrow(() -> new IllegalStateException("Hadde startdato som ikke kunne matches med søknadsperiode. behandlingId=" + behandligId
+    + ", trigger-startdato=" + p.getPeriode().getFomDato().format(java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+    + ", kjente søknadsperioder=" + søknadsperioder))
                 .toLocalDateInterval();
 
         }


### PR DESCRIPTION
### Behov / Bakgrunn

Ved feilsøking av "Hadde startdato som ikke kunne matches med søknadsperiode" manglet exceptionen konkrete data om hvilken startdato og hvilke søknadsperioder som faktisk ikke matchet. Dette gjorde feilsøking tregere enn nødvendig, siden man måtte hente ut data manuelt fra databasen for å forstå hva som gikk galt.

### Løsning

Utvidet feilmeldingen i `UngdomsytelseProsessTriggerPeriodeUtleder.finnPeriodeForBehandlingsårsak` til å inkludere trigger-startdato og alle kjente søknadsperioder for behandlingen. Exception-typen (`IllegalStateException`) er uendret, kun meldingsteksten er utvidet.


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
