### PR TITLE
TSFF-2868 - Duplikatsøknad: makuleringsendepunkt og @ChangeTracked-regresjonsfiks

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/startdato/StartdatoGrunnlag.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/startdato/StartdatoGrunnlag.java
@@ -2,6 +2,7 @@ package no.nav.ung.sak.behandlingslager.behandling.startdato;
 
 import jakarta.persistence.*;
 import no.nav.ung.sak.behandlingslager.BaseEntitet;
+import no.nav.ung.sak.diff.ChangeTracked;
 import org.hibernate.annotations.Immutable;
 
 import java.util.Collection;
@@ -24,6 +25,7 @@ public class StartdatoGrunnlag extends BaseEntitet {
      */
     @ManyToOne
     @Immutable
+    @ChangeTracked
     @JoinColumn(name = "relevante_startdatoer_id", nullable = true, updatable = false, unique = true)
     private Startdatoer relevanteStartdatoer;
 
@@ -32,6 +34,7 @@ public class StartdatoGrunnlag extends BaseEntitet {
      */
     @ManyToOne
     @Immutable
+    @ChangeTracked
     @JoinColumn(name = "oppgitte_startdatoer_id", nullable = false, updatable = false, unique = true)
     private Startdatoer oppgitteStartdatoer;
 

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/startdato/SøktStartdato.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/behandling/startdato/SøktStartdato.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import no.nav.ung.sak.behandlingslager.BaseEntitet;
+import no.nav.ung.sak.diff.ChangeTracked;
 import no.nav.ung.sak.typer.JournalpostId;
 
 @Entity(name = "SøktStartdato")
@@ -30,9 +31,11 @@ public class SøktStartdato extends BaseEntitet implements SøktPeriodeData {
     private Long id;
 
 
+    @ChangeTracked
     @Column(name = "startdato", nullable = false)
     private LocalDate startdato;
 
+    @ChangeTracked
     @Embedded
     @AttributeOverrides(@AttributeOverride(name = "journalpostId", column = @Column(name = "journalpost_id")))
     private JournalpostId journalpostId;

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggereRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/trigger/ProsessTriggereRepository.java
@@ -10,13 +10,19 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import no.nav.k9.felles.jpa.HibernateVerktøy;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.sak.behandlingslager.behandling.EndringsresultatDiff;
 import no.nav.ung.sak.behandlingslager.behandling.EndringsresultatSnapshot;
 import no.nav.ung.sak.behandlingslager.behandling.RegisterdataDiffsjekker;
 import no.nav.ung.sak.diff.DiffResult;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Dependent
 public class ProsessTriggereRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(ProsessTriggereRepository.class);
 
     private EntityManager entityManager;
 
@@ -41,6 +47,44 @@ public class ProsessTriggereRepository {
             entityManager.persist(oppdatert);
             entityManager.flush();
         }
+    }
+
+    /**
+     * Fjerner en spesifikk trigger (identifisert ved årsak + periode) fra aktivt grunnlag for en behandling.
+     * Brukes bl.a. av forvaltning for å nøytralisere en trigger som ble opprettet av et dokument som i
+     * ettertid er markert ugyldig (f.eks. en duplikat søknad), slik at den ikke lenger forsøkes matchet
+     * mot søknadsperioder ved senere vurdering.
+     * <p>
+     * Gjør ingenting (no-op) dersom det ikke finnes noe aktivt grunnlag, eller ingen trigger matcher
+     * angitt årsak+periode - dette logges eksplisitt siden det er en stille situasjon som ellers er
+     * vanskelig å oppdage.
+     */
+    public void fjern(Long behandlingId, BehandlingÅrsakType årsak, DatoIntervallEntitet periode) {
+        var eksisterende = hentEksisterendeGrunnlag(behandlingId);
+        if (eksisterende.isEmpty()) {
+            log.warn("Fant ingen aktivt ProsessTriggere-grunnlag for behandlingId={}, ingenting å fjerne (årsak={}, periode={})", behandlingId, årsak, periode);
+            return;
+        }
+
+        var eksisterendeTriggere = eksisterende.get().getTriggere();
+        var gjenværende = eksisterendeTriggere.stream()
+            .filter(t -> !(t.getÅrsak() == årsak && t.getPeriode().equals(periode)))
+            .map(Trigger::new)
+            .collect(Collectors.toSet());
+
+        if (gjenværende.size() == eksisterendeTriggere.size()) {
+            log.warn("Fant ingen trigger som matchet årsak={} og periode={} for behandlingId={} - ingen endring gjort. Eksisterende triggere: {}",
+                årsak, periode, behandlingId, eksisterendeTriggere);
+            return;
+        }
+
+        deaktiver(eksisterende.get());
+        var oppdatert = new ProsessTriggere(behandlingId, new Triggere(gjenværende));
+        entityManager.persist(oppdatert.getTriggereEntity());
+        entityManager.persist(oppdatert);
+        entityManager.flush();
+
+        log.info("Fjernet trigger årsak={} periode={} fra behandlingId={}. Gjenværende triggere: {}", årsak, periode, behandlingId, gjenværende);
     }
 
     public Optional<ProsessTriggere> hentGrunnlagBasertPåId(Long grunnlagId) {

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/behandling/startdato/StartdatoGrunnlagDiffTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/behandlingslager/behandling/startdato/StartdatoGrunnlagDiffTest.java
@@ -1,0 +1,59 @@
+package no.nav.ung.sak.behandlingslager.behandling.startdato;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.ung.sak.behandlingslager.behandling.RegisterdataDiffsjekker;
+import no.nav.ung.sak.typer.JournalpostId;
+
+/**
+ * Regresjonstest for at {@link StartdatoGrunnlag} sine innholdsfelter er merket med
+ * {@code @ChangeTracked}. Uten denne merkingen traverserer ikke diff-mekanismen
+ * (brukt av registerinnhenting/reposisjonering, jf. {@link RegisterdataDiffsjekker})
+ * inn i feltene, og en ny søknad blir da aldri oppdaget som en endring - selv om
+ * {@link Startdatoer#getStartdatoer()} lenger ned faktisk er merket med
+ * {@code @ChangeTracked}.
+ */
+class StartdatoGrunnlagDiffTest {
+
+    private final RegisterdataDiffsjekker diffsjekker = new RegisterdataDiffsjekker(true);
+
+    @Test
+    void skal_oppdage_diff_når_oppgitte_startdatoer_har_fått_ny_søknad() {
+        var grunnlag1 = new StartdatoGrunnlag(1L);
+        grunnlag1.leggTil(List.of(new SøktStartdato(LocalDate.of(2026, 1, 1), new JournalpostId(1L))));
+
+        var grunnlag2 = new StartdatoGrunnlag(1L);
+        grunnlag2.leggTil(List.of(
+            new SøktStartdato(LocalDate.of(2026, 1, 1), new JournalpostId(1L)),
+            new SøktStartdato(LocalDate.of(2026, 6, 1), new JournalpostId(2L))));
+
+        assertThat(diffsjekker.erForskjellPå(grunnlag1, grunnlag2)).isTrue();
+    }
+
+    @Test
+    void skal_oppdage_diff_når_relevante_startdatoer_endres() {
+        var grunnlag1 = new StartdatoGrunnlag(1L);
+        grunnlag1.setRelevanteStartdatoer(new Startdatoer(List.of(new SøktStartdato(LocalDate.of(2026, 1, 1), new JournalpostId(1L)))));
+
+        var grunnlag2 = new StartdatoGrunnlag(1L);
+        grunnlag2.setRelevanteStartdatoer(new Startdatoer(List.of(new SøktStartdato(LocalDate.of(2026, 6, 1), new JournalpostId(2L)))));
+
+        assertThat(diffsjekker.erForskjellPå(grunnlag1, grunnlag2)).isTrue();
+    }
+
+    @Test
+    void skal_ikke_oppdage_diff_for_identisk_innhold() {
+        var grunnlag1 = new StartdatoGrunnlag(1L);
+        grunnlag1.leggTil(List.of(new SøktStartdato(LocalDate.of(2026, 1, 1), new JournalpostId(1L))));
+
+        var grunnlag2 = new StartdatoGrunnlag(1L);
+        grunnlag2.leggTil(List.of(new SøktStartdato(LocalDate.of(2026, 1, 1), new JournalpostId(1L))));
+
+        assertThat(diffsjekker.erForskjellPå(grunnlag1, grunnlag2)).isFalse();
+    }
+}

--- a/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggereRepositoryFjernTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/ung/sak/trigger/ProsessTriggereRepositoryFjernTest.java
@@ -1,0 +1,89 @@
+package no.nav.ung.sak.trigger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
+import no.nav.ung.sak.typer.AktørId;
+import no.nav.ung.sak.typer.Saksnummer;
+
+/**
+ * Tester {@link ProsessTriggereRepository#fjern(Long, BehandlingÅrsakType, DatoIntervallEntitet)} mot en reell
+ * (JPA-backet) database, siden metoden gjør oppslag/skriving via EntityManager på samme måte som {@code leggTil}.
+ */
+@ExtendWith(JpaExtension.class)
+@ExtendWith(CdiAwareExtension.class)
+class ProsessTriggereRepositoryFjernTest {
+
+    @Inject
+    private FagsakRepository fagsakRepository;
+    @Inject
+    private BehandlingRepository behandlingRepository;
+    @Inject
+    private ProsessTriggereRepository prosessTriggereRepository;
+
+    private Long behandlingId;
+
+    @BeforeEach
+    void setUp() {
+        var fagsak = Fagsak.opprettNy(FagsakYtelseType.UNGDOMSYTELSE, AktørId.dummy(), new Saksnummer("SAKEN"), LocalDate.now(), null);
+        fagsakRepository.opprettNy(fagsak);
+        var behandling = Behandling.forFørstegangssøknad(fagsak).build();
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        behandlingRepository.lagre(behandling, lås);
+        behandlingId = behandling.getId();
+    }
+
+    @Test
+    void skal_fjerne_matchende_trigger_og_beholde_resten() {
+        var periodeSomSkalFjernes = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
+        var periodeSomSkalBeholdes = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 29));
+        prosessTriggereRepository.leggTil(behandlingId, Set.of(
+            new Trigger(BehandlingÅrsakType.NY_SØKT_PERIODE, periodeSomSkalFjernes),
+            new Trigger(BehandlingÅrsakType.RE_HENDELSE_FØDSEL, periodeSomSkalBeholdes)
+        ));
+
+        prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, periodeSomSkalFjernes);
+
+        var gjenværende = prosessTriggereRepository.hentGrunnlag(behandlingId).orElseThrow().getTriggere();
+        assertThat(gjenværende).hasSize(1);
+        assertThat(gjenværende.iterator().next().getÅrsak()).isEqualTo(BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
+    }
+
+    @Test
+    void skal_ikke_gjøre_noe_naar_ingen_trigger_matcher() {
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
+        prosessTriggereRepository.leggTil(behandlingId, Set.of(new Trigger(BehandlingÅrsakType.RE_HENDELSE_FØDSEL, periode)));
+
+        var annenPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 31));
+        prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, annenPeriode);
+
+        var gjenværende = prosessTriggereRepository.hentGrunnlag(behandlingId).orElseThrow().getTriggere();
+        assertThat(gjenværende).hasSize(1);
+    }
+
+    @Test
+    void skal_ikke_feile_naar_det_ikke_finnes_noe_grunnlag() {
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
+
+        prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, periode);
+
+        assertThat(prosessTriggereRepository.hentGrunnlag(behandlingId)).isEmpty();
+    }
+}

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -220,7 +220,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
         String formatertBegrunnelse = "Makulert som duplikat søknad av teknisk forvaltning. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
         mottattDokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
         mottatteDokumentRepository.oppdater(mottattDokument);
