### PR TITLE
TSFF-2041 - slett gammel uttalelsetabell som aldri ble droppet

### DIFF
--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_091__slette_gammel_uttalelsetabell.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_091__slette_gammel_uttalelsetabell.sql
@@ -1,0 +1,2 @@
+drop table if exists uttalelse;
+drop sequence if exists seq_uttalelse;

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningOppgaveRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningOppgaveRestTjeneste.java
@@ -159,6 +159,14 @@ public class ForvaltningOppgaveRestTjeneste {
         }
 
         final var behandlingId = Long.parseLong(behandlingIdDto.getId());
+        entityManager.createNativeQuery("delete from uttalelse_v2 where uttalelser_id in (select uttalelser_id from gr_uttalelse where behandling_id = :behandlingId)")
+            .setParameter("behandlingId", behandlingId)
+            .executeUpdate();
+
+        entityManager.createNativeQuery("delete from gr_uttalelse where behandling_id = :behandlingId")
+            .setParameter("behandlingId", behandlingId)
+            .executeUpdate();
+
         entityManager.createNativeQuery("DELETE FROM ETTERLYSNING WHERE behandling_id = :behandlingId")
             .setParameter("behandlingId", behandlingId)
             .executeUpdate();

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningOppgaveRestTjeneste.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/forvaltning/ForvaltningOppgaveRestTjeneste.java
@@ -159,11 +159,6 @@ public class ForvaltningOppgaveRestTjeneste {
         }
 
         final var behandlingId = Long.parseLong(behandlingIdDto.getId());
-        entityManager.createNativeQuery("DELETE FROM UTTALELSE WHERE etterlysning_id in (select id from ETTERLYSNING where behandling_id = :behandlingId)")
-            .setParameter("behandlingId", behandlingId)
-            .executeUpdate();
-
-
         entityManager.createNativeQuery("DELETE FROM ETTERLYSNING WHERE behandling_id = :behandlingId")
             .setParameter("behandlingId", behandlingId)
             .executeUpdate();


### PR DESCRIPTION
### Behov / Bakgrunn
`V1.0_067_slette_gammel_uttalelsetabell.sql` (PR #708, TSFF-2041) ble aldri plukket opp av Flyway fordi filnavnet manglet dobbel understrek (`__`). PR #1087 oppdaget feilen og slettet filen, men la ikke inn noen korrekt erstatning.

Tabellen `uttalelse` og sekvensen `seq_uttalelse` eksisterer derfor fortsatt i databasen, selv om applikasjonskoden ikke lenger bruker dem (JPA-mapping fjernet i #708).

### Løsning
Legger til `V1.0_091__slette_gammel_uttalelsetabell.sql` som dropper tabellen og sekvensen. `if exists` gjør migrasjonen idempotent.