### PR TITLE
TSFF-2835: Bruke tidligere vurdering hvis ikke alle vilkårsperioder vurderes på nytt i aksjonspunkt

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
@@ -4,12 +4,15 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Tuple;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.k9.felles.jpa.HibernateVerktøy;
 import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
 import no.nav.ung.kodeverk.vilkår.Utfall;
 import no.nav.ung.kodeverk.vilkår.VilkårType;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriodeBuilder;
 import no.nav.ung.sak.diff.DiffEntity;
 import no.nav.ung.sak.diff.TraverseEntityGraphFactory;
 import no.nav.ung.sak.diff.TraverseGraph;
@@ -117,6 +120,27 @@ public class VilkårResultatRepository {
         if (tilBehandlingVilkår.isPresent()) {
             throw new IllegalStateException("Kan ikke kopiere vilkår til en behandling hvor det allerede eksisterer et vilkårsresultat");
         }
+    }
+
+    public List<VilkårPeriodeBuilder> hentVilkårperioderForPerioderIkkeVurdert(Long fraBehandlingId, VilkårType vilkårType, List<VilkårPeriode> gjeldendeVilkårsperioder) {
+        var ikkeVurdertePerioder = gjeldendeVilkårsperioder.stream()
+            .filter(periode -> periode.getUtfall() == Utfall.IKKE_VURDERT)
+            .map(VilkårPeriode::getPeriode).map(p -> new LocalDateSegment<>(p.getFomDato(), p.getTomDato(), true))
+            .toList();
+
+        var fraVilkårResultatTidslinje = hentHvisEksisterer(fraBehandlingId)
+            .map(v -> v.getVilkårTimeline(vilkårType)
+                .mapValue(VilkårPeriodeBuilder::new)
+            )
+            .orElse(LocalDateTimeline.empty());
+
+        return fraVilkårResultatTidslinje.intersection(new LocalDateTimeline<>(ikkeVurdertePerioder)).segmenter()
+            .stream().map(segment -> segment.getValue()
+                .medPeriode(
+                    segment.getFom(),
+                    segment.getTom()
+                )
+            ).toList();
     }
 
     private DiffEntity vilkårsDiffer() {

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
@@ -129,13 +129,11 @@ public class VilkårResultatRepository {
             .toList();
 
         var fraVilkårResultatTidslinje = hentHvisEksisterer(fraBehandlingId)
-            .map(v -> v.getVilkårTimeline(vilkårType)
-                .mapValue(VilkårPeriodeBuilder::new)
-            )
+            .map(v -> v.getVilkårTimeline(vilkårType))
             .orElse(LocalDateTimeline.empty());
 
         return fraVilkårResultatTidslinje.intersection(new LocalDateTimeline<>(ikkeVurdertePerioder)).segmenter()
-            .stream().map(segment -> segment.getValue()
+            .stream().map(segment -> new VilkårPeriodeBuilder(segment.getValue())
                 .medPeriode(
                     segment.getFom(),
                     segment.getTom()

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/VilkårResultatRepository.java
@@ -122,25 +122,6 @@ public class VilkårResultatRepository {
         }
     }
 
-    public List<VilkårPeriodeBuilder> hentVilkårperioderForPerioderIkkeVurdert(Long fraBehandlingId, VilkårType vilkårType, List<VilkårPeriode> gjeldendeVilkårsperioder) {
-        var ikkeVurdertePerioder = gjeldendeVilkårsperioder.stream()
-            .filter(periode -> periode.getUtfall() == Utfall.IKKE_VURDERT)
-            .map(VilkårPeriode::getPeriode).map(p -> new LocalDateSegment<>(p.getFomDato(), p.getTomDato(), true))
-            .toList();
-
-        var fraVilkårResultatTidslinje = hentHvisEksisterer(fraBehandlingId)
-            .map(v -> v.getVilkårTimeline(vilkårType))
-            .orElse(LocalDateTimeline.empty());
-
-        return fraVilkårResultatTidslinje.intersection(new LocalDateTimeline<>(ikkeVurdertePerioder)).segmenter()
-            .stream().map(segment -> new VilkårPeriodeBuilder(segment.getValue())
-                .medPeriode(
-                    segment.getFom(),
-                    segment.getTom()
-                )
-            ).toList();
-    }
-
     private DiffEntity vilkårsDiffer() {
         TraverseGraph traverser = TraverseEntityGraphFactory.build();
         return new DiffEntity(traverser);

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/WrappedVilkårPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/WrappedVilkårPeriode.java
@@ -31,7 +31,8 @@ class WrappedVilkårPeriode {
             Objects.equals(vilkårPeriode.getAvslagsårsak(), that.vilkårPeriode.getAvslagsårsak()) &&
             Objects.equals(vilkårPeriode.getErOverstyrt(), that.vilkårPeriode.getErOverstyrt()) &&
             Objects.equals(vilkårPeriode.getErManueltVurdert(), that.vilkårPeriode.getErManueltVurdert()) &&
-            Objects.equals(vilkårPeriode.getBegrunnelse(), that.vilkårPeriode.getBegrunnelse());
+            Objects.equals(vilkårPeriode.getBegrunnelse(), that.vilkårPeriode.getBegrunnelse()) &&
+            Objects.equals(vilkårPeriode.getFritekstVurderingBrev(), that.vilkårPeriode.getFritekstVurderingBrev());
     }
 
     @Override
@@ -41,7 +42,8 @@ class WrappedVilkårPeriode {
             vilkårPeriode.getAvslagsårsak(),
             vilkårPeriode.getErOverstyrt(),
             vilkårPeriode.getErManueltVurdert(),
-            vilkårPeriode.getBegrunnelse());
+            vilkårPeriode.getBegrunnelse(),
+            vilkårPeriode.getFritekstVurderingBrev());
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/periode/VilkårPeriode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/vilkår/periode/VilkårPeriode.java
@@ -311,6 +311,7 @@ public class VilkårPeriode extends BaseEntitet implements IndexKey, Comparable<
         return manueltVurdert == that.manueltVurdert &&
             utfall == that.utfall &&
             Objects.equals(begrunnelse, that.begrunnelse) &&
+            Objects.equals(fritekstVurderingBrev, that.fritekstVurderingBrev) &&
             avslagsårsak == that.avslagsårsak &&
             utfallMerknad == that.utfallMerknad &&
             merknadParametere == that.merknadParametere &&
@@ -319,7 +320,7 @@ public class VilkårPeriode extends BaseEntitet implements IndexKey, Comparable<
 
     @Override
     public int hashCode() {
-        return Objects.hash(manueltVurdert, utfall, begrunnelse, avslagsårsak, utfallMerknad, merknadParametere, overstyrtUtfall);
+        return Objects.hash(manueltVurdert, utfall, begrunnelse, avslagsårsak, utfallMerknad, merknadParametere, overstyrtUtfall, fritekstVurderingBrev);
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/inngangsvilkår/InngangsvilkårVurderingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/inngangsvilkår/InngangsvilkårVurderingRepository.java
@@ -198,7 +198,7 @@ public class InngangsvilkårVurderingRepository {
             .map(BostedsvilkårResultatHolder::getVurderinger)
             .orElse(List.of()));
 
-        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).toSegments().stream().map(seg -> {
+        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).segmenter().stream().map(seg -> {
             var periode = DatoIntervallEntitet.fraOgMedTilOgMed(seg.getFom(), seg.getTom());
             var v = seg.getValue();
             return v.getPeriode().equals(periode) ? v : new BostedsvilkårResultatPeriode(periode, v);
@@ -213,7 +213,7 @@ public class InngangsvilkårVurderingRepository {
             .map(BistandsvilkårResultatHolder::getVurderinger)
             .orElse(List.of()));
 
-        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).toSegments().stream().map(seg -> {
+        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).segmenter().stream().map(seg -> {
             var periode = DatoIntervallEntitet.fraOgMedTilOgMed(seg.getFom(), seg.getTom());
             var v = seg.getValue();
             return v.getPeriode().equals(periode) ? v : new BistandsvilkårResultatPeriode(periode, v);
@@ -228,7 +228,7 @@ public class InngangsvilkårVurderingRepository {
             .map(AndreLivsoppholdsytelserResultatHolder::getVurderinger)
             .orElse(List.of()));
 
-        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).toSegments().stream().map(seg -> {
+        var oppdaterte = eksisterendeVurderingerTidslinje.disjoint(perioderSomSkalFjernes).segmenter().stream().map(seg -> {
             var periode = DatoIntervallEntitet.fraOgMedTilOgMed(seg.getFom(), seg.getTom());
             var v = seg.getValue();
             return v.getPeriode().equals(periode) ? v : new AndreLivsoppholdsytelserResultatPeriode(periode, v);

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
@@ -101,6 +101,7 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
         inngangsvilkårVurderingRepository.lagreBostedVurderinger(param.getBehandlingId(), periodeVurderinger);
 
         inngangsvilkårVurderingTjeneste.settBostedsvilkårResultat(param.getBehandlingId(), param.getVilkårResultatBuilder());
+        inngangsvilkårVurderingTjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(param.getBehandlingId(), param.getVilkårResultatBuilder(), VilkårType.BOSTEDSVILKÅR);
 
         Behandling behandling = behandlingRepository.hentBehandling(param.getBehandlingId());
         var historikkinnslag = new Historikkinnslag.Builder()

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
@@ -24,6 +24,7 @@ import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatPer
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.InngangsvilkårVurderingRepository;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.kontrakt.aktivitetspenger.vilkår.bosted.ManuellVurderingBostedsvilkårDto;
+import no.nav.ung.sak.kontrakt.aktivitetspenger.vilkår.bosted.VilkårBostedPeriodeVurderingDto;
 import no.nav.ung.sak.typer.Periode;
 import no.nav.ung.ytelse.aktivitetspenger.del1.InngangsvilkårVurderingTjeneste;
 
@@ -67,34 +68,43 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
     @Override
     public OppdateringResultat oppdater(ManuellVurderingBostedsvilkårDto dto, AksjonspunktOppdaterParameter param) {
         Vilkårene vilkårene = vilkårResultatRepository.hentHvisEksisterer(param.getBehandlingId()).orElseThrow();
-        LocalDateTimeline<VilkårPeriode> perioderTilVurdering = vilkårene.getVilkårTimeline(VilkårType.BOSTEDSVILKÅR)
+        LocalDateTimeline<VilkårPeriode> eksisterendeVilkårperioder = vilkårene.getVilkårTimeline(VilkårType.BOSTEDSVILKÅR)
             .filterValue(v -> v.getUtfall() != Utfall.IKKE_RELEVANT);
 
-        var senesteDatoFraVilkårsperiode = perioderTilVurdering.getMaxLocalDate();
+        var erEndretBostedOgKunAvslagEllerOpphør =
+            behandlingRepository.hentBehandling(param.getBehandlingId()).harBehandlingÅrsak(ENDRET_BOSTED) &&
+                dto.getVurdertePerioder().stream().noneMatch(VilkårBostedPeriodeVurderingDto::erVilkårOppfylt);
 
-        LocalDateTimeline<Boolean> inputOppdateres = new LocalDateTimeline<>(dto.getVurdertePerioder().stream().map(it ->
-            new LocalDateSegment<>(it.periode().getFom(), hentMaksDatoVedÅpenPeriode(it.periode(), senesteDatoFraVilkårsperiode), true)).toList()
-        );
 
-        LocalDateTimeline<Boolean> uforventedePerioder = inputOppdateres.disjoint(perioderTilVurdering);
-        if (!uforventedePerioder.isEmpty()) {
-            throw new IllegalArgumentException("Forsøker å vurdere perioder som ikke er til vurdering. Gjelder perioder: " + uforventedePerioder);
-        }
-
+        var senesteDatoFraVilkårsperiode = eksisterendeVilkårperioder.getMaxLocalDate();
         String vurdertAv = SubjectHandler.getSubjectHandler().getUid();
         LocalDateTime vurdertTidspunkt = LocalDateTime.now();
 
-        var periodeVurderinger = dto.getVurdertePerioder().stream()
-            .map(it -> new BostedsvilkårResultatPeriode(
+        var vurderteÅpnePerioder = new LocalDateTimeline<>(dto.getVurdertePerioder().stream()
+            .filter(it -> it.periode().getTom() == null)
+            .map(it -> new LocalDateSegment<>(it.periode().getFom(), hentMaksDatoVedÅpenPeriode(it.periode(), senesteDatoFraVilkårsperiode), it))
+            .toList())
+            .intersection(eksisterendeVilkårperioder);    // For å ikke innføre avslag der det er hull i eksisterende vilkårsperiode
+
+        var vurderteLukkedePerioder = new LocalDateTimeline<>(dto.getVurdertePerioder().stream()
+            .filter(it -> it.periode().getTom() != null)
+            .map(it -> new LocalDateSegment<>(it.periode().getFom(), it.periode().getTom(), it))
+            .toList());
+
+        validerLukkedePerioder(vurderteLukkedePerioder, eksisterendeVilkårperioder, erEndretBostedOgKunAvslagEllerOpphør);
+
+        var periodeVurderinger = vurderteÅpnePerioder.crossJoin(vurderteLukkedePerioder).segmenter().stream()
+            .map(it ->
+                new BostedsvilkårResultatPeriode(
                 DatoIntervallEntitet.fraOgMedTilOgMed(
-                    it.periode().getFom(),
-                    hentMaksDatoVedÅpenPeriode(it.periode(), senesteDatoFraVilkårsperiode)
+                    it.getFom(),
+                    it.getTom()
                 ),
-                it.erVilkårOppfylt(),
-                it.avslagsårsak(),
+                it.getValue().erVilkårOppfylt(),
+                it.getValue().avslagsårsak(),
                 true,
-                it.begrunnelse(),
-                it.fritekstVurderingBrev(),
+                it.getValue().begrunnelse(),
+                it.getValue().fritekstVurderingBrev(),
                 vurdertAv,
                 vurdertTidspunkt))
             .toList();
@@ -103,7 +113,7 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
 
         inngangsvilkårVurderingTjeneste.settBostedsvilkårResultat(param.getBehandlingId(), param.getVilkårResultatBuilder());
 
-        if (behandlingRepository.hentBehandling(param.getBehandlingId()).harBehandlingÅrsak(ENDRET_BOSTED)) {
+        if (erEndretBostedOgKunAvslagEllerOpphør) {
             inngangsvilkårVurderingTjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(param.getBehandlingId(), param.getVilkårResultatBuilder(), VilkårType.BOSTEDSVILKÅR);
         }
 
@@ -119,6 +129,20 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
 
         return OppdateringResultat.nyttResultat();
     }
+
+    private static void validerLukkedePerioder(LocalDateTimeline<VilkårBostedPeriodeVurderingDto> vurderteLukkedePerioder, LocalDateTimeline<VilkårPeriode> eksisterendeVilkårperiode, boolean erEndretBostedOgKunAvslagEllerOpphør) {
+        LocalDateTimeline<VilkårBostedPeriodeVurderingDto> uforventedePerioder = vurderteLukkedePerioder.disjoint(eksisterendeVilkårperiode);
+        if (!uforventedePerioder.isEmpty()) {
+            throw new IllegalArgumentException("Forsøker å vurdere perioder som ikke er til vurdering. Gjelder perioder: " + uforventedePerioder);
+        }
+
+        LocalDateTimeline<?> manglendePerioder = eksisterendeVilkårperiode.disjoint(vurderteLukkedePerioder);
+        if (!manglendePerioder.isEmpty() && !erEndretBostedOgKunAvslagEllerOpphør) {
+            // Brukers uttalelse kan føre til at ikke hele perioden opprinnelig satt til IKKE_VURDERT skal revurderes likevel.
+            throw new IllegalArgumentException("Forventer at alle perioder til vurdering vurderes. Mangler : " + manglendePerioder);
+        }
+    }
+
     static LocalDate hentMaksDatoVedÅpenPeriode(Periode periode, LocalDate senesteTomVilkårsperiode) {
         var erÅpenPeriode = periode.getTom() == null || periode.getFom().equals(TIDENES_ENDE);
         return erÅpenPeriode ? senesteTomVilkårsperiode : periode.getTom();

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static no.nav.fpsak.tidsserie.LocalDateInterval.TIDENES_ENDE;
+import static no.nav.ung.kodeverk.behandling.BehandlingÅrsakType.ENDRET_BOSTED;
 
 /**
  * Oppdaterer for aksjonspunkt 5144 – manuell vurdering av bostedsvilkåret.
@@ -101,7 +102,10 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
         inngangsvilkårVurderingRepository.lagreBostedVurderinger(param.getBehandlingId(), periodeVurderinger);
 
         inngangsvilkårVurderingTjeneste.settBostedsvilkårResultat(param.getBehandlingId(), param.getVilkårResultatBuilder());
-        inngangsvilkårVurderingTjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(param.getBehandlingId(), param.getVilkårResultatBuilder(), VilkårType.BOSTEDSVILKÅR);
+
+        if (behandlingRepository.hentBehandling(param.getBehandlingId()).harBehandlingÅrsak(ENDRET_BOSTED)) {
+            inngangsvilkårVurderingTjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(param.getBehandlingId(), param.getVilkårResultatBuilder(), VilkårType.BOSTEDSVILKÅR);
+        }
 
         Behandling behandling = behandlingRepository.hentBehandling(param.getBehandlingId());
         var historikkinnslag = new Historikkinnslag.Builder()

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdaterer.java
@@ -71,9 +71,8 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
         LocalDateTimeline<VilkårPeriode> eksisterendeVilkårperioder = vilkårene.getVilkårTimeline(VilkårType.BOSTEDSVILKÅR)
             .filterValue(v -> v.getUtfall() != Utfall.IKKE_RELEVANT);
 
-        var erEndretBostedOgKunAvslagEllerOpphør =
-            behandlingRepository.hentBehandling(param.getBehandlingId()).harBehandlingÅrsak(ENDRET_BOSTED) &&
-                dto.getVurdertePerioder().stream().noneMatch(VilkårBostedPeriodeVurderingDto::erVilkårOppfylt);
+        var erEndretBosted =
+            behandlingRepository.hentBehandling(param.getBehandlingId()).harBehandlingÅrsak(ENDRET_BOSTED);
 
 
         var senesteDatoFraVilkårsperiode = eksisterendeVilkårperioder.getMaxLocalDate();
@@ -91,7 +90,7 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
             .map(it -> new LocalDateSegment<>(it.periode().getFom(), it.periode().getTom(), it))
             .toList());
 
-        validerLukkedePerioder(vurderteLukkedePerioder, eksisterendeVilkårperioder, erEndretBostedOgKunAvslagEllerOpphør);
+        validerLukkedePerioder(vurderteLukkedePerioder, eksisterendeVilkårperioder, erEndretBosted);
 
         var periodeVurderinger = vurderteÅpnePerioder.crossJoin(vurderteLukkedePerioder).segmenter().stream()
             .map(it ->
@@ -113,7 +112,7 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
 
         inngangsvilkårVurderingTjeneste.settBostedsvilkårResultat(param.getBehandlingId(), param.getVilkårResultatBuilder());
 
-        if (erEndretBostedOgKunAvslagEllerOpphør) {
+        if (erEndretBosted) {
             inngangsvilkårVurderingTjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(param.getBehandlingId(), param.getVilkårResultatBuilder(), VilkårType.BOSTEDSVILKÅR);
         }
 
@@ -130,14 +129,14 @@ public class ManuellVurderingBostedsvilkårOppdaterer implements AksjonspunktOpp
         return OppdateringResultat.nyttResultat();
     }
 
-    private static void validerLukkedePerioder(LocalDateTimeline<VilkårBostedPeriodeVurderingDto> vurderteLukkedePerioder, LocalDateTimeline<VilkårPeriode> eksisterendeVilkårperiode, boolean erEndretBostedOgKunAvslagEllerOpphør) {
+    private static void validerLukkedePerioder(LocalDateTimeline<VilkårBostedPeriodeVurderingDto> vurderteLukkedePerioder, LocalDateTimeline<VilkårPeriode> eksisterendeVilkårperiode, boolean erEndretBosted) {
         LocalDateTimeline<VilkårBostedPeriodeVurderingDto> uforventedePerioder = vurderteLukkedePerioder.disjoint(eksisterendeVilkårperiode);
         if (!uforventedePerioder.isEmpty()) {
             throw new IllegalArgumentException("Forsøker å vurdere perioder som ikke er til vurdering. Gjelder perioder: " + uforventedePerioder);
         }
 
         LocalDateTimeline<?> manglendePerioder = eksisterendeVilkårperiode.disjoint(vurderteLukkedePerioder);
-        if (!manglendePerioder.isEmpty() && !erEndretBostedOgKunAvslagEllerOpphør) {
+        if (!manglendePerioder.isEmpty() && !erEndretBosted) {
             // Brukers uttalelse kan føre til at ikke hele perioden opprinnelig satt til IKKE_VURDERT skal revurderes likevel.
             throw new IllegalArgumentException("Forventer at alle perioder til vurdering vurderes. Mangler : " + manglendePerioder);
         }

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdatererTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdatererTest.java
@@ -1,0 +1,7 @@
+package no.nav.ung.sak.web.app.tjenester.behandling.aktivitetspenger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ManuellVurderingBostedsvilkårOppdatererTest {
+
+}

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdatererTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/ManuellVurderingBostedsvilkårOppdatererTest.java
@@ -1,7 +1,376 @@
 package no.nav.ung.sak.web.app.tjenester.behandling.aktivitetspenger;
 
-import static org.junit.jupiter.api.Assertions.*;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.k9.felles.testutilities.sikkerhet.StaticSubjectHandler;
+import no.nav.k9.felles.testutilities.sikkerhet.SubjectHandlerUtils;
+import no.nav.ung.kodeverk.behandling.BehandlingType;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
+import no.nav.ung.kodeverk.vilkår.BostedsvilkårIkkeOppfyltÅrsak;
+import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.kodeverk.vilkår.VilkårType;
+import no.nav.ung.sak.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.BehandlingÅrsak;
+import no.nav.ung.sak.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatBuilder;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatRepository;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriodeBuilder;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.AktivitetspengerInngangsvilkårResultatGrunnlag;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatHolder;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatPeriode;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.InngangsvilkårVurderingRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.kontrakt.aktivitetspenger.ÅpenPeriode;
+import no.nav.ung.sak.kontrakt.aktivitetspenger.vilkår.bosted.ManuellVurderingBostedsvilkårDto;
+import no.nav.ung.sak.kontrakt.aktivitetspenger.vilkår.bosted.VilkårBostedPeriodeVurderingDto;
+import no.nav.ung.sak.typer.AktørId;
+import no.nav.ung.sak.typer.Periode;
+import no.nav.ung.sak.typer.Saksnummer;
+import no.nav.ung.ytelse.aktivitetspenger.del1.InngangsvilkårVurderingTjeneste;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(JpaExtension.class)
+@ExtendWith(CdiAwareExtension.class)
 class ManuellVurderingBostedsvilkårOppdatererTest {
 
+    private static final String SAKSBEHANDLER = "saksbehandlerBosted";
+
+    private static final Periode PERIODE_1 = new Periode(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31));
+    private static final Periode PERIODE_2 = new Periode(LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+    private static final Periode PERIODE_3 = new Periode(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31));
+
+    @Inject
+    private EntityManager entityManager;
+
+    private FagsakRepository fagsakRepository;
+    private BehandlingRepository behandlingRepository;
+    private VilkårResultatRepository vilkårResultatRepository;
+    private InngangsvilkårVurderingRepository inngangsvilkårVurderingRepository;
+    private ManuellVurderingBostedsvilkårOppdaterer oppdaterer;
+
+    private Fagsak fagsak;
+
+    @BeforeAll
+    static void beforeAll() {
+        SubjectHandlerUtils.useSubjectHandler(StaticSubjectHandler.class);
+        SubjectHandlerUtils.setInternBruker(SAKSBEHANDLER);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        SubjectHandlerUtils.reset();
+    }
+
+    @BeforeEach
+    void setUp() {
+        var repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        fagsakRepository = repositoryProvider.getFagsakRepository();
+        behandlingRepository = repositoryProvider.getBehandlingRepository();
+        vilkårResultatRepository = repositoryProvider.getVilkårResultatRepository();
+        inngangsvilkårVurderingRepository = new InngangsvilkårVurderingRepository(entityManager);
+        var inngangsvilkårVurderingTjeneste = new InngangsvilkårVurderingTjeneste(inngangsvilkårVurderingRepository, behandlingRepository, vilkårResultatRepository);
+
+        oppdaterer = new ManuellVurderingBostedsvilkårOppdaterer(
+            behandlingRepository,
+            vilkårResultatRepository,
+            inngangsvilkårVurderingRepository,
+            inngangsvilkårVurderingTjeneste,
+            new HistorikkinnslagRepository(entityManager));
+
+        fagsak = Fagsak.opprettNy(FagsakYtelseType.AKTIVITETSPENGER, new AktørId("1122334455667"), new Saksnummer("BOSTED1"),
+            LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31));
+        fagsakRepository.opprettNy(fagsak);
+    }
+
+    @Test
+    void førstegangsbehandling_skal_lagre_bostedvurdering_og_sette_vilkårsresultat_for_vurderte_perioder() {
+        var behandling = opprettFørstegangsbehandling(
+            ikkeVurdertVilkårsperiode(PERIODE_1),
+            ikkeVurdertVilkårsperiode(PERIODE_2));
+
+        var dto = dto(
+            oppfylt(PERIODE_1, "bor i Trondheim"),
+            ikkeOppfylt(PERIODE_2, BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM, "flyttet ut av Trondheim"));
+
+        var vilkårResultat = utførOppdatering(behandling, dto);
+
+        var lagredeVurderinger = hentBostedvurderinger(behandling);
+        assertThat(lagredeVurderinger).hasSize(2);
+
+        var vurderingPeriode1 = lagredeVurderinger.stream().filter(v -> v.getPeriode().equals(tilDatoIntervallEntitet(PERIODE_1))).findFirst().orElseThrow();
+        assertThat(vurderingPeriode1.isGodkjent()).isTrue();
+        assertThat(vurderingPeriode1.getIkkeOppfyltÅrsak()).isNull();
+        assertThat(vurderingPeriode1.isManuellVurdering()).isTrue();
+        assertThat(vurderingPeriode1.getBegrunnelse()).isEqualTo("bor i Trondheim");
+        assertThat(vurderingPeriode1.getVurdertAv()).isEqualTo(SAKSBEHANDLER);
+        assertThat(vurderingPeriode1.getVurdertTidspunkt()).isNotNull();
+
+        var vurderingPeriode2 = lagredeVurderinger.stream().filter(v -> v.getPeriode().equals(tilDatoIntervallEntitet(PERIODE_2))).findFirst().orElseThrow();
+        assertThat(vurderingPeriode2.isGodkjent()).isFalse();
+        assertThat(vurderingPeriode2.getIkkeOppfyltÅrsak()).isEqualTo(BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM);
+        assertThat(vurderingPeriode2.getFritekstVurderingBrev()).isEqualTo("fritekst " + PERIODE_2.getFom());
+
+        var vilkårPeriode1 = hentVilkårsperiode(vilkårResultat, PERIODE_1);
+        assertThat(vilkårPeriode1.getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
+        assertThat(vilkårPeriode1.getErManueltVurdert()).isTrue();
+        assertThat(vilkårPeriode1.getBegrunnelse()).isEqualTo("bor i Trondheim");
+
+        var vilkårPeriode2 = hentVilkårsperiode(vilkårResultat, PERIODE_2);
+        assertThat(vilkårPeriode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode2.getErManueltVurdert()).isTrue();
+        assertThat(vilkårPeriode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+    }
+
+    @Test
+    void førstegangsbehandling_skal_avvise_vurdering_av_periode_som_ikke_er_til_vurdering() {
+        var behandling = opprettFørstegangsbehandling(ikkeVurdertVilkårsperiode(PERIODE_1));
+
+        var dto = dto(oppfylt(PERIODE_2, "periode som ikke er til vurdering"));
+        var param = oppdaterParameter(behandling, dto);
+
+        assertThatThrownBy(() -> oppdaterer.oppdater(dto, param))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Forsøker å vurdere perioder som ikke er til vurdering");
+    }
+
+    @Test
+    void endret_bosted_avslag_skal_fylle_inn_ikke_vurderte_vilkårsperioder_fra_forrige_behandling() {
+        var originalBehandling = opprettFørstegangsbehandling(
+            vilkårsperiode(PERIODE_1, Utfall.OPPFYLT, null, "original periode 1"),
+            vilkårsperiode(PERIODE_2, Utfall.IKKE_OPPFYLT, Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE, "original periode 2"),
+            vilkårsperiode(PERIODE_3, Utfall.OPPFYLT, null, "original periode 3"));
+
+        var revurdering = opprettRevurdering(originalBehandling, BehandlingÅrsakType.ENDRET_BOSTED,
+            ikkeVurdertVilkårsperiode(PERIODE_1),
+            ikkeVurdertVilkårsperiode(PERIODE_2),
+            ikkeVurdertVilkårsperiode(PERIODE_3));
+
+        var dto = dto(ikkeOppfylt(PERIODE_1, BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM, "vurdert på nytt i denne behandlingen"));
+
+        var vilkårResultat = utførOppdatering(revurdering, dto);
+
+        var vilkårPeriode1 = hentVilkårsperiode(vilkårResultat, PERIODE_1);
+        assertThat(vilkårPeriode1.getGjeldendeUtfall())
+            .as("vurdering gjort i denne behandlingen skal ikke overskrives av forrige behandling")
+            .isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode1.getBegrunnelse()).isEqualTo("vurdert på nytt i denne behandlingen");
+        assertThat(vilkårPeriode1.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+
+        var vilkårPeriode2 = hentVilkårsperiode(vilkårResultat, PERIODE_2);
+        assertThat(vilkårPeriode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+        assertThat(vilkårPeriode2.getBegrunnelse()).isEqualTo("original periode 2");
+
+        var vilkårPeriode3 = hentVilkårsperiode(vilkårResultat, PERIODE_3);
+        assertThat(vilkårPeriode3.getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
+        assertThat(vilkårPeriode3.getBegrunnelse()).isEqualTo("original periode 3");
+
+        assertThat(vilkårResultat.filterValue(v -> Utfall.IKKE_VURDERT.equals(v.getGjeldendeUtfall())).isEmpty())
+            .as("ingen bostedsperioder skal stå igjen som ikke vurdert")
+            .isTrue();
+
+        assertThat(hentBostedvurderinger(revurdering))
+            .as("kun perioden vurdert i denne behandlingen skal lagres som vurdering på revurderingen")
+            .extracting(BostedsvilkårResultatPeriode::getPeriode)
+            .containsExactly(tilDatoIntervallEntitet(PERIODE_1));
+    }
+
+    @Test
+    void endret_bosted_opphør_skal_fylle_inn_ikke_vurderte_vilkårsperioder_fra_forrige_behandling() {
+        var originalBehandling = opprettFørstegangsbehandling(
+            vilkårsperiode(PERIODE_1, Utfall.OPPFYLT, null, "original periode 1"),
+            vilkårsperiode(PERIODE_2, Utfall.IKKE_OPPFYLT, Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE, "original periode 2"),
+            vilkårsperiode(PERIODE_3, Utfall.OPPFYLT, null, "original periode 3"));
+
+        var revurdering = opprettRevurdering(originalBehandling, BehandlingÅrsakType.ENDRET_BOSTED,
+            vilkårsperiode(PERIODE_1, Utfall.OPPFYLT, null, "original periode 1 (kopiert grunnlag)"),
+            ikkeVurdertVilkårsperiode(PERIODE_2),
+            ikkeVurdertVilkårsperiode(PERIODE_3));
+
+        var opphørFraMidtenAvPeriode1 = new Periode(PERIODE_1.getFom().plusDays(15), null);
+        var dto = dto(ikkeOppfylt(opphørFraMidtenAvPeriode1, BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM, "vurdert på nytt i denne behandlingen"));
+
+        var vilkårResultat = utførOppdatering(revurdering, dto);
+
+        var periodeFørOpphør = new Periode(PERIODE_1.getFom(), opphørFraMidtenAvPeriode1.getFom().minusDays(1));
+        var vilkårPeriode0 = hentVilkårsperiode(vilkårResultat, periodeFørOpphør);
+        assertThat(vilkårPeriode0.getGjeldendeUtfall())
+            .as("vurdering gjort i denne behandlingen skal ikke overskrives av forrige behandling")
+            .isEqualTo(Utfall.OPPFYLT);
+        assertThat(vilkårPeriode0.getBegrunnelse()).isEqualTo("original periode 1 (kopiert grunnlag)");
+
+        // Sjekker at overlapp med periode 1 også får nytt utfall - selv om den ikke var til vurdering
+        var periode1_rest = new Periode(opphørFraMidtenAvPeriode1.getFom(), PERIODE_1.getTom());
+        var vilkårPeriode1 = hentVilkårsperiode(vilkårResultat, periode1_rest);
+        assertThat(vilkårPeriode1.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode1.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+        assertThat(vilkårPeriode1.getBegrunnelse()).isEqualTo("vurdert på nytt i denne behandlingen");
+
+        var vilkårPeriode2 = hentVilkårsperiode(vilkårResultat, PERIODE_2);
+        assertThat(vilkårPeriode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+        assertThat(vilkårPeriode2.getBegrunnelse()).isEqualTo("vurdert på nytt i denne behandlingen");
+
+        var vilkårPeriode3 = hentVilkårsperiode(vilkårResultat, PERIODE_3);
+        assertThat(vilkårPeriode3.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode3.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+        assertThat(vilkårPeriode3.getBegrunnelse()).isEqualTo("vurdert på nytt i denne behandlingen");
+
+        assertThat(vilkårResultat.filterValue(v -> Utfall.IKKE_VURDERT.equals(v.getGjeldendeUtfall())).isEmpty())
+            .as("ingen bostedsperioder skal stå igjen som ikke vurdert")
+            .isTrue();
+
+        assertThat(hentBostedvurderinger(revurdering))
+            .as("kun perioden vurdert i denne behandlingen skal lagres som vurdering på revurderingen")
+            .extracting(BostedsvilkårResultatPeriode::getPeriode)
+            .containsExactlyInAnyOrder(tilDatoIntervallEntitet(periode1_rest), tilDatoIntervallEntitet(PERIODE_2), tilDatoIntervallEntitet(PERIODE_3));
+    }
+
+    @Test
+    void skal_ikke_gjenopprette_periode_som_ikke_var_vurdert_i_forrige_behandling() {
+        var originalBehandling = opprettFørstegangsbehandling(
+            vilkårsperiode(PERIODE_1, Utfall.OPPFYLT, null, "original periode 1"));
+
+        var revurdering = opprettRevurdering(originalBehandling, BehandlingÅrsakType.ENDRET_BOSTED,
+            ikkeVurdertVilkårsperiode(PERIODE_1),
+            ikkeVurdertVilkårsperiode(PERIODE_2));
+
+        var dto = dto(ikkeOppfylt(PERIODE_1, BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM, "flyttet"));
+
+        var vilkårResultat = utførOppdatering(revurdering, dto);
+
+        assertThat(hentVilkårsperiode(vilkårResultat, PERIODE_1).getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(hentVilkårsperiode(vilkårResultat, PERIODE_2).getGjeldendeUtfall())
+            .as("periode uten vurdering i forrige behandling skal fortsatt være til vurdering")
+            .isEqualTo(Utfall.IKKE_VURDERT);
+    }
+
+    @Test
+    void skal_ikke_gjenopprette_fra_forrige_behandling_når_behandlingen_ikke_har_årsak_endret_bosted() {
+        var originalBehandling = opprettFørstegangsbehandling(
+            vilkårsperiode(PERIODE_1, Utfall.OPPFYLT, null, "original periode 1"),
+            vilkårsperiode(PERIODE_2, Utfall.OPPFYLT, null, "original periode 2"));
+
+        var revurdering = opprettRevurdering(originalBehandling, BehandlingÅrsakType.NY_SØKT_PERIODE,
+            ikkeVurdertVilkårsperiode(PERIODE_1),
+            ikkeVurdertVilkårsperiode(PERIODE_2));
+
+        var dto = dto(oppfylt(PERIODE_1, "vurdert i denne behandlingen"));
+
+        assertThatThrownBy(() -> utførOppdatering(revurdering, dto))
+            .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Forventer at alle perioder til vurdering vurderes");
+    }
+
+    private LocalDateTimeline<VilkårPeriode> utførOppdatering(Behandling behandling, ManuellVurderingBostedsvilkårDto dto) {
+        var param = oppdaterParameter(behandling, dto);
+        oppdaterer.oppdater(dto, param);
+        return param.getVilkårResultatBuilder().build().getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
+    }
+
+    private AksjonspunktOppdaterParameter oppdaterParameter(Behandling behandling, ManuellVurderingBostedsvilkårDto dto) {
+        VilkårResultatBuilder vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(behandling.getId()));
+        return new AksjonspunktOppdaterParameter(behandling, Optional.empty(), vilkårResultatBuilder, dto);
+    }
+
+    private List<BostedsvilkårResultatPeriode> hentBostedvurderinger(Behandling behandling) {
+        return inngangsvilkårVurderingRepository.hentGrunnlag(behandling.getId())
+            .flatMap(AktivitetspengerInngangsvilkårResultatGrunnlag::getBostedsvilkårResultatHolder)
+            .map(BostedsvilkårResultatHolder::getVurderinger)
+            .orElseThrow();
+    }
+
+    private static VilkårPeriode hentVilkårsperiode(LocalDateTimeline<VilkårPeriode> tidslinje, Periode periode) {
+        return tidslinje.segmenter().stream()
+            .filter(s -> s.getFom().equals(periode.getFom()) && s.getTom().equals(periode.getTom()))
+            .map(s -> s.getValue())
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Fant ikke vilkårsperiode " + periode + " i " + tidslinje));
+    }
+
+    private Behandling opprettFørstegangsbehandling(VilkårsperiodeData... vilkårsperioder) {
+        var behandling = Behandling.nyBehandlingFor(fagsak, BehandlingType.FØRSTEGANGSSØKNAD).build();
+        lagre(behandling, vilkårsperioder);
+        return behandling;
+    }
+
+    private Behandling opprettRevurdering(Behandling originalBehandling, BehandlingÅrsakType årsak, VilkårsperiodeData... vilkårsperioder) {
+        var revurdering = Behandling.fraTidligereBehandling(originalBehandling, BehandlingType.REVURDERING)
+            .medBehandlingÅrsak(BehandlingÅrsak.builder(årsak))
+            .build();
+        lagre(revurdering, vilkårsperioder);
+        return revurdering;
+    }
+
+    private void lagre(Behandling behandling, VilkårsperiodeData... vilkårsperioder) {
+        behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
+
+        var vilkårResultatBuilder = Vilkårene.builder();
+        var vilkårBuilder = vilkårResultatBuilder.hentBuilderFor(VilkårType.BOSTEDSVILKÅR);
+        for (var v : vilkårsperioder) {
+            var periodeBuilder = new VilkårPeriodeBuilder()
+                .medPeriode(v.periode())
+                .medUtfall(v.utfall());
+            if (v.avslagsårsak() != null) {
+                periodeBuilder.medAvslagsårsak(v.avslagsårsak());
+            }
+            if (v.begrunnelse() != null) {
+                periodeBuilder.medBegrunnelse(v.begrunnelse());
+            }
+            vilkårBuilder.leggTil(periodeBuilder);
+        }
+        vilkårResultatBuilder.leggTil(vilkårBuilder);
+        vilkårResultatRepository.lagre(behandling.getId(), vilkårResultatBuilder.build());
+    }
+
+    private static ManuellVurderingBostedsvilkårDto dto(VilkårBostedPeriodeVurderingDto... vurderinger) {
+        return new ManuellVurderingBostedsvilkårDto(List.of(vurderinger), "begrunnelse for aksjonspunktet");
+    }
+
+    private static VilkårBostedPeriodeVurderingDto oppfylt(Periode periode, String begrunnelse) {
+        return new VilkårBostedPeriodeVurderingDto(
+            new ÅpenPeriode(periode.getFom(), periode.getTom()), true, null, begrunnelse, "fritekst " + periode.getFom());
+    }
+
+    private static VilkårBostedPeriodeVurderingDto ikkeOppfylt(Periode periode, BostedsvilkårIkkeOppfyltÅrsak årsak, String begrunnelse) {
+        return new VilkårBostedPeriodeVurderingDto(
+            new ÅpenPeriode(periode.getFom(), periode.getTom()), false, årsak, begrunnelse, "fritekst " + periode.getFom());
+    }
+
+    private static VilkårsperiodeData ikkeVurdertVilkårsperiode(Periode periode) {
+        return new VilkårsperiodeData(tilDatoIntervallEntitet(periode), Utfall.IKKE_VURDERT, null, null);
+    }
+
+    private static VilkårsperiodeData vilkårsperiode(Periode periode, Utfall utfall, Avslagsårsak avslagsårsak, String begrunnelse) {
+        return new VilkårsperiodeData(tilDatoIntervallEntitet(periode), utfall, avslagsårsak, begrunnelse);
+    }
+
+    private record VilkårsperiodeData(DatoIntervallEntitet periode, Utfall utfall, Avslagsårsak avslagsårsak, String begrunnelse) {
+    }
+
+    private static DatoIntervallEntitet tilDatoIntervallEntitet(Periode periode) {
+        return DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
+    }
 }

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjeneste.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjeneste.java
@@ -2,6 +2,8 @@ package no.nav.ung.ytelse.aktivitetspenger.del1;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
 import no.nav.ung.kodeverk.vilkår.BostedsvilkårIkkeOppfyltÅrsak;
 import no.nav.ung.kodeverk.vilkår.Utfall;
@@ -10,6 +12,7 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatBuilder;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriodeBuilder;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.AktivitetspengerInngangsvilkårResultatGrunnlag;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatHolder;
@@ -106,11 +109,30 @@ public class InngangsvilkårVurderingTjeneste {
         }
         var eksisterendeVilkårsperioder = vilkårResultatBuilder.hentBuilderFor(vilkårType).build().getPerioder();
         var vilkårBuilder = vilkårResultatBuilder.hentBuilderFor(vilkårType);
-        var vilkårperioderSomSkalKopieres = vilkårResultatRepository.hentVilkårperioderForPerioderIkkeVurdert(originalBehandlingId, vilkårType, eksisterendeVilkårsperioder);
+        var vilkårperioderSomSkalKopieres = hentVilkårperioderForPerioderIkkeVurdert(originalBehandlingId, vilkårType, eksisterendeVilkårsperioder);
         for (var vilkårPeriodeBuilder : vilkårperioderSomSkalKopieres) {
             vilkårBuilder.leggTil(vilkårPeriodeBuilder);
         }
         vilkårResultatBuilder.leggTil(vilkårBuilder);
+    }
+
+    private List<VilkårPeriodeBuilder> hentVilkårperioderForPerioderIkkeVurdert(Long fraBehandlingId, VilkårType vilkårType, List<VilkårPeriode> gjeldendeVilkårsperioder) {
+        var ikkeVurdertePerioder = gjeldendeVilkårsperioder.stream()
+            .filter(periode -> periode.getUtfall() == Utfall.IKKE_VURDERT)
+            .map(VilkårPeriode::getPeriode).map(p -> new LocalDateSegment<>(p.getFomDato(), p.getTomDato(), true))
+            .toList();
+
+        LocalDateTimeline<VilkårPeriode> fraVilkårResultatTidslinje = vilkårResultatRepository.hentHvisEksisterer(fraBehandlingId)
+            .map(v -> v.getVilkårTimeline(vilkårType))
+            .orElse(LocalDateTimeline.empty());
+
+        return fraVilkårResultatTidslinje.intersection(new LocalDateTimeline<>(ikkeVurdertePerioder)).segmenter()
+            .stream().map(segment -> new VilkårPeriodeBuilder(segment.getValue())
+                .medPeriode(
+                    segment.getFom(),
+                    segment.getTom()
+                )
+            ).toList();
     }
 
     public void settBostedsvilkårResultat(Long behandlingId, VilkårResultatBuilder resultatBuilder) {

--- a/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjeneste.java
+++ b/ytelse-aktivitetspenger/src/main/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjeneste.java
@@ -6,9 +6,11 @@ import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
 import no.nav.ung.kodeverk.vilkår.BostedsvilkårIkkeOppfyltÅrsak;
 import no.nav.ung.kodeverk.vilkår.Utfall;
 import no.nav.ung.kodeverk.vilkår.VilkårType;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatBuilder;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriodeBuilder;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.AktivitetspengerInngangsvilkårResultatGrunnlag;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatHolder;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.InngangsvilkårVurderingRepository;
@@ -24,6 +26,7 @@ import java.util.List;
 public class InngangsvilkårVurderingTjeneste {
 
     private InngangsvilkårVurderingRepository repository;
+    private BehandlingRepository behandlingRepository;
     private VilkårResultatRepository vilkårResultatRepository;
 
     InngangsvilkårVurderingTjeneste() {
@@ -32,8 +35,10 @@ public class InngangsvilkårVurderingTjeneste {
 
     @Inject
     public InngangsvilkårVurderingTjeneste(InngangsvilkårVurderingRepository repository,
+                                           BehandlingRepository behandlingRepository,
                                            VilkårResultatRepository vilkårResultatRepository) {
         this.repository = repository;
+        this.behandlingRepository = behandlingRepository;
         this.vilkårResultatRepository = vilkårResultatRepository;
     }
 
@@ -92,6 +97,20 @@ public class InngangsvilkårVurderingTjeneste {
             resultatBuilderForVilkår.leggTil(periodeBuilder);
         });
         vilkårResultatBuilder.leggTil(resultatBuilderForVilkår);
+    }
+
+    public void gjenopprettForrigeVurderingForPerioderIkkeVurdert(Long behandlingId, VilkårResultatBuilder vilkårResultatBuilder, VilkårType vilkårType) {
+        var originalBehandlingId = behandlingRepository.hentBehandling(behandlingId).getOriginalBehandlingId().orElse(null);
+        if (originalBehandlingId == null) {
+            return;
+        }
+        var eksisterendeVilkårsperioder = vilkårResultatBuilder.hentBuilderFor(vilkårType).build().getPerioder();
+        var vilkårBuilder = vilkårResultatBuilder.hentBuilderFor(vilkårType);
+        var vilkårperioderSomSkalKopieres = vilkårResultatRepository.hentVilkårperioderForPerioderIkkeVurdert(originalBehandlingId, vilkårType, eksisterendeVilkårsperioder);
+        for (var vilkårPeriodeBuilder : vilkårperioderSomSkalKopieres) {
+            vilkårBuilder.leggTil(vilkårPeriodeBuilder);
+        }
+        vilkårResultatBuilder.leggTil(vilkårBuilder);
     }
 
     public void settBostedsvilkårResultat(Long behandlingId, VilkårResultatBuilder resultatBuilder) {

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjenesteTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjenesteTest.java
@@ -1,0 +1,266 @@
+package no.nav.ung.ytelse.aktivitetspenger.del1;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.behandling.BehandlingType;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.kodeverk.vilkår.Avslagsårsak;
+import no.nav.ung.kodeverk.vilkår.BostedsvilkårIkkeOppfyltÅrsak;
+import no.nav.ung.kodeverk.vilkår.Utfall;
+import no.nav.ung.kodeverk.vilkår.VilkårType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatRepository;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.Vilkårene;
+import no.nav.ung.sak.behandlingslager.behandling.vilkår.periode.VilkårPeriode;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.AktivitetspengerInngangsvilkårResultatGrunnlag;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatHolder;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.BostedsvilkårResultatPeriode;
+import no.nav.ung.sak.behandlingslager.inngangsvilkår.InngangsvilkårVurderingRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.typer.Periode;
+import no.nav.ung.ytelse.aktivitetspenger.testdata.AktivitetspengerTestScenarioBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(JpaExtension.class)
+@ExtendWith(CdiAwareExtension.class)
+class InngangsvilkårVurderingTjenesteTest {
+
+    private static final Periode PERIODE_1 = new Periode(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31));
+    private static final Periode PERIODE_2 = new Periode(LocalDate.of(2026, 2, 1), LocalDate.of(2026, 2, 28));
+    private static final Periode PERIODE_3 = new Periode(LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+    private static final String VURDERT_AV = "Z999999";
+    private static final LocalDateTime VURDERT_TIDSPUNKT = LocalDateTime.of(2026, 2, 1, 10, 0);
+
+    @Inject
+    private EntityManager entityManager;
+
+    private BehandlingRepository behandlingRepository;
+    private VilkårResultatRepository vilkårResultatRepository;
+    private InngangsvilkårVurderingRepository inngangsvilkårVurderingRepository;
+    private InngangsvilkårVurderingTjeneste tjeneste;
+
+    @BeforeEach
+    void setUp() {
+        var repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        behandlingRepository = repositoryProvider.getBehandlingRepository();
+        vilkårResultatRepository = repositoryProvider.getVilkårResultatRepository();
+        inngangsvilkårVurderingRepository = new InngangsvilkårVurderingRepository(entityManager);
+        tjeneste = new InngangsvilkårVurderingTjeneste(inngangsvilkårVurderingRepository, behandlingRepository, vilkårResultatRepository);
+    }
+
+    @Test
+    void skal_lagre_bostedvurdering_og_sette_tilsvarende_vilkårsresultat() {
+        var behandling = opprettFørstegangsbehandling(
+            vilkår(PERIODE_1, Utfall.IKKE_VURDERT),
+            vilkår(PERIODE_2, Utfall.IKKE_VURDERT));
+
+        inngangsvilkårVurderingRepository.lagreBostedVurderinger(behandling.getId(), List.of(
+            oppfyltBostedvurdering(PERIODE_1),
+            ikkeOppfyltBostedvurdering(PERIODE_2, BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM)));
+
+        tjeneste.oppdaterBostedsvilkårResultatFraVurdering(behandling.getId());
+
+        var lagredeVurderinger = inngangsvilkårVurderingRepository.hentGrunnlag(behandling.getId())
+            .flatMap(AktivitetspengerInngangsvilkårResultatGrunnlag::getBostedsvilkårResultatHolder)
+            .map(BostedsvilkårResultatHolder::getVurderinger)
+            .orElseThrow();
+        assertThat(lagredeVurderinger).hasSize(2);
+        var lagretPeriode2 = lagredeVurderinger.stream().filter(v -> v.getPeriode().equals(tilIntervall(PERIODE_2))).findFirst().orElseThrow();
+        assertThat(lagretPeriode2.isGodkjent()).isFalse();
+        assertThat(lagretPeriode2.getIkkeOppfyltÅrsak()).isEqualTo(BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM);
+        assertThat(lagretPeriode2.isManuellVurdering()).isTrue();
+        assertThat(lagretPeriode2.getVurdertAv()).isEqualTo(VURDERT_AV);
+        assertThat(lagretPeriode2.getVurdertTidspunkt()).isEqualTo(VURDERT_TIDSPUNKT);
+
+        var vilkårsperioder = hentBostedsvilkårTidslinje(behandling.getId());
+        var vilkårPeriode1 = hentVilkårPeriode(vilkårsperioder, PERIODE_1);
+        assertThat(vilkårPeriode1.getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
+        assertThat(vilkårPeriode1.getErManueltVurdert()).isTrue();
+        assertThat(vilkårPeriode1.getBegrunnelse()).isEqualTo("Begrunnelse " + PERIODE_1.getFom());
+
+        var vilkårPeriode2 = hentVilkårPeriode(vilkårsperioder, PERIODE_2);
+        assertThat(vilkårPeriode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode2.getErManueltVurdert()).isTrue();
+        assertThat(vilkårPeriode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+    }
+
+    @Test
+    void skal_sette_automatisk_utfall_når_vurderingen_ikke_er_manuell() {
+        var behandling = opprettFørstegangsbehandling(vilkår(PERIODE_1, Utfall.IKKE_VURDERT));
+
+        inngangsvilkårVurderingRepository.lagreBostedVurderinger(behandling.getId(), List.of(
+            new BostedsvilkårResultatPeriode(tilIntervall(PERIODE_1), false, BostedsvilkårIkkeOppfyltÅrsak.STUDIE_ELLER_ARBEIDSSTED_UTENFOR_TRONDHEIM,
+                false, "Automatisk avslag", null, null, null)));
+
+        tjeneste.oppdaterBostedsvilkårResultatFraVurdering(behandling.getId());
+
+        var vilkårPeriode = hentVilkårPeriode(hentBostedsvilkårTidslinje(behandling.getId()), PERIODE_1);
+        assertThat(vilkårPeriode.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(vilkårPeriode.getErManueltVurdert()).isFalse();
+        assertThat(vilkårPeriode.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+    }
+
+    @Test
+    void skal_fylle_inn_ikke_vurderte_perioder_fra_forrige_behandling_uten_å_overskrive_vurdering_i_denne_behandlingen() {
+        var originalBehandling = opprettFørstegangsbehandling(
+            vilkår(PERIODE_1, Utfall.IKKE_OPPFYLT, Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE, "fra original periode 1"),
+            vilkår(PERIODE_2, Utfall.IKKE_OPPFYLT, Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE, "fra original periode 2"),
+            vilkår(PERIODE_3, Utfall.OPPFYLT, null, "fra original periode 3"));
+
+        // Periode 1 er vurdert på nytt i revurderingen, periode 2 og 3 er ikke vurdert
+        var revurdering = opprettRevurdering(originalBehandling,
+            vilkår(PERIODE_1, Utfall.OPPFYLT, null, "vurdert i denne behandlingen"),
+            vilkår(PERIODE_2, Utfall.IKKE_VURDERT),
+            vilkår(PERIODE_3, Utfall.IKKE_VURDERT));
+
+        var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(revurdering.getId()));
+        tjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(revurdering.getId(), vilkårResultatBuilder, VilkårType.BOSTEDSVILKÅR);
+        var resultat = vilkårResultatBuilder.build().getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
+
+        var periode1 = hentVilkårPeriode(resultat, PERIODE_1);
+        assertThat(periode1.getGjeldendeUtfall()).as("vurdering gjort i denne behandlingen skal ikke overskrives").isEqualTo(Utfall.OPPFYLT);
+        assertThat(periode1.getFritekstVurderingBrev()).isEqualTo("vurdert i denne behandlingen");
+
+        var periode2 = hentVilkårPeriode(resultat, PERIODE_2);
+        assertThat(periode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(periode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+        assertThat(periode2.getFritekstVurderingBrev()).isEqualTo("fra original periode 2");
+
+        var periode3 = hentVilkårPeriode(resultat, PERIODE_3);
+        assertThat(periode3.getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
+        assertThat(periode3.getFritekstVurderingBrev()).isEqualTo("fra original periode 3");
+
+        assertThat(resultat.filterValue(v -> Utfall.IKKE_VURDERT.equals(v.getGjeldendeUtfall())).isEmpty())
+            .as("ingen perioder skal stå igjen som ikke vurdert")
+            .isTrue();
+    }
+
+    @Test
+    void skal_ikke_gjenopprette_perioder_som_ikke_var_vurdert_i_forrige_behandling() {
+        var originalBehandling = opprettFørstegangsbehandling(
+            vilkår(PERIODE_1, Utfall.OPPFYLT, null, "fra original periode 1"));
+
+        var revurdering = opprettRevurdering(originalBehandling,
+            vilkår(PERIODE_1, Utfall.IKKE_VURDERT),
+            vilkår(PERIODE_2, Utfall.IKKE_VURDERT));
+
+        var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(revurdering.getId()));
+        tjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(revurdering.getId(), vilkårResultatBuilder, VilkårType.BOSTEDSVILKÅR);
+        var resultat = vilkårResultatBuilder.build().getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
+
+        assertThat(hentVilkårPeriode(resultat, PERIODE_1).getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
+        assertThat(hentVilkårPeriode(resultat, PERIODE_2).getGjeldendeUtfall())
+            .as("periode uten vurdering i forrige behandling skal fortsatt være til vurdering")
+            .isEqualTo(Utfall.IKKE_VURDERT);
+    }
+
+    @Test
+    void skal_ikke_gjenopprette_noe_når_behandlingen_ikke_har_original_behandling() {
+        var behandling = opprettFørstegangsbehandling(vilkår(PERIODE_1, Utfall.IKKE_VURDERT));
+
+        var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(behandling.getId()));
+        tjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(behandling.getId(), vilkårResultatBuilder, VilkårType.BOSTEDSVILKÅR);
+        var resultat = vilkårResultatBuilder.build().getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
+
+        assertThat(hentVilkårPeriode(resultat, PERIODE_1).getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_VURDERT);
+    }
+
+    @Test
+    void skal_fjerne_vurdering_og_sette_vilkår_til_ikke_vurdert_for_angitte_perioder() {
+        var behandling = opprettFørstegangsbehandling(
+            vilkår(PERIODE_1, Utfall.IKKE_VURDERT),
+            vilkår(PERIODE_2, Utfall.IKKE_VURDERT));
+
+        inngangsvilkårVurderingRepository.lagreBostedVurderinger(behandling.getId(), List.of(
+            oppfyltBostedvurdering(PERIODE_1),
+            oppfyltBostedvurdering(PERIODE_2)));
+        tjeneste.oppdaterBostedsvilkårResultatFraVurdering(behandling.getId());
+
+        var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(behandling.getId()));
+        tjeneste.fjernVilkårVurderingOgSettVilkårResultatIkkeVurdertForPeriode(behandling.getId(), vilkårResultatBuilder,
+            VilkårType.BOSTEDSVILKÅR, List.of(tilIntervall(PERIODE_2)));
+        var resultat = vilkårResultatBuilder.build().getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
+
+        assertThat(hentVilkårPeriode(resultat, PERIODE_1).getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
+        assertThat(hentVilkårPeriode(resultat, PERIODE_2).getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_VURDERT);
+
+        var gjenværendeVurderinger = inngangsvilkårVurderingRepository.hentGrunnlag(behandling.getId())
+            .flatMap(AktivitetspengerInngangsvilkårResultatGrunnlag::getBostedsvilkårResultatHolder)
+            .map(BostedsvilkårResultatHolder::getVurderinger)
+            .orElseThrow();
+        assertThat(gjenværendeVurderinger).hasSize(1);
+        assertThat(gjenværendeVurderinger.getFirst().getPeriode()).isEqualTo(tilIntervall(PERIODE_1));
+    }
+
+    private LocalDateTimeline<VilkårPeriode> hentBostedsvilkårTidslinje(Long behandlingId) {
+        return vilkårResultatRepository.hent(behandlingId).getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
+    }
+
+    private static VilkårPeriode hentVilkårPeriode(LocalDateTimeline<VilkårPeriode> tidslinje, Periode periode) {
+        return tidslinje.toSegments().stream()
+            .filter(s -> s.getFom().equals(periode.getFom()) && s.getTom().equals(periode.getTom()))
+            .map(s -> s.getValue())
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Fant ikke vilkårsperiode " + periode + " i " + tidslinje));
+    }
+
+    private static DatoIntervallEntitet tilIntervall(Periode periode) {
+        return DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
+    }
+
+    private static BostedsvilkårResultatPeriode oppfyltBostedvurdering(Periode periode) {
+        return new BostedsvilkårResultatPeriode(tilIntervall(periode), true, null, true,
+            "Begrunnelse " + periode.getFom(), null, VURDERT_AV, VURDERT_TIDSPUNKT);
+    }
+
+    private static BostedsvilkårResultatPeriode ikkeOppfyltBostedvurdering(Periode periode, BostedsvilkårIkkeOppfyltÅrsak årsak) {
+        return new BostedsvilkårResultatPeriode(tilIntervall(periode), false, årsak, true,
+            "Begrunnelse " + periode.getFom(), null, VURDERT_AV, VURDERT_TIDSPUNKT);
+    }
+
+    private Behandling opprettFørstegangsbehandling(VilkårsperiodeData... vilkårsperioder) {
+        var scenario = AktivitetspengerTestScenarioBuilder.builderMedSøknad();
+        leggTilVilkår(scenario, vilkårsperioder);
+        return scenario.lagre(entityManager);
+    }
+
+    private Behandling opprettRevurdering(Behandling originalBehandling, VilkårsperiodeData... vilkårsperioder) {
+        var scenario = AktivitetspengerTestScenarioBuilder.builderMedSøknad()
+            .medBehandlingType(BehandlingType.REVURDERING)
+            .medOriginalBehandling(originalBehandling, BehandlingÅrsakType.ENDRET_BOSTED);
+        leggTilVilkår(scenario, vilkårsperioder);
+        return scenario.lagre(entityManager);
+    }
+
+    private static void leggTilVilkår(AktivitetspengerTestScenarioBuilder scenario, VilkårsperiodeData... vilkårsperioder) {
+        for (var v : vilkårsperioder) {
+            scenario.leggTilVilkår(VilkårType.BOSTEDSVILKÅR, v.utfall(), v.periode(), v.avslagsårsak(), v.fritekstBrev());
+            scenario.leggTilVilkår(VilkårType.ALDERSVILKÅR, Utfall.OPPFYLT, v.periode());
+        }
+    }
+
+    private static VilkårsperiodeData vilkår(Periode periode, Utfall utfall) {
+        return new VilkårsperiodeData(periode, utfall, null, null);
+    }
+
+    private static VilkårsperiodeData vilkår(Periode periode, Utfall utfall, Avslagsårsak avslagsårsak, String fritekstBrev) {
+        return new VilkårsperiodeData(periode, utfall, avslagsårsak, fritekstBrev);
+    }
+
+    private record VilkårsperiodeData(Periode periode, Utfall utfall, Avslagsårsak avslagsårsak, String fritekstBrev) {
+    }
+}

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjenesteTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/InngangsvilkårVurderingTjenesteTest.java
@@ -42,9 +42,6 @@ class InngangsvilkårVurderingTjenesteTest {
     private static final Periode PERIODE_2 = new Periode(LocalDate.of(2026, 2, 1), LocalDate.of(2026, 2, 28));
     private static final Periode PERIODE_3 = new Periode(LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
 
-    private static final String VURDERT_AV = "Z999999";
-    private static final LocalDateTime VURDERT_TIDSPUNKT = LocalDateTime.of(2026, 2, 1, 10, 0);
-
     @Inject
     private EntityManager entityManager;
 
@@ -63,48 +60,12 @@ class InngangsvilkårVurderingTjenesteTest {
     }
 
     @Test
-    void skal_lagre_bostedvurdering_og_sette_tilsvarende_vilkårsresultat() {
-        var behandling = opprettFørstegangsbehandling(
-            vilkår(PERIODE_1, Utfall.IKKE_VURDERT),
-            vilkår(PERIODE_2, Utfall.IKKE_VURDERT));
-
-        inngangsvilkårVurderingRepository.lagreBostedVurderinger(behandling.getId(), List.of(
-            oppfyltBostedvurdering(PERIODE_1),
-            ikkeOppfyltBostedvurdering(PERIODE_2, BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM)));
-
-        tjeneste.oppdaterBostedsvilkårResultatFraVurdering(behandling.getId());
-
-        var lagredeVurderinger = inngangsvilkårVurderingRepository.hentGrunnlag(behandling.getId())
-            .flatMap(AktivitetspengerInngangsvilkårResultatGrunnlag::getBostedsvilkårResultatHolder)
-            .map(BostedsvilkårResultatHolder::getVurderinger)
-            .orElseThrow();
-        assertThat(lagredeVurderinger).hasSize(2);
-        var lagretPeriode2 = lagredeVurderinger.stream().filter(v -> v.getPeriode().equals(tilIntervall(PERIODE_2))).findFirst().orElseThrow();
-        assertThat(lagretPeriode2.isGodkjent()).isFalse();
-        assertThat(lagretPeriode2.getIkkeOppfyltÅrsak()).isEqualTo(BostedsvilkårIkkeOppfyltÅrsak.IKKE_BOSATTADRESSE_I_TRONDHEIM);
-        assertThat(lagretPeriode2.isManuellVurdering()).isTrue();
-        assertThat(lagretPeriode2.getVurdertAv()).isEqualTo(VURDERT_AV);
-        assertThat(lagretPeriode2.getVurdertTidspunkt()).isEqualTo(VURDERT_TIDSPUNKT);
-
-        var vilkårsperioder = hentBostedsvilkårTidslinje(behandling.getId());
-        var vilkårPeriode1 = hentVilkårPeriode(vilkårsperioder, PERIODE_1);
-        assertThat(vilkårPeriode1.getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
-        assertThat(vilkårPeriode1.getErManueltVurdert()).isTrue();
-        assertThat(vilkårPeriode1.getBegrunnelse()).isEqualTo("Begrunnelse " + PERIODE_1.getFom());
-
-        var vilkårPeriode2 = hentVilkårPeriode(vilkårsperioder, PERIODE_2);
-        assertThat(vilkårPeriode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
-        assertThat(vilkårPeriode2.getErManueltVurdert()).isTrue();
-        assertThat(vilkårPeriode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
-    }
-
-    @Test
     void skal_sette_automatisk_utfall_når_vurderingen_ikke_er_manuell() {
         var behandling = opprettFørstegangsbehandling(vilkår(PERIODE_1, Utfall.IKKE_VURDERT));
 
         inngangsvilkårVurderingRepository.lagreBostedVurderinger(behandling.getId(), List.of(
             new BostedsvilkårResultatPeriode(tilIntervall(PERIODE_1), false, BostedsvilkårIkkeOppfyltÅrsak.STUDIE_ELLER_ARBEIDSSTED_UTENFOR_TRONDHEIM,
-                false, "Automatisk avslag", null, null, null)));
+                false, "Automatisk avslag", null, "A111111", LocalDateTime.now())));
 
         tjeneste.oppdaterBostedsvilkårResultatFraVurdering(behandling.getId());
 
@@ -121,26 +82,33 @@ class InngangsvilkårVurderingTjenesteTest {
             vilkår(PERIODE_2, Utfall.IKKE_OPPFYLT, Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE, "fra original periode 2"),
             vilkår(PERIODE_3, Utfall.OPPFYLT, null, "fra original periode 3"));
 
-        // Periode 1 er vurdert på nytt i revurderingen, periode 2 og 3 er ikke vurdert
+        var PERIODE_1_AVKORTET = new Periode(PERIODE_1.getFom(), PERIODE_1.getTom().minusDays(15));
+        var PERIODE_2_3_FLYTTET = new Periode(PERIODE_2.getFom().minusDays(15), PERIODE_3.getTom().minusDays(15));
+
         var revurdering = opprettRevurdering(originalBehandling,
-            vilkår(PERIODE_1, Utfall.OPPFYLT, null, "vurdert i denne behandlingen"),
-            vilkår(PERIODE_2, Utfall.IKKE_VURDERT),
-            vilkår(PERIODE_3, Utfall.IKKE_VURDERT));
+            vilkår(PERIODE_1_AVKORTET, Utfall.OPPFYLT, null, "vurdert i denne behandlingen"),
+            vilkår(PERIODE_2_3_FLYTTET, Utfall.IKKE_VURDERT)
+        );
 
         var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(revurdering.getId()));
         tjeneste.gjenopprettForrigeVurderingForPerioderIkkeVurdert(revurdering.getId(), vilkårResultatBuilder, VilkårType.BOSTEDSVILKÅR);
         var resultat = vilkårResultatBuilder.build().getVilkårTimeline(VilkårType.BOSTEDSVILKÅR);
 
-        var periode1 = hentVilkårPeriode(resultat, PERIODE_1);
-        assertThat(periode1.getGjeldendeUtfall()).as("vurdering gjort i denne behandlingen skal ikke overskrives").isEqualTo(Utfall.OPPFYLT);
-        assertThat(periode1.getFritekstVurderingBrev()).isEqualTo("vurdert i denne behandlingen");
+        var vurdertPeriode = hentVilkårPeriode(resultat, PERIODE_1_AVKORTET);
+        assertThat(vurdertPeriode.getGjeldendeUtfall()).as("vurdering gjort i denne behandlingen skal ikke overskrives").isEqualTo(Utfall.OPPFYLT);
+        assertThat(vurdertPeriode.getFritekstVurderingBrev()).isEqualTo("vurdert i denne behandlingen");
+
+        var periode1 = hentVilkårPeriode(resultat, new Periode(PERIODE_1_AVKORTET.getTom().plusDays(1), PERIODE_1.getTom()));
+        assertThat(periode1.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
+        assertThat(periode1.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
+        assertThat(periode1.getFritekstVurderingBrev()).isEqualTo("fra original periode 1");
 
         var periode2 = hentVilkårPeriode(resultat, PERIODE_2);
         assertThat(periode2.getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_OPPFYLT);
         assertThat(periode2.getAvslagsårsak()).isEqualTo(Avslagsårsak.YTELSE_IKKE_TILGJENGELIG_PÅ_FOLKEREGISTRERT_ELLER_BOSTEDSADRESSE);
         assertThat(periode2.getFritekstVurderingBrev()).isEqualTo("fra original periode 2");
 
-        var periode3 = hentVilkårPeriode(resultat, PERIODE_3);
+        var periode3 = hentVilkårPeriode(resultat, new Periode(PERIODE_3.getFom(), PERIODE_2_3_FLYTTET.getTom()));
         assertThat(periode3.getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
         assertThat(periode3.getFritekstVurderingBrev()).isEqualTo("fra original periode 3");
 
@@ -182,13 +150,8 @@ class InngangsvilkårVurderingTjenesteTest {
     @Test
     void skal_fjerne_vurdering_og_sette_vilkår_til_ikke_vurdert_for_angitte_perioder() {
         var behandling = opprettFørstegangsbehandling(
-            vilkår(PERIODE_1, Utfall.IKKE_VURDERT),
-            vilkår(PERIODE_2, Utfall.IKKE_VURDERT));
-
-        inngangsvilkårVurderingRepository.lagreBostedVurderinger(behandling.getId(), List.of(
-            oppfyltBostedvurdering(PERIODE_1),
-            oppfyltBostedvurdering(PERIODE_2)));
-        tjeneste.oppdaterBostedsvilkårResultatFraVurdering(behandling.getId());
+            vilkår(PERIODE_1, Utfall.OPPFYLT),
+            vilkår(PERIODE_2, Utfall.IKKE_OPPFYLT));
 
         var vilkårResultatBuilder = Vilkårene.builderFraEksisterende(vilkårResultatRepository.hent(behandling.getId()));
         tjeneste.fjernVilkårVurderingOgSettVilkårResultatIkkeVurdertForPeriode(behandling.getId(), vilkårResultatBuilder,
@@ -197,13 +160,6 @@ class InngangsvilkårVurderingTjenesteTest {
 
         assertThat(hentVilkårPeriode(resultat, PERIODE_1).getGjeldendeUtfall()).isEqualTo(Utfall.OPPFYLT);
         assertThat(hentVilkårPeriode(resultat, PERIODE_2).getGjeldendeUtfall()).isEqualTo(Utfall.IKKE_VURDERT);
-
-        var gjenværendeVurderinger = inngangsvilkårVurderingRepository.hentGrunnlag(behandling.getId())
-            .flatMap(AktivitetspengerInngangsvilkårResultatGrunnlag::getBostedsvilkårResultatHolder)
-            .map(BostedsvilkårResultatHolder::getVurderinger)
-            .orElseThrow();
-        assertThat(gjenværendeVurderinger).hasSize(1);
-        assertThat(gjenværendeVurderinger.getFirst().getPeriode()).isEqualTo(tilIntervall(PERIODE_1));
     }
 
     private LocalDateTimeline<VilkårPeriode> hentBostedsvilkårTidslinje(Long behandlingId) {
@@ -211,7 +167,7 @@ class InngangsvilkårVurderingTjenesteTest {
     }
 
     private static VilkårPeriode hentVilkårPeriode(LocalDateTimeline<VilkårPeriode> tidslinje, Periode periode) {
-        return tidslinje.toSegments().stream()
+        return tidslinje.segmenter().stream()
             .filter(s -> s.getFom().equals(periode.getFom()) && s.getTom().equals(periode.getTom()))
             .map(s -> s.getValue())
             .findFirst()
@@ -220,16 +176,6 @@ class InngangsvilkårVurderingTjenesteTest {
 
     private static DatoIntervallEntitet tilIntervall(Periode periode) {
         return DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
-    }
-
-    private static BostedsvilkårResultatPeriode oppfyltBostedvurdering(Periode periode) {
-        return new BostedsvilkårResultatPeriode(tilIntervall(periode), true, null, true,
-            "Begrunnelse " + periode.getFom(), null, VURDERT_AV, VURDERT_TIDSPUNKT);
-    }
-
-    private static BostedsvilkårResultatPeriode ikkeOppfyltBostedvurdering(Periode periode, BostedsvilkårIkkeOppfyltÅrsak årsak) {
-        return new BostedsvilkårResultatPeriode(tilIntervall(periode), false, årsak, true,
-            "Begrunnelse " + periode.getFom(), null, VURDERT_AV, VURDERT_TIDSPUNKT);
     }
 
     private Behandling opprettFørstegangsbehandling(VilkårsperiodeData... vilkårsperioder) {

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/steg/bosatt/VurderBostedVilkårStegTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/steg/bosatt/VurderBostedVilkårStegTest.java
@@ -88,7 +88,7 @@ class VurderBostedVilkårStegTest {
         startdatoRepository = new StartdatoRepository(entityManager);
         prosessTriggereRepository = new ProsessTriggereRepository(entityManager);
         inngangsvilkårVurderingRepository = new InngangsvilkårVurderingRepository(entityManager);
-        inngangsvilkårVurderingTjeneste = new InngangsvilkårVurderingTjeneste(inngangsvilkårVurderingRepository, vilkårResultatRepository);
+        inngangsvilkårVurderingTjeneste = new InngangsvilkårVurderingTjeneste(inngangsvilkårVurderingRepository, behandlingRepository, vilkårResultatRepository);
         behandlingprosessSporingRepository = new BehandingprosessSporingRepository(entityManager);
 
         steg = lagSteg(List.of());


### PR DESCRIPTION
Behov / Bakgrunn
Når saksbehandler foreslår et opphør eller avslag, settes vilkårsperioden aktuell for avslag til IKKE_VURDERT, slik at denne kan vurderes på nytt etter brukers uttalelse. Hvis perioden i vurderingen forkortes som følge av informasjon i uttalelse, skal saksbehandler slippe å måtte forholde seg til vilkårsperioden som ikke endres.

Løsning
Henter tidligere vilkårsvurdering for perioder ikke vurdert etter at aksjonspunkt for manuell vilkårsvurdering er utført.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