-        log.info("Satt dokument journalpostId={} fra status GYLDIG til UGYLDIG med begrunnelse: {}", journalpostId.getVerdi(), formatertBegrunnelse);
+        log.info("Satt dokument journalpostId={} fra status GYLDIG til UGYLDIG.", journalpostId.getVerdi());
 
         prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, periode);
 

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -15,15 +15,25 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import no.nav.k9.prosesstask.api.ProsessTaskData;
+import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.k9.felles.sikkerhet.abac.*;
+import no.nav.k9.søknad.Søknad;
+import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse;
 import no.nav.ung.kodeverk.abac.StandardAbacAttributt;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.dokument.DokumentStatus;
+import no.nav.ung.sak.behandling.prosessering.task.TilbakeTilStartBehandlingTask;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.kontrakt.KortTekst;
 import no.nav.ung.sak.kontrakt.behandling.SaksnummerDto;
+import no.nav.ung.sak.mottak.dokumentmottak.SøknadParser;
+import no.nav.ung.sak.trigger.ProsessTriggereRepository;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
 import no.nav.ung.sak.web.app.tjenester.forvaltning.dump.logg.DiagnostikkFagsakLogg;
@@ -49,8 +59,15 @@ public class ForvaltningMottattDokumentRestTjeneste {
     );
     private static final Logger log = LoggerFactory.getLogger(ForvaltningMottattDokumentRestTjeneste.class);
 
