### PR TITLE
TSFF-2835: Bruke tidligere vurdering hvis ikke alle vilkårsperioder vurderes på nytt i aksjonspunkt

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
@@ -4,12 +4,15 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Tuple;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
 import no.nav.ung.kodeverk.vilkår.Utfall;
 import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriodeBuilder;
 import no.nav.ung.sak.diff.DiffEntity;
 import no.nav.ung.sak.diff.TraverseEntityGraphFactory;
 import no.nav.ung.sak.diff.TraverseGraph;
@@ -117,6 +120,27 @@ public class VilkårResultatRepository {
         if (tilBehandlingVilkår.isPresent()) {
             throw new IllegalStateException("Kan ikke kopiere vilkår til en behandling hvor det allerede eksisterer et vilkårsresultat");
         }
+    }
+
+    public List<VilkårPeriodeBuilder> hentVilkårperioderForPerioderIkkeVurdert(Long fraBehandlingId, VilkårType vilkårType, List<VilkårPeriode> gjeldendeVilkårsperioder) {
+        var ikkeVurdertePerioder = gjeldendeVilkårsperioder.stream()
+            .filter(periode -> periode.getUtfall() == Utfall.IKKE_VURDERT)
+            .map(VilkårPeriode::getPeriode).map(p -> new LocalDateSegment<>(p.getFomDato(), p.getTomDato(), true))
+            .toList();
+
+        var fraVilkårResultatTidslinje = hentHvisEksisterer(fraBehandlingId)
+            .map(v -> v.getVilkårTimeline(vilkårType)
+                .mapValue(VilkårPeriodeBuilder::new)
+            )
+            .orElse(LocalDateTimeline.empty());
+
+        return fraVilkårResultatTidslinje.intersection(new LocalDateTimeline<>(ikkeVurdertePerioder)).segmenter()
+            .stream().map(segment -> segment.getValue()
+                .medPeriode(
+                    segment.getFom(),
+                    segment.getTom()
+                )
+            ).toList();
     }
 
     private DiffEntity vilkårsDiffer() {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/inngangsvilkår/InngangsvilkårVurderingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/inngangsvilkår/InngangsvilkårVurderingRepository.java
@@ -198,7 +198,7 @@ public class InngangsvilkårVurderingRepository {
             .map(BostedsvilkårResultatHolder::getVurderinger)
             .orElse(List.of()));
 
-        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).toSegments().stream().map(seg -> {
+        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).segmenter().stream().map(seg -> {
             var periode = DatoIntervallEntitet.fraOgMedTilOgMed(seg.getFom(), seg.getTom());
             var v = seg.getValue();
             return v.getPeriode().equals(periode) ? v : new BostedsvilkårResultatPeriode(periode, v);
@@ -213,7 +213,7 @@ public class InngangsvilkårVurderingRepository {
             .map(BistandsvilkårResultatHolder::getVurderinger)
             .orElse(List.of()));
 
-        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).toSegments().stream().map(seg -> {
+        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).segmenter().stream().map(seg -> {
             var periode = DatoIntervallEntitet.fraOgMedTilOgMed(seg.getFom(), seg.getTom());
             var v = seg.getValue();
             return v.getPeriode().equals(periode) ? v : new BistandsvilkårResultatPeriode(periode, v);
@@ -228,7 +228,7 @@ public class InngangsvilkårVurderingRepository {
             .map(AndreLivsoppholdsytelserResultatHolder::getVurderinger)
             .orElse(List.of()));
 
-        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).toSegments().stream().map(seg -> {
+        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).segmenter().stream().map(seg -> {
             var periode = DatoIntervallEntitet.fraOgMedTilOgMed(seg.getFom(), seg.getTom());
             var v = seg.getValue();
             return v.getPeriode().equals(periode) ? v : new AndreLivsoppholdsytelserResultatPeriode(periode, v);

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
@@ -101,6 +101,7 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
         inngangsvilkårVurderingRepository.lagreBostedVurderinger(param.getBehandlingId(), periodeVurderinger);
 
         inngangsvilkårVurderingTjeneste.settBostedsvilkårResultat(param.getBehandlingId(), param.getVilkårResultatBuilder());
+        inngangsvilkårVurderingTjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(param.getBehandlingId(), param.getVilkårResultatBuilder(), VilkårType.BOSTEDSVILKÅR);
 
         Behandling behandling = behandlingRepository.hentBehandling(param.getBehandlingId());
         var historikkinnslag = new Historikkinnslag.Builder()

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjeneste.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjeneste.java
@@ -6,9 +6,11 @@ import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
 import no.nav.ung.kodeverk.vilkår.BostedsvilkårIkkeOppfyltÅrsak;
 import no.nav.ung.kodeverk.vilkår.Utfall;
 import no.nav.ung.kodeverk.vilkår.VilkårType;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatBuilder;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriodeBuilder;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.AktivitetspengerInngangsvilkårResultatGrunnlag;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatHolder;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.InngangsvilkårVurderingRepository;
@@ -24,6 +26,7 @@ import java.util.List;
 public class InngangsvilkårVurderingTjeneste {
 
     private InngangsvilkårVurderingRepository repository;
+    private BehandlingRepository behandlingRepository;
     private VilkårResultatRepository vilkårResultatRepository;
 
     InngangsvilkårVurderingTjeneste() {
@@ -32,8 +35,10 @@ public class InngangsvilkårVurderingTjeneste {
 
     @Inject
     public InngangsvilkårVurderingTjeneste(InngangsvilkårVurderingRepository repository,
+                                           BehandlingRepository behandlingRepository,
                                            VilkårResultatRepository vilkårResultatRepository) {
         this.repository = repository;
+        this.behandlingRepository = behandlingRepository;
         this.vilkårResultatRepository = vilkårResultatRepository;
     }
 
@@ -92,6 +97,20 @@ public class InngangsvilkårVurderingTjeneste {
             resultatBuilderForVilkår.leggTil(periodeBuilder);
         });
         vilkårResultatBuilder.leggTil(resultatBuilderForVilkår);
+    }
+
+    public void gjenopprettForrigeVurderingForPerioderIkkeVurdert(Long behandlingId, VilkårResultatBuilder vilkårResultatBuilder, VilkårType vilkårType) {
+        var originalBehandlingId = behandlingRepository.hentBehandling(behandlingId).getOriginalBehandlingId().orElse(null);
+        if (originalBehandlingId == null) {
+            return;
+        }
+        var eksisterendeVilkårsperioder = vilkårResultatBuilder.hentBuilderFor(vilkårType).build().getPerioder();
+        var vilkårBuilder = vilkårResultatBuilder.hentBuilderFor(vilkårType);
+        var vilkårperioderSomSkalKopieres = vilkårResultatRepository.hentVilkårperioderForPerioderIkkeVurdert(originalBehandlingId, vilkårType, eksisterendeVilkårsperioder);
+        for (var vilkårPeriodeBuilder : vilkårperioderSomSkalKopieres) {
+            vilkårBuilder.leggTil(vilkårPeriodeBuilder);
+        }
+        vilkårResultatBuilder.leggTil(vilkårBuilder);
     }
 
     public void settBostedsvilkårResultat(Long behandlingId, VilkårResultatBuilder resultatBuilder) {

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/steg/bosatt/VurderBostedVilkårStegTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/steg/bosatt/VurderBostedVilkårStegTest.java
@@ -88,7 +88,7 @@ class VurderBostedVilkårStegTest {
         startdatoRepository = new StartdatoRepository(entityManager);
         prosessTriggereRepository = new ProsessTriggereRepository(entityManager);
         inngangsvilkårVurderingRepository = new InngangsvilkårVurderingRepository(entityManager);
-        inngangsvilkårVurderingTjeneste = new InngangsvilkårVurderingTjeneste(inngangsvilkårVurderingRepository, vilkårResultatRepository);
+        inngangsvilkårVurderingTjeneste = new InngangsvilkårVurderingTjeneste(inngangsvilkårVurderingRepository, behandlingRepository, vilkårResultatRepository);
         behandlingprosessSporingRepository = new BehandingprosessSporingRepository(entityManager);
 
         steg = lagSteg(List.of());


### PR DESCRIPTION
### Behov / Bakgrunn
Når saksbehandler foreslår et opphør eller avslag, settes vilkårsperioden aktuell for avslag til IKKE_VURDERT, slik at denne kan vurderes på nytt etter brukers uttalelse. Hvis perioden i vurderingen forkortes som følge av informasjon i uttalelse, skal saksbehandler slippe å måtte forholde seg til vilkårsperioden som ikke endres. 

### Løsning
Henter tidligere vilkårsvurdering for perioder ikke vurdert etter at aksjonspunkt for manuell vilkårsvurdering er utført.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
