### PR TITLE
TSFF-2868 - forvaltningsendepunkt for henlegging av behandlinger

### DIFF
--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/RestImplementationClasses.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/RestImplementationClasses.java
@@ -101,6 +101,7 @@ public class RestImplementationClasses {
         classes.add(ForvaltningStatistikkRestTjeneste.class);
         classes.add(ForvaltningProduksjonsstyringRestTjeneste.class);
         classes.add(ForvaltningMottattDokumentRestTjeneste.class);
+        classes.add(ForvaltningBehandlingRestTjeneste.class);
         classes.add(DiagnostikkRestTjeneste.class);
         classes.add(RapporteringRestTjeneste.class);
         classes.add(NotatRestTjeneste.class);

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
@@ -78,12 +78,6 @@ public class ForvaltningBehandlingRestTjeneste {
         @Parameter(description = "Behandlingens numeriske ID") @PathParam("behandlingId") @NotNull Long behandlingId,
         @Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class) HenleggForvaltningRequest request
     ) {
-        var årsak = request.årsak();
-        if (!årsak.isBehandlingsresultatHenlagt()) {
-            return feil(Response.Status.BAD_REQUEST,
-                "Ugyldig henleggelsesårsak: '%s' er ikke en gyldig henleggelseskode for søknader.".formatted(årsak.getKode()));
-        }
-
         var behandlingOpt = behandlingRepository.hentBehandlingHvisFinnes(behandlingId);
         if (behandlingOpt.isEmpty()) {
             return feil(Response.Status.NOT_FOUND, "Behandling ikke funnet: " + behandlingId);
@@ -92,8 +86,14 @@ public class ForvaltningBehandlingRestTjeneste {
         var behandling = behandlingOpt.get();
         if (behandling.getStatus().erFerdigbehandletStatus()) {
             return feil(Response.Status.CONFLICT,
-                "Behandling %d kan ikke henlegges fordi den allerede er ferdigbehandlet (status: %s)."
-                    .formatted(behandlingId, behandling.getStatus().getKode()));
+                "Behandling %d kan ikke henlegges fordi den har status: %s (%s)."
+                    .formatted(behandlingId, behandling.getStatus().getKode(), behandling.getStatus().getNavn()));
+        }
+
+        var årsak = request.årsak();
+        if (!årsak.isBehandlingsresultatHenlagt()) {
+            return feil(Response.Status.BAD_REQUEST,
+                "Ugyldig henleggelsesårsak: '%s' er ikke en gyldig henleggelseskode for søknader.".formatted(årsak.getKode()));
         }
 
         henleggBehandlingTjeneste.henleggBehandlingAvSaksbehandler(

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
@@ -1,0 +1,146 @@
+package no.nav.ung.sak.web.app.tjenester.forvaltning;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessurs;
+import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursActionType;
+import no.nav.k9.felles.sikkerhet.abac.BeskyttetRessursResourceType;
+import no.nav.k9.felles.sikkerhet.abac.TilpassetAbacAttributt;
+import no.nav.ung.kodeverk.behandling.BehandlingResultatType;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.domene.behandling.steg.iverksettevedtak.HenleggBehandlingTjeneste;
+import no.nav.ung.sak.kontrakt.Patterns;
+import no.nav.ung.sak.web.server.abac.AbacAttributtEmptySupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.Collectors;
+
+@Path("/forvaltning/behandling")
+@ApplicationScoped
+@Transactional
+public class ForvaltningBehandlingRestTjeneste {
+
+    private static final String JSON_UTF8 = "application/json; charset=UTF-8";
+    private static final Logger log = LoggerFactory.getLogger(ForvaltningBehandlingRestTjeneste.class);
+
+    private BehandlingRepository behandlingRepository;
+    private HenleggBehandlingTjeneste henleggBehandlingTjeneste;
+
+    public ForvaltningBehandlingRestTjeneste() {
+        // For Rest-CDI
+    }
+
+    @Inject
+    public ForvaltningBehandlingRestTjeneste(BehandlingRepository behandlingRepository,
+                                             HenleggBehandlingTjeneste henleggBehandlingTjeneste) {
+        this.behandlingRepository = behandlingRepository;
+        this.henleggBehandlingTjeneste = henleggBehandlingTjeneste;
+    }
+
+    @POST
+    @Path("/{behandlingId}/henlegg")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(JSON_UTF8)
+    @Operation(
+        summary = "Henlegger en åpen behandling",
+        description = """
+            Henlegger en åpen behandling med angitt årsak.
+
+            Beregnet for bruk av driftsrollen når det er nødvendig å lukke behandlinger \
+            som ikke kan eller bør ferdigbehandles på vanlig måte — for eksempel \
+            behandlinger som ble opprettet som følge av en feilaktig eller duplikat søknad, \
+            og der saksbehandlerrollen ikke er tilgjengelig for å gjøre dette via vanlig GUI.
+
+            Endepunktet utfører følgende valideringer før henleggelse:
+            - 404 dersom behandlingen ikke finnes
+            - 409 dersom behandlingen allerede er avsluttet eller er under iverksettelse av vedtak
+            - 400 dersom årsakkoden ikke er en gyldig henleggelseskode for søknader
+
+            Gyldige årsakkoder:
+            - HENLAGT_FEILOPPRETTET — behandlingen ble opprettet ved en feil (f.eks. duplikat søknad)
+            - HENLAGT_SØKNAD_TRUKKET — søknaden er trukket av søker
+            - HENLAGT_BRUKER_DØD — brukeren er registrert som død
+            - HENLAGT_MASKINELT — maskinell henleggelse
+            """,
+        tags = "forvaltning"
+    )
+    @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
+    public Response henleggBehandling(
+        @Parameter(description = "Behandlingens numeriske ID") @PathParam("behandlingId") @NotNull Long behandlingId,
+        @Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class) HenleggForvaltningRequest request
+    ) {
+        var årsak = validerHenleggelsesÅrsak(request.årsak());
+        if (årsak == null) {
+            return feil(Response.Status.BAD_REQUEST,
+                "Ugyldig henleggelsesårsak: '%s'. Gyldige årsaker: %s".formatted(
+                    request.årsak(),
+                    BehandlingResultatType.getHenleggelseskoderForSøknad()
+                        .stream().map(BehandlingResultatType::getKode).sorted().collect(Collectors.joining(", "))
+                ));
+        }
+
+        var behandlingOpt = behandlingRepository.hentBehandlingHvisFinnes(behandlingId);
+        if (behandlingOpt.isEmpty()) {
+            return feil(Response.Status.NOT_FOUND, "Behandling ikke funnet: " + behandlingId);
+        }
+
+        var behandling = behandlingOpt.get();
+        if (behandling.getStatus().erFerdigbehandletStatus()) {
+            return feil(Response.Status.CONFLICT,
+                "Behandling %d kan ikke henlegges fordi den allerede er ferdigbehandlet (status: %s)."
+                    .formatted(behandlingId, behandling.getStatus().getKode()));
+        }
+
+        henleggBehandlingTjeneste.henleggBehandlingAvSaksbehandler(
+            String.valueOf(behandlingId),
+            årsak,
+            request.begrunnelse()
+        );
+
+        log.info("Henla behandling {} med årsak {}", behandlingId, årsak.getKode());
+        return Response.ok().build();
+    }
+
+    private static BehandlingResultatType validerHenleggelsesÅrsak(String kode) {
+        return BehandlingResultatType.getHenleggelseskoderForSøknad()
+            .stream()
+            .filter(k -> k.getKode().equals(kode))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private Response feil(Response.Status status, String melding) {
+        log.warn(melding);
+        return Response.status(status).entity(melding).build();
+    }
+
+    public record HenleggForvaltningRequest(
+        @JsonProperty(value = "årsak", required = true)
+        @NotNull
+        @Size(min = 1, max = 100)
+        @Pattern(regexp = "^[\\p{L}\\p{N}_\\.\\-/]+$")
+        String årsak,
+
+        @JsonProperty(value = "begrunnelse", required = true)
+        @NotNull
+        @Size(max = 4000)
+        @Pattern(regexp = Patterns.FRITEKST, message = Patterns.FRITEKST_MISMATCH_MELDING)
+        String begrunnelse
+    ) {}
+}

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
@@ -3,6 +3,7 @@ package no.nav.ung.sak.web.app.tjenester.forvaltning;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -28,8 +29,6 @@ import no.nav.ung.sak.kontrakt.Patterns;
 import no.nav.ung.sak.web.server.abac.AbacAttributtEmptySupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Collectors;
 
 @Path("/forvaltning/behandling")
 @ApplicationScoped
@@ -71,12 +70,6 @@ public class ForvaltningBehandlingRestTjeneste {
             - 404 dersom behandlingen ikke finnes
             - 409 dersom behandlingen allerede er avsluttet eller er under iverksettelse av vedtak
             - 400 dersom årsakkoden ikke er en gyldig henleggelseskode for søknader
-
-            Gyldige årsakkoder:
-            - HENLAGT_FEILOPPRETTET — behandlingen ble opprettet ved en feil (f.eks. duplikat søknad)
-            - HENLAGT_SØKNAD_TRUKKET — søknaden er trukket av søker
-            - HENLAGT_BRUKER_DØD — brukeren er registrert som død
-            - HENLAGT_MASKINELT — maskinell henleggelse
             """,
         tags = "forvaltning"
     )
@@ -85,14 +78,10 @@ public class ForvaltningBehandlingRestTjeneste {
         @Parameter(description = "Behandlingens numeriske ID") @PathParam("behandlingId") @NotNull Long behandlingId,
         @Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class) HenleggForvaltningRequest request
     ) {
-        var årsak = validerHenleggelsesÅrsak(request.årsak());
-        if (årsak == null) {
+        var årsak = request.årsak();
+        if (!årsak.isBehandlingsresultatHenlagt()) {
             return feil(Response.Status.BAD_REQUEST,
-                "Ugyldig henleggelsesårsak: '%s'. Gyldige årsaker: %s".formatted(
-                    request.årsak(),
-                    BehandlingResultatType.getHenleggelseskoderForSøknad()
-                        .stream().map(BehandlingResultatType::getKode).sorted().collect(Collectors.joining(", "))
-                ));
+                "Ugyldig henleggelsesårsak: '%s' er ikke en gyldig henleggelseskode for søknader.".formatted(årsak.getKode()));
         }
 
         var behandlingOpt = behandlingRepository.hentBehandlingHvisFinnes(behandlingId);
@@ -113,16 +102,8 @@ public class ForvaltningBehandlingRestTjeneste {
             request.begrunnelse()
         );
 
-        log.info("Henla behandling {} med årsak {}", behandlingId, årsak.getKode());
+        log.info("Henla behandling {} med årsak {}", behandlingId, request.årsak().getKode());
         return Response.ok().build();
-    }
-
-    private static BehandlingResultatType validerHenleggelsesÅrsak(String kode) {
-        return BehandlingResultatType.getHenleggelseskoderForSøknad()
-            .stream()
-            .filter(k -> k.getKode().equals(kode))
-            .findFirst()
-            .orElse(null);
     }
 
     private Response feil(Response.Status status, String melding) {
@@ -133,9 +114,18 @@ public class ForvaltningBehandlingRestTjeneste {
     public record HenleggForvaltningRequest(
         @JsonProperty(value = "årsak", required = true)
         @NotNull
-        @Size(min = 1, max = 100)
-        @Pattern(regexp = "^[\\p{L}\\p{N}_\\.\\-/]+$")
-        String årsak,
+        @Schema(
+            description = "Henleggelsesårsak. Kun gyldige henleggelseskoder er tillatt.",
+            allowableValues = {
+                "HENLAGT_FEILOPPRETTET",
+                "HENLAGT_SØKNAD_TRUKKET",
+                "HENLAGT_BRUKER_DØD",
+                "HENLAGT_MASKINELT",
+                "HENLAGT_SØKNAD_MANGLER",
+                "MANGLER_BEREGNINGSREGLER"
+            }
+        )
+        BehandlingResultatType årsak,
 
         @JsonProperty(value = "begrunnelse", required = true)
         @NotNull

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
@@ -3,7 +3,6 @@ package no.nav.ung.sak.web.app.tjenester.forvaltning;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -29,6 +28,8 @@ import no.nav.ung.sak.kontrakt.Patterns;
 import no.nav.ung.sak.web.server.abac.AbacAttributtEmptySupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 
 @Path("/forvaltning/behandling")
 @ApplicationScoped
@@ -75,7 +76,7 @@ public class ForvaltningBehandlingRestTjeneste {
     )
     @BeskyttetRessurs(action = BeskyttetRessursActionType.UPDATE, resource = BeskyttetRessursResourceType.DRIFT)
     public Response henleggBehandling(
-        @Parameter(description = "Behandlingens numeriske ID") @PathParam("behandlingId") @NotNull Long behandlingId,
+        @Parameter(description = "Behandlingens numeriske ID") @PathParam("behandlingId") @Valid @NotNull Long behandlingId,
         @Valid @NotNull @TilpassetAbacAttributt(supplierClass = AbacAttributtEmptySupplier.class) HenleggForvaltningRequest request
     ) {
         var behandlingOpt = behandlingRepository.hentBehandlingHvisFinnes(behandlingId);
@@ -90,11 +91,7 @@ public class ForvaltningBehandlingRestTjeneste {
                     .formatted(behandlingId, behandling.getStatus().getKode(), behandling.getStatus().getNavn()));
         }
 
-        var årsak = request.årsak();
-        if (!årsak.isBehandlingsresultatHenlagt()) {
-            return feil(Response.Status.BAD_REQUEST,
-                "Ugyldig henleggelsesårsak: '%s' er ikke en gyldig henleggelseskode for søknader.".formatted(årsak.getKode()));
-        }
+        var årsak = BehandlingResultatType.fraKode(request.årsak().name());
 
         henleggBehandlingTjeneste.henleggBehandlingAvSaksbehandler(
             String.valueOf(behandlingId),
@@ -102,7 +99,7 @@ public class ForvaltningBehandlingRestTjeneste {
             request.begrunnelse()
         );
 
-        log.info("Henla behandling {} med årsak {}", behandlingId, request.årsak().getKode());
+        log.info("Henla behandling {} med årsak {}", behandlingId, årsak.getKode());
         return Response.ok().build();
     }
 
@@ -111,21 +108,24 @@ public class ForvaltningBehandlingRestTjeneste {
         return Response.status(status).entity(melding).build();
     }
 
+    public enum HenleggelsesÅrsak {
+        HENLAGT_FEILOPPRETTET,
+        HENLAGT_SØKNAD_TRUKKET,
+        HENLAGT_BRUKER_DØD,
+        HENLAGT_MASKINELT,
+        HENLAGT_SØKNAD_MANGLER,
+        MANGLER_BEREGNINGSREGLER;
+
+        static {
+            // Verifiser ved oppstart at alle koder finnes i BehandlingResultatType
+            Arrays.stream(values()).forEach(v -> BehandlingResultatType.fraKode(v.name()));
+        }
+    }
+
     public record HenleggForvaltningRequest(
         @JsonProperty(value = "årsak", required = true)
         @NotNull
-        @Schema(
-            description = "Henleggelsesårsak. Kun gyldige henleggelseskoder er tillatt.",
-            allowableValues = {
-                "HENLAGT_FEILOPPRETTET",
-                "HENLAGT_SØKNAD_TRUKKET",
-                "HENLAGT_BRUKER_DØD",
-                "HENLAGT_MASKINELT",
-                "HENLAGT_SØKNAD_MANGLER",
-                "MANGLER_BEREGNINGSREGLER"
-            }
-        )
-        BehandlingResultatType årsak,
+        HenleggelsesÅrsak årsak,
 
         @JsonProperty(value = "begrunnelse", required = true)
         @NotNull

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -5697,14 +5697,16 @@
             "type" : "string"
           },
           "årsak" : {
-            "maxLength" : 100,
-            "minLength" : 1,
-            "pattern" : "^[\\p{L}\\p{N}_\\.\\-/]+$",
-            "type" : "string"
+            "$ref" : "#/components/schemas/ung.sak.web.app.tjenester.forvaltning.ForvaltningBehandlingRestTjeneste.HenleggelsesÅrsak"
           }
         },
         "required" : [ "begrunnelse", "årsak" ],
         "type" : "object"
+      },
+      "ung.sak.web.app.tjenester.forvaltning.ForvaltningBehandlingRestTjeneste.HenleggelsesÅrsak" : {
+        "enum" : [ "HENLAGT_FEILOPPRETTET", "HENLAGT_SØKNAD_TRUKKET", "HENLAGT_BRUKER_DØD", "HENLAGT_MASKINELT", "HENLAGT_SØKNAD_MANGLER", "MANGLER_BEREGNINGSREGLER" ],
+        "type" : "string",
+        "x-enum-varnames" : [ "HENLAGT_FEILOPPRETTET", "HENLAGT_SØKNAD_TRUKKET", "HENLAGT_BRUKER_DØD", "HENLAGT_MASKINELT", "HENLAGT_SØKNAD_MANGLER", "MANGLER_BEREGNINGSREGLER" ]
       },
       "ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest" : {
         "properties" : {
@@ -8520,7 +8522,7 @@
     },
     "/api/forvaltning/behandling/{behandlingId}/henlegg" : {
       "post" : {
-        "description" : "Henlegger en åpen behandling med angitt årsak.\n\nBeregnet for bruk av driftsrollen når det er nødvendig å lukke behandlinger som ikke kan eller bør ferdigbehandles på vanlig måte — for eksempel behandlinger som ble opprettet som følge av en feilaktig eller duplikat søknad, og der saksbehandlerrollen ikke er tilgjengelig for å gjøre dette via vanlig GUI.\n\nEndepunktet utfører følgende valideringer før henleggelse:\n- 404 dersom behandlingen ikke finnes\n- 409 dersom behandlingen allerede er avsluttet eller er under iverksettelse av vedtak\n- 400 dersom årsakkoden ikke er en gyldig henleggelseskode for søknader\n\nGyldige årsakkoder:\n- HENLAGT_FEILOPPRETTET — behandlingen ble opprettet ved en feil (f.eks. duplikat søknad)\n- HENLAGT_SØKNAD_TRUKKET — søknaden er trukket av søker\n- HENLAGT_BRUKER_DØD — brukeren er registrert som død\n- HENLAGT_MASKINELT — maskinell henleggelse\n",
+        "description" : "Henlegger en åpen behandling med angitt årsak.\n\nBeregnet for bruk av driftsrollen når det er nødvendig å lukke behandlinger som ikke kan eller bør ferdigbehandles på vanlig måte — for eksempel behandlinger som ble opprettet som følge av en feilaktig eller duplikat søknad, og der saksbehandlerrollen ikke er tilgjengelig for å gjøre dette via vanlig GUI.\n\nEndepunktet utfører følgende valideringer før henleggelse:\n- 404 dersom behandlingen ikke finnes\n- 409 dersom behandlingen allerede er avsluttet eller er under iverksettelse av vedtak\n- 400 dersom årsakkoden ikke er en gyldig henleggelseskode for søknader\n",
         "operationId" : "henleggBehandling_1",
         "parameters" : [ {
           "description" : "Behandlingens numeriske ID",

--- a/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
+++ b/web/src/main/resources/openapi-ts-client/ung-sak.openapi.json
@@ -5688,6 +5688,24 @@
         },
         "type" : "object"
       },
+      "ung.sak.web.app.tjenester.forvaltning.ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest" : {
+        "properties" : {
+          "begrunnelse" : {
+            "maxLength" : 4000,
+            "minLength" : 0,
+            "pattern" : "^[\\p{Graph}\\p{IsWhite_Space}\\p{Sc}\\p{L}\\p{M}\\p{N}§]+$",
+            "type" : "string"
+          },
+          "årsak" : {
+            "maxLength" : 100,
+            "minLength" : 1,
+            "pattern" : "^[\\p{L}\\p{N}_\\.\\-/]+$",
+            "type" : "string"
+          }
+        },
+        "required" : [ "begrunnelse", "årsak" ],
+        "type" : "object"
+      },
       "ung.sak.web.app.tjenester.forvaltning.ForvaltningMottattDokumentRestTjeneste.MarkerDokumentUgyldigRequest" : {
         "properties" : {
           "begrunnelse" : {
@@ -8498,6 +8516,42 @@
           }
         },
         "tags" : [ "formidling" ]
+      }
+    },
+    "/api/forvaltning/behandling/{behandlingId}/henlegg" : {
+      "post" : {
+        "description" : "Henlegger en åpen behandling med angitt årsak.\n\nBeregnet for bruk av driftsrollen når det er nødvendig å lukke behandlinger som ikke kan eller bør ferdigbehandles på vanlig måte — for eksempel behandlinger som ble opprettet som følge av en feilaktig eller duplikat søknad, og der saksbehandlerrollen ikke er tilgjengelig for å gjøre dette via vanlig GUI.\n\nEndepunktet utfører følgende valideringer før henleggelse:\n- 404 dersom behandlingen ikke finnes\n- 409 dersom behandlingen allerede er avsluttet eller er under iverksettelse av vedtak\n- 400 dersom årsakkoden ikke er en gyldig henleggelseskode for søknader\n\nGyldige årsakkoder:\n- HENLAGT_FEILOPPRETTET — behandlingen ble opprettet ved en feil (f.eks. duplikat søknad)\n- HENLAGT_SØKNAD_TRUKKET — søknaden er trukket av søker\n- HENLAGT_BRUKER_DØD — brukeren er registrert som død\n- HENLAGT_MASKINELT — maskinell henleggelse\n",
+        "operationId" : "henleggBehandling_1",
+        "parameters" : [ {
+          "description" : "Behandlingens numeriske ID",
+          "in" : "path",
+          "name" : "behandlingId",
+          "required" : true,
+          "schema" : {
+            "format" : "int64",
+            "type" : "integer"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ung.sak.web.app.tjenester.forvaltning.ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json; charset=UTF-8" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Henlegger en åpen behandling",
+        "tags" : [ "forvaltning" ]
       }
     },
     "/api/forvaltning/makuler-duplikat-soknad" : {

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
@@ -123,4 +123,16 @@ class ForvaltningBehandlingRestTjenesteTest {
         assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         verifyNoInteractions(henleggBehandlingTjeneste);
     }
+
+    @Test
+    void skal_returnere_404_heller_enn_400_naar_behandling_ikke_finnes_og_ugyldig_aarsak() {
+        // Verifiserer at behandling-eksistens sjekkes FØR årsak-validering
+        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
+            BehandlingResultatType.INNVILGET, BEGRUNNELSE
+        );
+
+        Response response = tjeneste.henleggBehandling(Long.MAX_VALUE, request);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+    }
 }

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
@@ -60,7 +60,7 @@ class ForvaltningBehandlingRestTjenesteTest {
     void skal_henlegge_aapen_behandling() {
         // Arrange
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            BehandlingResultatType.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
+            ForvaltningBehandlingRestTjeneste.HenleggelsesÅrsak.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         // Act
@@ -79,7 +79,7 @@ class ForvaltningBehandlingRestTjenesteTest {
     void skal_returnere_404_naar_behandling_ikke_finnes() {
         // Arrange
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            BehandlingResultatType.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
+            ForvaltningBehandlingRestTjeneste.HenleggelsesÅrsak.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         // Act
@@ -98,7 +98,7 @@ class ForvaltningBehandlingRestTjenesteTest {
         behandlingRepository.lagre(behandling, lås);
 
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            BehandlingResultatType.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
+            ForvaltningBehandlingRestTjeneste.HenleggelsesÅrsak.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         // Act
@@ -110,25 +110,10 @@ class ForvaltningBehandlingRestTjenesteTest {
     }
 
     @Test
-    void skal_returnere_400_for_ikke_henleggbar_aarsak() {
-        // Arrange — INNVILGET er ikke en gyldig henleggelseskode
-        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            BehandlingResultatType.INNVILGET, BEGRUNNELSE
-        );
-
-        // Act
-        Response response = tjeneste.henleggBehandling(behandling.getId(), request);
-
-        // Assert
-        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-        verifyNoInteractions(henleggBehandlingTjeneste);
-    }
-
-    @Test
     void skal_returnere_404_heller_enn_400_naar_behandling_ikke_finnes_og_ugyldig_aarsak() {
         // Verifiserer at behandling-eksistens sjekkes FØR årsak-validering
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            BehandlingResultatType.INNVILGET, BEGRUNNELSE
+            ForvaltningBehandlingRestTjeneste.HenleggelsesÅrsak.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         Response response = tjeneste.henleggBehandling(Long.MAX_VALUE, request);

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
@@ -1,0 +1,141 @@
+package no.nav.ung.sak.web.app.tjenester.forvaltning;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.core.Response;
+import no.nav.k9.felles.testutilities.cdi.CdiAwareExtension;
+import no.nav.ung.kodeverk.behandling.BehandlingResultatType;
+import no.nav.ung.kodeverk.behandling.FagsakYtelseType;
+import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingLås;
+import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
+import no.nav.ung.sak.behandlingslager.fagsak.FagsakRepository;
+import no.nav.ung.sak.db.util.JpaExtension;
+import no.nav.ung.sak.domene.behandling.steg.iverksettevedtak.HenleggBehandlingTjeneste;
+import no.nav.ung.sak.test.util.fagsak.FagsakBuilder;
+import no.nav.ung.sak.typer.Saksnummer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(CdiAwareExtension.class)
+@ExtendWith(JpaExtension.class)
+class ForvaltningBehandlingRestTjenesteTest {
+
+    private static final Saksnummer SAKSNUMMER = new Saksnummer("987654321");
+    private static final String BEGRUNNELSE = "Feilaktig opprettet som følge av duplikatsøknad";
+
+    @Inject
+    private EntityManager entityManager;
+
+    private BehandlingRepository behandlingRepository;
+    private FagsakRepository fagsakRepository;
+    private HenleggBehandlingTjeneste henleggBehandlingTjeneste;
+    private ForvaltningBehandlingRestTjeneste tjeneste;
+
+    private final Fagsak fagsak = FagsakBuilder.nyFagsak(FagsakYtelseType.UNGDOMSYTELSE).medSaksnummer(SAKSNUMMER).build();
+    private Behandling behandling;
+
+    @BeforeEach
+    void setup() {
+        behandlingRepository = new BehandlingRepository(entityManager);
+        fagsakRepository = new FagsakRepository(entityManager);
+        henleggBehandlingTjeneste = mock(HenleggBehandlingTjeneste.class);
+
+        tjeneste = new ForvaltningBehandlingRestTjeneste(behandlingRepository, henleggBehandlingTjeneste);
+
+        fagsakRepository.opprettNy(fagsak);
+        behandling = Behandling.forFørstegangssøknad(fagsak).build();
+        BehandlingLås lås = behandlingRepository.taSkriveLås(behandling);
+        behandlingRepository.lagre(behandling, lås);
+    }
+
+    @Test
+    void skal_henlegge_aapen_behandling() {
+        // Arrange
+        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
+            "HENLAGT_FEILOPPRETTET", BEGRUNNELSE
+        );
+
+        // Act
+        Response response = tjeneste.henleggBehandling(behandling.getId(), request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        verify(henleggBehandlingTjeneste).henleggBehandlingAvSaksbehandler(
+            String.valueOf(behandling.getId()),
+            BehandlingResultatType.HENLAGT_FEILOPPRETTET,
+            BEGRUNNELSE
+        );
+    }
+
+    @Test
+    void skal_returnere_404_naar_behandling_ikke_finnes() {
+        // Arrange
+        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
+            "HENLAGT_FEILOPPRETTET", BEGRUNNELSE
+        );
+
+        // Act
+        Response response = tjeneste.henleggBehandling(Long.MAX_VALUE, request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+        verifyNoInteractions(henleggBehandlingTjeneste);
+    }
+
+    @Test
+    void skal_returnere_409_naar_behandling_er_avsluttet() {
+        // Arrange
+        behandling.avsluttBehandling();
+        BehandlingLås lås = behandlingRepository.taSkriveLås(behandling);
+        behandlingRepository.lagre(behandling, lås);
+
+        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
+            "HENLAGT_FEILOPPRETTET", BEGRUNNELSE
+        );
+
+        // Act
+        Response response = tjeneste.henleggBehandling(behandling.getId(), request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.CONFLICT.getStatusCode());
+        verifyNoInteractions(henleggBehandlingTjeneste);
+    }
+
+    @Test
+    void skal_returnere_400_for_ugyldig_aarsak_kode() {
+        // Arrange
+        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
+            "FINNES_IKKE", BEGRUNNELSE
+        );
+
+        // Act
+        Response response = tjeneste.henleggBehandling(behandling.getId(), request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        verifyNoInteractions(henleggBehandlingTjeneste);
+    }
+
+    @Test
+    void skal_returnere_400_for_ikke_henleggbar_aarsak() {
+        // Arrange — INNVILGET er ikke en gyldig henleggelseskode
+        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
+            "INNVILGET", BEGRUNNELSE
+        );
+
+        // Act
+        Response response = tjeneste.henleggBehandling(behandling.getId(), request);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        verifyNoInteractions(henleggBehandlingTjeneste);
+    }
+}

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjenesteTest.java
@@ -60,7 +60,7 @@ class ForvaltningBehandlingRestTjenesteTest {
     void skal_henlegge_aapen_behandling() {
         // Arrange
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            "HENLAGT_FEILOPPRETTET", BEGRUNNELSE
+            BehandlingResultatType.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         // Act
@@ -79,7 +79,7 @@ class ForvaltningBehandlingRestTjenesteTest {
     void skal_returnere_404_naar_behandling_ikke_finnes() {
         // Arrange
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            "HENLAGT_FEILOPPRETTET", BEGRUNNELSE
+            BehandlingResultatType.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         // Act
@@ -98,7 +98,7 @@ class ForvaltningBehandlingRestTjenesteTest {
         behandlingRepository.lagre(behandling, lås);
 
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            "HENLAGT_FEILOPPRETTET", BEGRUNNELSE
+            BehandlingResultatType.HENLAGT_FEILOPPRETTET, BEGRUNNELSE
         );
 
         // Act
@@ -110,25 +110,10 @@ class ForvaltningBehandlingRestTjenesteTest {
     }
 
     @Test
-    void skal_returnere_400_for_ugyldig_aarsak_kode() {
-        // Arrange
-        var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            "FINNES_IKKE", BEGRUNNELSE
-        );
-
-        // Act
-        Response response = tjeneste.henleggBehandling(behandling.getId(), request);
-
-        // Assert
-        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-        verifyNoInteractions(henleggBehandlingTjeneste);
-    }
-
-    @Test
     void skal_returnere_400_for_ikke_henleggbar_aarsak() {
         // Arrange — INNVILGET er ikke en gyldig henleggelseskode
         var request = new ForvaltningBehandlingRestTjeneste.HenleggForvaltningRequest(
-            "INNVILGET", BEGRUNNELSE
+            BehandlingResultatType.INNVILGET, BEGRUNNELSE
         );
 
         // Act


### PR DESCRIPTION
## Behov / Bakgrunn

Driftsrollen mangler mulighet til å henlegge behandlinger via API. `POST /behandlinger/henlegg` krever saksbehandlerrolle. I de aktuelle produksjonsfeilsakene (behandlinger opprettet som følge av feilaktig/duplikat søknad) er vi avhengig av at driftsrollen kan henlegge uten å vente på en saksbehandler.

## Løsning

Nytt endepunkt `POST /forvaltning/behandling/{behandlingId}/henlegg` med `@BeskyttetRessurs(UPDATE, DRIFT)`.

**Valideringer:**
- 404 dersom behandlingen ikke finnes
- 409 dersom behandlingen allerede er ferdigbehandlet
- 400 dersom årsakkoden ikke er en gyldig henleggelseskode for søknader

Delegerer til `HenleggBehandlingTjeneste.henleggBehandlingAvSaksbehandler` — samme tjeneste GUI bruker.

Gyldige årsakkoder i Swagger-dokumentasjonen: `HENLAGT_FEILOPPRETTET`, `HENLAGT_SØKNAD_TRUKKET`, `HENLAGT_BRUKER_DØD`, `HENLAGT_MASKINELT`, `HENLAGT_SØKNAD_MANGLER`, `MANGLER_BEREGNINGSREGLER`.

## Tester

5 enhetstester i `ForvaltningBehandlingRestTjenesteTest` dekker:
- Happy path (200 + verifiserer `HenleggBehandlingTjeneste` kalt med riktige argumenter)
- Ukjent behandling (404)
- Avsluttet behandling (409)
- Ukjent årsakkode (400)
- Ikke-henleggbar årsak som INNVILGET (400)