+    private static final Set<Brevkode> TILLATT_BREVKODE_MAKULERING = Set.of(
+        Brevkode.UNGDOMSYTELSE_SOKNAD
+    );
+
     private FagsakRepository fagsakRepository;
     private MottatteDokumentRepository mottatteDokumentRepository;
+    private ProsessTriggereRepository prosessTriggereRepository;
+    private ProsessTaskTjeneste taskTjeneste;
+    private SøknadParser søknadParser;
     private EntityManager entityManager;
 
     public ForvaltningMottattDokumentRestTjeneste() {
@@ -60,9 +77,15 @@ public class ForvaltningMottattDokumentRestTjeneste {
     @Inject
     public ForvaltningMottattDokumentRestTjeneste(FagsakRepository fagsakRepository,
                                                   MottatteDokumentRepository mottatteDokumentRepository,
+                                                  ProsessTriggereRepository prosessTriggereRepository,
+                                                  ProsessTaskTjeneste taskTjeneste,
+                                                  SøknadParser søknadParser,
                                                   EntityManager entityManager) {
         this.fagsakRepository = fagsakRepository;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
+        this.prosessTriggereRepository = prosessTriggereRepository;
+        this.taskTjeneste = taskTjeneste;
+        this.søknadParser = søknadParser;
         this.entityManager = entityManager;
     }
 
@@ -118,6 +141,105 @@ public class ForvaltningMottattDokumentRestTjeneste {
         entityManager.flush();
 
         log.info("Manuelt markert mottatt dokument med journalpostId={} av type {} som ugyldig.", mottattDokument.getJournalpostId().getVerdi(), mottattDokument.getType());
+
+        return Response.ok().build();
+    }
+
+    /**
+     * Makulerer en duplikat søknad: markerer det mottatte dokumentet som ugyldig, fjerner den tilhørende
+     * NY_SØKT_PERIODE-prosesstriggeren for behandlingen (utledet ved å reparse søknaden på samme måte som
+     * ved opprinnelig mottak), og sender behandlingen tilbake til start slik at perioder/vilkår vurderes på
+     * nytt uten den duplikate søknaden.
+     * <p>
+     * Brukes for tilfeller der en digital søknad viser seg å være et rent duplikat av en allerede
+     * registrert (f.eks. papir-)søknad, og der den digitale søknadens trigger ellers vil føre til at
+     * behandlingen krasjer i vilkårsvurderingen (jf. "Hadde startdato som ikke kunne matches med søknadsperiode").
+     */
+    @POST
+    @Path("/makuler-duplikat-soknad")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(description = "Makulerer en duplikat søknad: markerer dokumentet ugyldig, fjerner tilhørende prosesstrigger og sender behandlingen tilbake til start.",
+        summary = ("Makulerer duplikat søknad og resetter behandlingen"), tags = "forvaltning")
+    @Produces(JSON_UTF8)
+    @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
+    public Response makulerDuplikatSøknad(@Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtSupplier.class) MarkerDokumentUgyldigRequest dto) {
+        log.info("Starter makulering av duplikat søknad: saksnummer={}, journalpostId={}", dto.saksnummer().getVerdi(), dto.journalpostId().getJournalpostId().getVerdi());
+
+        var fagsakOpt = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer());
+        if (fagsakOpt.isEmpty()) {
+            String feilmelding = "Fant ikke fagsak for saksnummer: " + dto.saksnummer().getVerdi();
+            log.warn(feilmelding);
+            return Response.status(Response.Status.NOT_FOUND).entity(feilmelding).build();
+        }
+        Fagsak fagsak = fagsakOpt.get();
+        Long fagsakId = fagsak.getId();
+        JournalpostId journalpostId = dto.journalpostId().getJournalpostId();
+        List<MottattDokument> mottattDokuments = mottatteDokumentRepository.hentMottatteDokument(fagsakId, List.of(journalpostId));
+
+        if (mottattDokuments.isEmpty()) {
+            String feilmelding = "Fant ingen dokumenter for saksnummer " + dto.saksnummer().getVerdi() + " og journalpostId " + journalpostId.getVerdi();
+            log.warn(feilmelding);
+            return Response.status(Response.Status.NOT_FOUND).entity(feilmelding).build();
+        }
+        if (mottattDokuments.size() > 1) {
+            String feilmelding = "Forventet maks 1 dokument, men fant " + mottattDokuments.size();
+            log.warn(feilmelding);
+            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        }
+
+        MottattDokument mottattDokument = mottattDokuments.getFirst();
+        Long behandlingId = mottattDokument.getBehandlingId();
+        log.info("Fant mottatt dokument: behandlingId={}, journalpostId={}, status={}, type={}",
+            behandlingId, journalpostId.getVerdi(), mottattDokument.getStatus(), mottattDokument.getType());
+
+        if (!TILLATT_BREVKODE_MAKULERING.contains(mottattDokument.getType())) {
+            String feilmelding = "Dokumentet har brevkode " + mottattDokument.getType() + ", makulering av duplikat er bare støttet for brevkodene " + TILLATT_BREVKODE_MAKULERING;
+            log.warn(feilmelding);
+            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        }
+
+        if (mottattDokument.getStatus() != DokumentStatus.GYLDIG) {
+            String feilmelding = "Forventet at dokument har status GYLDIG (ferdigbehandlet søknad), men hadde: " + mottattDokument.getStatus();
+            log.warn(feilmelding);
+            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        }
+
+        if (behandlingId == null) {
+            String feilmelding = "Dokumentet med journalpostId=" + journalpostId.getVerdi() + " har ingen tilknyttet behandlingId";
+            log.warn(feilmelding);
+            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        }
+
+        log.info("Reparser søknad for journalpostId={} for å utlede periode for trigger-fjerning", journalpostId.getVerdi());
+        Søknad søknad = søknadParser.parseSøknad(mottattDokument);
+        Ungdomsytelse ytelse = (Ungdomsytelse) søknad.getYtelse();
+        var søknadsperiode = ytelse.getSøknadsperiode();
+        DatoIntervallEntitet periode = DatoIntervallEntitet.fraOgMedTilOgMed(søknadsperiode.getFraOgMed(), søknadsperiode.getTilOgMed());
+        log.info("Utledet søknadsperiode={} fra journalpostId={} for behandlingId={}", periode, journalpostId.getVerdi(), behandlingId);
+
+        String formatertBegrunnelse = "Makulert som duplikat søknad av teknisk forvaltning. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
+        mottattDokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
+        mottatteDokumentRepository.oppdater(mottattDokument);
+        log.info("Satt dokument journalpostId={} fra status GYLDIG til UGYLDIG med begrunnelse: {}", journalpostId.getVerdi(), formatertBegrunnelse);
+
+        prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, periode);
+
+        log.info("Oppretter TilbakeTilStartBehandlingTask for behandlingId={} (manueltOpprettet=true)", behandlingId);
+        ProsessTaskData prosessTaskData = ProsessTaskData.forProsessTask(TilbakeTilStartBehandlingTask.class);
+        prosessTaskData.setCallIdFraEksisterende();
+        prosessTaskData.setBehandling(fagsakId, behandlingId, fagsak.getAktørId().getId());
+        prosessTaskData.setProperty(TilbakeTilStartBehandlingTask.PROPERTY_MANUELT_OPPRETTET, Boolean.toString(true));
+        taskTjeneste.lagre(prosessTaskData);
+        log.info("Opprettet task id={} for behandlingId={}", prosessTaskData.getId(), behandlingId);
+
+        String diagnostikkTekst = ("Makulert duplikat søknad (journalpostId=%s): dokument satt til UGYLDIG, tilhørende prosesstrigger " +
+            "(NY_SØKT_PERIODE, periode=%s) forsøkt fjernet, behandling sendt tilbake til start. Begrunnelse: %s")
+            .formatted(journalpostId.getVerdi(), periode, dto.begrunnelse().getTekst());
+        entityManager.persist(new DiagnostikkFagsakLogg(fagsakId, "/makuler-duplikat-soknad", diagnostikkTekst));
+        entityManager.flush();
+
+        log.info("Makulering fullført for saksnummer={}, journalpostId={}, behandlingId={}: dokument=UGYLDIG, trigger-fjerning forsøkt for periode={}, task opprettet={}",
+            dto.saksnummer().getVerdi(), journalpostId.getVerdi(), behandlingId, periode, prosessTaskData.getId());
 
         return Response.ok().build();
     }

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -25,8 +25,10 @@ import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.dokument.DokumentStatus;
 import no.nav.ung.sak.behandling.prosessering.task.TilbakeTilStartBehandlingTask;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottattDokument;
 import no.nav.ung.sak.behandlingslager.behandling.motattdokument.MottatteDokumentRepository;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
@@ -65,6 +67,7 @@ public class ForvaltningMottattDokumentRestTjeneste {
 
     private FagsakRepository fagsakRepository;
     private MottatteDokumentRepository mottatteDokumentRepository;
+    private BehandlingRepository behandlingRepository;
     private ProsessTriggereRepository prosessTriggereRepository;
     private ProsessTaskTjeneste taskTjeneste;
     private SøknadParser søknadParser;
@@ -77,12 +80,14 @@ public class ForvaltningMottattDokumentRestTjeneste {
     @Inject
     public ForvaltningMottattDokumentRestTjeneste(FagsakRepository fagsakRepository,
                                                   MottatteDokumentRepository mottatteDokumentRepository,
+                                                  BehandlingRepository behandlingRepository,
                                                   ProsessTriggereRepository prosessTriggereRepository,
                                                   ProsessTaskTjeneste taskTjeneste,
                                                   SøknadParser søknadParser,
                                                   EntityManager entityManager) {
         this.fagsakRepository = fagsakRepository;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
+        this.behandlingRepository = behandlingRepository;
         this.prosessTriggereRepository = prosessTriggereRepository;
         this.taskTjeneste = taskTjeneste;
         this.søknadParser = søknadParser;
@@ -208,6 +213,13 @@ public class ForvaltningMottattDokumentRestTjeneste {
             String feilmelding = "Dokumentet med journalpostId=" + journalpostId.getVerdi() + " har ingen tilknyttet behandlingId";
             log.warn(feilmelding);
             return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        }
+
+        Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
+        if (behandling.getStatus().erFerdigbehandletStatus()) {
+            String feilmelding = "Behandling " + behandlingId + " er allerede ferdigbehandlet (status=" + behandling.getStatus() + "), kan ikke makulere søknad";
+            log.warn(feilmelding);
+            return Response.status(Response.Status.CONFLICT).entity(feilmelding).build();
         }
 
         log.info("Reparser søknad for journalpostId={} for å utlede periode for trigger-fjerning", journalpostId.getVerdi());

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjeneste.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -172,88 +173,113 @@ public class ForvaltningMottattDokumentRestTjeneste {
 
         var fagsakOpt = fagsakRepository.hentSakGittSaksnummer(dto.saksnummer());
         if (fagsakOpt.isEmpty()) {
-            String feilmelding = "Fant ikke fagsak for saksnummer: " + dto.saksnummer().getVerdi();
-            log.warn(feilmelding);
-            return Response.status(Response.Status.NOT_FOUND).entity(feilmelding).build();
+            return feil(Response.Status.NOT_FOUND, "Fant ikke fagsak for saksnummer: " + dto.saksnummer().getVerdi());
         }
         Fagsak fagsak = fagsakOpt.get();
-        Long fagsakId = fagsak.getId();
         JournalpostId journalpostId = dto.journalpostId().getJournalpostId();
-        List<MottattDokument> mottattDokuments = mottatteDokumentRepository.hentMottatteDokument(fagsakId, List.of(journalpostId));
 
-        if (mottattDokuments.isEmpty()) {
-            String feilmelding = "Fant ingen dokumenter for saksnummer " + dto.saksnummer().getVerdi() + " og journalpostId " + journalpostId.getVerdi();
-            log.warn(feilmelding);
-            return Response.status(Response.Status.NOT_FOUND).entity(feilmelding).build();
-        }
-        if (mottattDokuments.size() > 1) {
-            String feilmelding = "Forventet maks 1 dokument, men fant " + mottattDokuments.size();
-            log.warn(feilmelding);
-            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
-        }
+        List<MottattDokument> dokumenter = mottatteDokumentRepository.hentMottatteDokument(fagsak.getId(), List.of(journalpostId));
+        var dokumentSettFeil = validerDokumentSett(dokumenter, dto.saksnummer(), journalpostId);
+        if (dokumentSettFeil.isPresent()) return dokumentSettFeil.get();
 
-        MottattDokument mottattDokument = mottattDokuments.getFirst();
-        Long behandlingId = mottattDokument.getBehandlingId();
+        MottattDokument mottattDokument = dokumenter.getFirst();
         log.info("Fant mottatt dokument: behandlingId={}, journalpostId={}, status={}, type={}",
-            behandlingId, journalpostId.getVerdi(), mottattDokument.getStatus(), mottattDokument.getType());
+            mottattDokument.getBehandlingId(), journalpostId.getVerdi(), mottattDokument.getStatus(), mottattDokument.getType());
 
-        if (!TILLATT_BREVKODE_MAKULERING.contains(mottattDokument.getType())) {
-            String feilmelding = "Dokumentet har brevkode " + mottattDokument.getType() + ", makulering av duplikat er bare støttet for brevkodene " + TILLATT_BREVKODE_MAKULERING;
-            log.warn(feilmelding);
-            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        var dokumentFeil = validerDokumentForMakulering(mottattDokument, journalpostId);
+        if (dokumentFeil.isPresent()) return dokumentFeil.get();
+
+        var behandlingFeil = validerBehandlingÅpen(mottattDokument.getBehandlingId());
+        if (behandlingFeil.isPresent()) return behandlingFeil.get();
+
+        // --- Utfør makulering ---
+        Long behandlingId = mottattDokument.getBehandlingId();
+        DatoIntervallEntitet periode = parseSøknadsperiode(mottattDokument, journalpostId, behandlingId);
+        ugyldiggjørDokument(mottattDokument, dto.begrunnelse().getTekst(), journalpostId);
+        prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, periode);
+        opprettTilbakeTilStartTask(fagsak, behandlingId);
+        loggDiagnostikk(fagsak.getId(), journalpostId, behandlingId, periode, dto.begrunnelse().getTekst());
+
+        log.info("Makulering fullført for saksnummer={}, journalpostId={}, behandlingId={}: dokument=UGYLDIG, trigger-fjerning forsøkt for periode={}",
+            dto.saksnummer().getVerdi(), journalpostId.getVerdi(), behandlingId, periode);
+
+        return Response.ok().build();
+    }
+
+    private Optional<Response> validerDokumentSett(List<MottattDokument> dokumenter, Saksnummer saksnummer, JournalpostId journalpostId) {
+        if (dokumenter.isEmpty()) {
+            return Optional.of(feil(Response.Status.NOT_FOUND,
+                "Fant ingen dokumenter for saksnummer " + saksnummer.getVerdi() + " og journalpostId " + journalpostId.getVerdi()));
         }
-
-        if (mottattDokument.getStatus() != DokumentStatus.GYLDIG) {
-            String feilmelding = "Forventet at dokument har status GYLDIG (ferdigbehandlet søknad), men hadde: " + mottattDokument.getStatus();
-            log.warn(feilmelding);
-            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+        if (dokumenter.size() > 1) {
+            return Optional.of(feil(Response.Status.BAD_REQUEST,
+                "Forventet maks 1 dokument, men fant " + dokumenter.size()));
         }
+        return Optional.empty();
+    }
 
-        if (behandlingId == null) {
-            String feilmelding = "Dokumentet med journalpostId=" + journalpostId.getVerdi() + " har ingen tilknyttet behandlingId";
-            log.warn(feilmelding);
-            return Response.status(Response.Status.BAD_REQUEST).entity(feilmelding).build();
+    private Optional<Response> validerDokumentForMakulering(MottattDokument dokument, JournalpostId journalpostId) {
+        if (!TILLATT_BREVKODE_MAKULERING.contains(dokument.getType())) {
+            return Optional.of(feil(Response.Status.BAD_REQUEST,
+                "Dokumentet har brevkode " + dokument.getType() + ", makulering av duplikat er bare støttet for brevkodene " + TILLATT_BREVKODE_MAKULERING));
         }
+        if (dokument.getStatus() != DokumentStatus.GYLDIG) {
+            return Optional.of(feil(Response.Status.BAD_REQUEST,
+                "Forventet at dokument har status GYLDIG (ferdigbehandlet søknad), men hadde: " + dokument.getStatus()));
+        }
+        if (dokument.getBehandlingId() == null) {
+            return Optional.of(feil(Response.Status.BAD_REQUEST,
+                "Dokumentet med journalpostId=" + journalpostId.getVerdi() + " har ingen tilknyttet behandlingId"));
+        }
+        return Optional.empty();
+    }
 
+    private Optional<Response> validerBehandlingÅpen(Long behandlingId) {
         Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
         if (behandling.getStatus().erFerdigbehandletStatus()) {
-            String feilmelding = "Behandling " + behandlingId + " er allerede ferdigbehandlet (status=" + behandling.getStatus() + "), kan ikke makulere søknad";
-            log.warn(feilmelding);
-            return Response.status(Response.Status.CONFLICT).entity(feilmelding).build();
+            return Optional.of(feil(Response.Status.CONFLICT,
+                "Behandling " + behandlingId + " er allerede ferdigbehandlet (status=" + behandling.getStatus() + "), kan ikke makulere søknad"));
         }
+        return Optional.empty();
+    }
 
+    private DatoIntervallEntitet parseSøknadsperiode(MottattDokument dokument, JournalpostId journalpostId, Long behandlingId) {
         log.info("Reparser søknad for journalpostId={} for å utlede periode for trigger-fjerning", journalpostId.getVerdi());
-        Søknad søknad = søknadParser.parseSøknad(mottattDokument);
-        Ungdomsytelse ytelse = (Ungdomsytelse) søknad.getYtelse();
-        var søknadsperiode = ytelse.getSøknadsperiode();
+        Søknad søknad = søknadParser.parseSøknad(dokument);
+        var søknadsperiode = ((Ungdomsytelse) søknad.getYtelse()).getSøknadsperiode();
         DatoIntervallEntitet periode = DatoIntervallEntitet.fraOgMedTilOgMed(søknadsperiode.getFraOgMed(), søknadsperiode.getTilOgMed());
         log.info("Utledet søknadsperiode={} fra journalpostId={} for behandlingId={}", periode, journalpostId.getVerdi(), behandlingId);
+        return periode;
+    }
 
-        String formatertBegrunnelse = "Makulert som duplikat søknad av teknisk forvaltning. Begrunnelse: %s".formatted(dto.begrunnelse().getTekst());
-        mottattDokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
-        mottatteDokumentRepository.oppdater(mottattDokument);
+    private void ugyldiggjørDokument(MottattDokument dokument, String begrunnelse, JournalpostId journalpostId) {
+        String formatertBegrunnelse = "Makulert som duplikat søknad av teknisk forvaltning. Begrunnelse: %s".formatted(begrunnelse);
+        dokument.setFeilmeldingOgOppdaterStatus(formatertBegrunnelse);
+        mottatteDokumentRepository.oppdater(dokument);
         log.info("Satt dokument journalpostId={} fra status GYLDIG til UGYLDIG.", journalpostId.getVerdi());
+    }
 
-        prosessTriggereRepository.fjern(behandlingId, BehandlingÅrsakType.NY_SØKT_PERIODE, periode);
-
+    private void opprettTilbakeTilStartTask(Fagsak fagsak, Long behandlingId) {
         log.info("Oppretter TilbakeTilStartBehandlingTask for behandlingId={} (manueltOpprettet=true)", behandlingId);
         ProsessTaskData prosessTaskData = ProsessTaskData.forProsessTask(TilbakeTilStartBehandlingTask.class);
         prosessTaskData.setCallIdFraEksisterende();
-        prosessTaskData.setBehandling(fagsakId, behandlingId, fagsak.getAktørId().getId());
+        prosessTaskData.setBehandling(fagsak.getId(), behandlingId, fagsak.getAktørId().getId());
         prosessTaskData.setProperty(TilbakeTilStartBehandlingTask.PROPERTY_MANUELT_OPPRETTET, Boolean.toString(true));
         taskTjeneste.lagre(prosessTaskData);
-        log.info("Opprettet task id={} for behandlingId={}", prosessTaskData.getId(), behandlingId);
+        log.info("Opprettet TilbakeTilStartBehandlingTask for behandlingId={}", behandlingId);
+    }
 
+    private void loggDiagnostikk(Long fagsakId, JournalpostId journalpostId, Long behandlingId, DatoIntervallEntitet periode, String begrunnelse) {
         String diagnostikkTekst = ("Makulert duplikat søknad (journalpostId=%s): dokument satt til UGYLDIG, tilhørende prosesstrigger " +
             "(NY_SØKT_PERIODE, periode=%s) forsøkt fjernet, behandling sendt tilbake til start. Begrunnelse: %s")
-            .formatted(journalpostId.getVerdi(), periode, dto.begrunnelse().getTekst());
+            .formatted(journalpostId.getVerdi(), periode, begrunnelse);
         entityManager.persist(new DiagnostikkFagsakLogg(fagsakId, "/makuler-duplikat-soknad", diagnostikkTekst));
         entityManager.flush();
+    }
 
-        log.info("Makulering fullført for saksnummer={}, journalpostId={}, behandlingId={}: dokument=UGYLDIG, trigger-fjerning forsøkt for periode={}, task opprettet={}",
-            dto.saksnummer().getVerdi(), journalpostId.getVerdi(), behandlingId, periode, prosessTaskData.getId());
-
-        return Response.ok().build();
+    private Response feil(Response.Status status, String melding) {
+        log.warn(melding);
+        return Response.status(status).entity(melding).build();
     }
 
     public record MarkerDokumentUgyldigRequest(

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -8500,6 +8500,32 @@
         "tags" : [ "formidling" ]
       }
     },
+    "/api/forvaltning/makuler-duplikat-soknad" : {
+      "post" : {
+        "description" : "Makulerer en duplikat søknad: markerer dokumentet ugyldig, fjerner tilhørende prosesstrigger og sender behandlingen tilbake til start.",
+        "operationId" : "makulerDuplikatSøknad",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json; charset=UTF-8" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Makulerer duplikat søknad og resetter behandlingen",
+        "tags" : [ "forvaltning" ]
+      }
+    },
     "/api/forvaltning/marker-ugyldig" : {
       "post" : {
         "description" : "Markerer et mottatt dokument som ugyldig",

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -4,6 +4,11 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.Response;
 import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.k9.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.k9.søknad.Søknad;
+import no.nav.k9.søknad.felles.type.Periode;
+import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse;
+import no.nav.ung.kodeverk.behandling.BehandlingÅrsakType;
 import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
 import no.nav.ung.kodeverk.dokument.Brevkode;
 import no.nav.ung.kodeverk.dokument.DokumentStatus;
@@ -15,8 +20,11 @@ import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepositor
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
 import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
 import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.typer.tid.DatoIntervallEntitet;
 import no.nav.ung.sak.kontrakt.KortTekst;
+import no.nav.ung.sak.mottak.dokumentmottak.SøknadParser;
 import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
+import no.nav.ung.sak.trigger.ProsessTriggereRepository;
 import no.nav.ung.sak.typer.JournalpostId;
 import no.nav.ung.sak.typer.Saksnummer;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +34,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(CdiAwareExtension.class)
 @ExtendWith(JpaExtension.class)
@@ -41,6 +53,9 @@ class ForvaltningMottattDokumentRestTjenesteTest {
     private MottatteDokumentRepository mottatteDokumentRepository;
     private BehandlingRepository behandlingRepository;
     private FagsakRepository fagsakRepository;
+    private ProsessTriggereRepository prosessTriggereRepository;
+    private ProsessTaskTjeneste taskTjeneste;
+    private SøknadParser søknadParser;
     private ForvaltningMottattDokumentRestTjeneste tjeneste;
 
     private final Fagsak fagsak = FagsakBuilder.nyFagsak(FagsakYtelseType.UNGDOMSYTELSE).medSaksnummer(SAKSNUMMER).build();
@@ -51,10 +66,16 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         mottatteDokumentRepository = new MottatteDokumentRepository(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
         fagsakRepository = new FagsakRepository(entityManager);
+        prosessTriggereRepository = mock(ProsessTriggereRepository.class);
+        taskTjeneste = mock(ProsessTaskTjeneste.class);
+        søknadParser = mock(SøknadParser.class);
 
         tjeneste = new ForvaltningMottattDokumentRestTjeneste(
             fagsakRepository,
             mottatteDokumentRepository,
+            prosessTriggereRepository,
+            taskTjeneste,
+            søknadParser,
             entityManager
         );
 
@@ -162,6 +183,83 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
     }
 
+    @Test
+    void skal_makulere_duplikat_soknad_marker_ugyldig_fjerne_trigger_og_sende_tilbake_til_start() {
+        // Arrange
+        var periode = new Periode(LocalDate.of(2024, 1, 1), LocalDate.of(9999, 12, 31));
+        var dokumentId = lagreSøknadDokument();
+        stubSøknadParser(periode);
+
+        var request = lagRequest();
+
+        // Act
+        Response response = tjeneste.makulerDuplikatSøknad(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        var oppdatert = mottatteDokumentRepository.hentMottattDokument(dokumentId).orElseThrow();
+        assertThat(oppdatert.getStatus()).isEqualTo(DokumentStatus.UGYLDIG);
+        assertThat(oppdatert.getFeilmelding()).contains("Makulert som duplikat søknad").contains(FEILMELDING);
+
+        var forventetPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFraOgMed(), periode.getTilOgMed());
+        verify(prosessTriggereRepository).fjern(behandling.getId(), BehandlingÅrsakType.NY_SØKT_PERIODE, forventetPeriode);
+        verify(taskTjeneste).lagre(any(no.nav.k9.prosesstask.api.ProsessTaskData.class));
+
+        Long antallDiagnostikk = entityManager.createQuery(
+                "select count(d) from DiagnostikkFagsakLogg d where d.fagsakId = :fagsakId", Long.class)
+            .setParameter("fagsakId", fagsak.getId())
+            .getSingleResult();
+        assertThat(antallDiagnostikk).isEqualTo(1L);
+    }
+
+    @Test
+    void skal_returnere_400_ved_makulering_naar_brevkode_ikke_er_soknad() {
+        // Arrange
+        var dokument = new MottattDokument.Builder()
+            .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
+            .medType(Brevkode.UNGDOMSYTELSE_VARSEL_UTTALELSE)
+            .medMottattDato(LocalDate.now())
+            .medFagsakId(fagsak.getId())
+            .medBehandlingId(behandling.getId())
+            .medPayload("{}")
+            .build();
+        mottatteDokumentRepository.lagre(dokument, DokumentStatus.GYLDIG);
+
+        var request = lagRequest();
+
+        // Act
+        Response response = tjeneste.makulerDuplikatSøknad(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    void skal_returnere_400_ved_makulering_naar_status_ikke_er_gyldig() {
+        // Arrange - søknad som ennå ikke er ferdigbehandlet (status MOTTATT)
+        var dokument = new MottattDokument.Builder()
+            .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
+            .medType(Brevkode.UNGDOMSYTELSE_SOKNAD)
+            .medMottattDato(LocalDate.now())
+            .medFagsakId(fagsak.getId())
+            .medBehandlingId(behandling.getId())
+            .medPayload("{}")
+            .build();
+        mottatteDokumentRepository.lagre(dokument, DokumentStatus.MOTTATT);
+
+        var request = lagRequest();
+
+        // Act
+        Response response = tjeneste.makulerDuplikatSøknad(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
     // --- helpers ---
 
     private Long lagreMottattDokument() {
@@ -173,6 +271,26 @@ class ForvaltningMottattDokumentRestTjenesteTest {
             .medBehandlingId(behandling.getId())
             .build();
         return mottatteDokumentRepository.lagre(dokument, DokumentStatus.MOTTATT).getId();
+    }
+
+    private Long lagreSøknadDokument() {
+        var dokument = new MottattDokument.Builder()
+            .medJournalPostId(new JournalpostId(JOURNALPOST_ID))
+            .medType(Brevkode.UNGDOMSYTELSE_SOKNAD)
+            .medMottattDato(LocalDate.now())
+            .medFagsakId(fagsak.getId())
+            .medBehandlingId(behandling.getId())
+            .medPayload("{}")
+            .build();
+        return mottatteDokumentRepository.lagre(dokument, DokumentStatus.GYLDIG).getId();
+    }
+
+    private void stubSøknadParser(Periode periode) {
+        Ungdomsytelse ytelse = mock(Ungdomsytelse.class);
+        when(ytelse.getSøknadsperiode()).thenReturn(periode);
+        Søknad søknad = mock(Søknad.class);
+        when(søknad.<Ungdomsytelse>getYtelse()).thenReturn(ytelse);
+        when(søknadParser.parseSøknad(any())).thenReturn(søknad);
     }
 
     private ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest lagRequest() {

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningMottattDokumentRestTjenesteTest.java
@@ -73,6 +73,7 @@ class ForvaltningMottattDokumentRestTjenesteTest {
         tjeneste = new ForvaltningMottattDokumentRestTjeneste(
             fagsakRepository,
             mottatteDokumentRepository,
+            behandlingRepository,
             prosessTriggereRepository,
             taskTjeneste,
             søknadParser,
@@ -214,6 +215,24 @@ class ForvaltningMottattDokumentRestTjenesteTest {
             .setParameter("fagsakId", fagsak.getId())
             .getSingleResult();
         assertThat(antallDiagnostikk).isEqualTo(1L);
+    }
+
+    @Test
+    void skal_returnere_409_ved_makulering_naar_behandling_er_avsluttet() {
+        // Arrange
+        lagreSøknadDokument();
+
+        behandling.avsluttBehandling();
+        BehandlingLås lås = behandlingRepository.taSkriveLås(behandling);
+        behandlingRepository.lagre(behandling, lås);
+
+        var request = lagRequest();
+
+        // Act
+        Response response = tjeneste.makulerDuplikatSøknad(request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.CONFLICT.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
### Behov / Bakgrunn

Behandling feilet i `VurderUngdomsprogramVilkårSteg` med `IllegalStateException` («Hadde startdato som ikke kunne matches med søknadsperiode»), fordi en digital søknad kom inn som duplikat etter at saksbehandler allerede hadde registrert en papirsøknad. Ungdomsprogramytelsen er ikke ment å motta mer enn én søknad, og systemet har i dag ingen sperre mot dette ved mottak.

Root cause-analysen avdekket i tillegg en separat, generell regresjon: `StartdatoGrunnlag` (søknadsdata-grunnlaget) manglet `@ChangeTracked` på sine felter, slik at diff-mekanismen som reposisjonerer behandlinger til `INIT_PERIODER` aldri oppdaget at en ny søknad hadde kommet inn på en allerede prosessert/revurdert behandling. Git-historikk (`git log -S"@ChangeTracked"`) bekrefter at dette ble fjernet ved en feil i PR #1157 (commit `8125401f5`) — en regresjon, ikke bevisst design.

### Løsning

**1. Forvaltningsendepunkt for å makulere duplikatsøknad** (`POST /forvaltning/makuler-duplikat-soknad`):
- Markerer det mottatte dokumentet (kun brevkode `UNGDOMSYTELSE_SOKNAD`) som ugyldig.
- Fjerner tilhørende `NY_SØKT_PERIODE`-prosesstrigger for behandlingen (ny `ProsessTriggereRepository.fjern`), med periode utledet ved å reparse søknaden på samme måte som ved opprinnelig mottak.
- Sender behandlingen tilbake til start (`TilbakeTilStartBehandlingTask`) slik at perioder/vilkår vurderes på nytt uten den duplikate søknaden.
- Logger et diagnostikkinnslag (`DiagnostikkFagsakLogg`) med begrunnelse for sporbarhet.

Brukes til manuell opprydding i konkrete, identifiserte saker der en duplikat søknad ellers fører til at behandlingen krasjer i vilkårsvurderingen.

**2. `@ChangeTracked` på `StartdatoGrunnlag`/`SøktStartdato`** (separat, generell diff-fiks):
- La til `@ChangeTracked` på `StartdatoGrunnlag.relevanteStartdatoer` og `.oppgitteStartdatoer`.
- La til `@ChangeTracked` også på `SøktStartdato.startdato` og `.journalpostId` (bladnivået under `Startdatoer.startdatoer`) — uten dette forblir diff-traverseringen «død» selv med forrige punkt på plass, siden `TraverseGraph` krever `@ChangeTracked` helt ned til et faktisk blad for å ekstrahere og sammenligne verdier.
- Sikrer at systemet korrekt oppdager og reposisjonerer til `INIT_PERIODER` når `StartdatoGrunnlag` faktisk endres på en allerede prosessert behandling, fremfor å krasje.

### Andre endringer

- `ProsessTriggereRepositoryFjernTest`: tester for ny `fjern`-metode.
- `ForvaltningMottattDokumentRestTjenesteTest`: tester for nytt endepunkt.
- `StartdatoGrunnlagDiffTest`: regresjonstest som verifiserer diff-deteksjon direkte via `RegisterdataDiffsjekker` for begge feltene og bladnivået.
- Regenerert OpenAPI-klientspesifikasjon (`ung-sak.openapi.json`) for nytt endepunkt.

> **Merk:** Forvaltningsendepunktet er et reaktivt opprydningsverktøy for allerede oppståtte
> enkelttilfeller, ikke en preventiv sperre. Det finnes i dag ingen automatisk validering ved
> mottak som hindrer en 2. søknad på samme fagsak for ungdomsprogramytelsen — dette er
> vurdert som en mulig oppfølging, men inngår ikke i denne PR-en.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
