### PR TITLE
TSFF-2863: Kun vise datoen ytelsen opphører fra

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/bosatt/Avklaringtype.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/bosatt/Avklaringtype.java
@@ -1,0 +1,10 @@
+package no.nav.ung.sak.behandlingslager.bosatt;
+
+/**
+ * Type avklaring for bostedsvilkåret. Avgjør hvilken oppgavetype som sendes til bruker
+ * og for readonly-visning av tidligere forslag, siden tom konverteres til gjeldende vilkårsperiode ende ved lagring forslag.
+ */
+public enum Avklaringtype {
+    AVSLAG,
+    OPPHØR
+}

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/bosatt/BostedsAvklaringHolder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/bosatt/BostedsAvklaringHolder.java
@@ -43,7 +43,7 @@ public class BostedsAvklaringHolder extends BaseEntitet {
     void leggTilEllerErstattPeriodeAvklaringer(Collection<BostedsPeriodeAvklaring> nyePeriodeAvklaring) {
         periodeAvklaringer = byggAvklaringTidslinje(nyePeriodeAvklaring)
             .crossJoin(hentSomTidslinje())
-            .toSegments().stream()
+            .segmenter().stream()
             .map(s -> s.getValue().medNyPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(s.getFom(), s.getTom())))
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }

--- a/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/bosatt/BostedsPeriodeAvklaring.java
+++ b/behandlingslager/domene/src/main/java/no/nav/ung/sak/behandlingslager/bosatt/BostedsPeriodeAvklaring.java
@@ -52,6 +52,10 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
     @Column(name = "begrunnelse_ikke_varsel", updatable = false)
     private String begrunnelseIkkeVarsel;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "avklaringtype", updatable = false, nullable = false)
+    private Avklaringtype avklaringtype;
+
     @Column(name = "vurdert_av", updatable = false)
     private String vurdertAv;
 
@@ -62,7 +66,7 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
         // Hibernate
     }
 
-    public BostedsPeriodeAvklaring(DatoIntervallEntitet periode, boolean erBosattITrondheim, BostedsvilkårIkkeOppfyltÅrsak ikkeOppfyltÅrsak, String begrunnelse, boolean skalSendeVarsel, String fritekstTilVarsel, String begrunnelseIkkeVarsel, String vurdertAv, LocalDateTime vurdertTidspunkt) {
+    public BostedsPeriodeAvklaring(DatoIntervallEntitet periode, boolean erBosattITrondheim, BostedsvilkårIkkeOppfyltÅrsak ikkeOppfyltÅrsak, String begrunnelse, boolean skalSendeVarsel, String fritekstTilVarsel, String begrunnelseIkkeVarsel, String vurdertAv, LocalDateTime vurdertTidspunkt, Avklaringtype avklaringtype) {
         if (!skalSendeVarsel) {
             Objects.requireNonNull(begrunnelseIkkeVarsel, "Mangler begrunnelse for hvorfor det ikke varsles");
         } else if (BostedsvilkårIkkeOppfyltÅrsak.ANNET.equals(ikkeOppfyltÅrsak)) {
@@ -86,6 +90,7 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
         this.begrunnelseIkkeVarsel = begrunnelseIkkeVarsel;
         this.vurdertAv = vurdertAv;
         this.vurdertTidspunkt = vurdertTidspunkt;
+        this.avklaringtype = avklaringtype;
     }
 
     public BostedsPeriodeAvklaring(BostedsPeriodeAvklaring annenAvklaring) {
@@ -99,9 +104,10 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
         this.begrunnelseIkkeVarsel = annenAvklaring.getBegrunnelseIkkeVarsel();
         this.vurdertAv = annenAvklaring.getVurdertAv();
         this.vurdertTidspunkt = annenAvklaring.getVurdertTidspunkt();
+        this.avklaringtype = annenAvklaring.getAvklaringtype();
     }
 
-    private BostedsPeriodeAvklaring(DatoIntervallEntitet periode, UUID referanse, boolean erBosattITrondheim, BostedsvilkårIkkeOppfyltÅrsak ikkeOppfyltÅrsak, String begrunnelse, boolean skalSendeVarsel, String fritekstTilVarsel, String begrunnelseIkkeVarsel, String vurdertAv, LocalDateTime vurdertTidspunkt) {
+    private BostedsPeriodeAvklaring(DatoIntervallEntitet periode, UUID referanse, boolean erBosattITrondheim, BostedsvilkårIkkeOppfyltÅrsak ikkeOppfyltÅrsak, String begrunnelse, boolean skalSendeVarsel, String fritekstTilVarsel, String begrunnelseIkkeVarsel, String vurdertAv, LocalDateTime vurdertTidspunkt, Avklaringtype avklaringtype) {
         this.periode = periode.toRange();
         this.referanse = referanse;
         this.erBosattITrondheim = erBosattITrondheim;
@@ -112,6 +118,7 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
         this.begrunnelseIkkeVarsel = begrunnelseIkkeVarsel;
         this.vurdertAv = vurdertAv;
         this.vurdertTidspunkt = vurdertTidspunkt;
+        this.avklaringtype = avklaringtype;
     }
 
     public BostedsPeriodeAvklaring medNyPeriode(DatoIntervallEntitet nyPeriode) {
@@ -125,7 +132,8 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
             this.fritekstTilVarsel,
             this.begrunnelseIkkeVarsel,
             this.vurdertAv,
-            this.vurdertTidspunkt
+            this.vurdertTidspunkt,
+            this.avklaringtype
         );
     }
 
@@ -169,6 +177,10 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
         return begrunnelseIkkeVarsel;
     }
 
+    public Avklaringtype getAvklaringtype() {
+        return avklaringtype;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof BostedsPeriodeAvklaring that)) return false;
@@ -180,12 +192,13 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
             && Objects.equals(fritekstTilVarsel, that.fritekstTilVarsel)
             && Objects.equals(begrunnelseIkkeVarsel, that.begrunnelseIkkeVarsel)
             && Objects.equals(vurdertAv, that.vurdertAv)
-            && Objects.equals(vurdertTidspunkt, that.vurdertTidspunkt);
+            && Objects.equals(vurdertTidspunkt, that.vurdertTidspunkt)
+            && avklaringtype == that.avklaringtype;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(periode, erBosattITrondheim, ikkeOppfyltÅrsak, begrunnelse, skalSendeVarsel, fritekstTilVarsel, begrunnelseIkkeVarsel, vurdertAv, vurdertTidspunkt);
+        return Objects.hash(periode, erBosattITrondheim, ikkeOppfyltÅrsak, begrunnelse, skalSendeVarsel, fritekstTilVarsel, begrunnelseIkkeVarsel, vurdertAv, vurdertTidspunkt, avklaringtype);
     }
 
     @Override
@@ -195,6 +208,7 @@ public class BostedsPeriodeAvklaring extends BaseEntitet {
             + ", erBosattITrondheim=" + erBosattITrondheim
             + ", ikkeOppfyltÅrsak=" + ikkeOppfyltÅrsak
             + ", skalSendeVarsel=" + skalSendeVarsel
+            + ", avklaringtype=" + avklaringtype
             + ", vurdertAv=" + vurdertAv
             + ", vurdertTidspunkt=" + vurdertTidspunkt + '}';
     }

--- a/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/bosted/BostedOppgaveOppretter.java
+++ b/domenetjenester/etterlysning/src/main/java/no/nav/ung/sak/etterlysning/bosted/BostedOppgaveOppretter.java
@@ -3,10 +3,13 @@ package no.nav.ung.sak.etterlysning.bosted;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveYtelsetype;
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgavetypeDataDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OpprettOppgaveDto;
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.bosted.BekreftBostedOppgavetypeDataDto;
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.bosted.BekreftBostedOpphørOppgavetypeDataDto;
 import no.nav.ung.kodeverk.vilkår.BostedsvilkårIkkeOppfyltÅrsak;
 import no.nav.ung.sak.behandlingslager.behandling.Behandling;
+import no.nav.ung.sak.behandlingslager.bosatt.Avklaringtype;
 import no.nav.ung.sak.behandlingslager.bosatt.BostedsGrunnlagRepository;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.etterlysning.OppgaveYtelsetypeMapper;
@@ -44,17 +47,32 @@ public class BostedOppgaveOppretter {
                 Objects.requireNonNull(periodeAvklaring.getFritekstTilVarsel(), "FritekstTilVarsel må være satt når årsak er "+ ikkeOppfyltÅrsak);
             }
 
-            var oppgaveDto = new OpprettOppgaveDto(
-                new no.nav.ung.brukerdialog.typer.AktørId(aktørId.getAktørId()),
-                ytelsetype,
-                etterlysning.getEksternReferanse(),
-                new BekreftBostedOppgavetypeDataDto(
+            var mappetÅrsak = mapIkkeOppfyltÅrsak(ikkeOppfyltÅrsak);
+            var avklaringtype = periodeAvklaring.getAvklaringtype();
+
+            OppgavetypeDataDto oppgavetypeData;
+            if (avklaringtype == Avklaringtype.OPPHØR) {
+                oppgavetypeData = new BekreftBostedOpphørOppgavetypeDataDto(
+                    etterlysning.getPeriode().getFomDato(),
+                    periodeAvklaring.isErBosattITrondheim(),
+                    periodeAvklaring.getFritekstTilVarsel(),
+                    mappetÅrsak
+                );
+            } else {
+                oppgavetypeData = new BekreftBostedOppgavetypeDataDto(
                     etterlysning.getPeriode().getFomDato(),
                     etterlysning.getPeriode().getTomDato(),
                     periodeAvklaring.isErBosattITrondheim(),
                     periodeAvklaring.getFritekstTilVarsel(),
-                    mapIkkeOppfyltÅrsak(ikkeOppfyltÅrsak)
-                ),
+                    mappetÅrsak
+                );
+            }
+
+            var oppgaveDto = new OpprettOppgaveDto(
+                new no.nav.ung.brukerdialog.typer.AktørId(aktørId.getAktørId()),
+                ytelsetype,
+                etterlysning.getEksternReferanse(),
+                oppgavetypeData,
                 etterlysning.getFrist()
             );
             oppgaveKlient.opprettOppgave(oppgaveDto);

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_092__bosatt_avklaringtype.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_092__bosatt_avklaringtype.sql
@@ -1,9 +1,5 @@
 alter table bosatt_periode_avklaring
-    add column if not exists avklaringtype varchar(50) default 'AVSLAG';
-
-update bosatt_periode_avklaring
-    set avklaringtype = 'AVSLAG'
-    where avklaringtype is null;
+    add column if not exists avklaringtype varchar(50) default 'AVSLAG' not null;
 
 alter table bosatt_periode_avklaring
-    alter column avklaringtype set not null;
+    alter column avklaringtype drop default;

--- a/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_092__bosatt_avklaringtype.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/1.0/V1.0_092__bosatt_avklaringtype.sql
@@ -1,0 +1,9 @@
+alter table bosatt_periode_avklaring
+    add column if not exists avklaringtype varchar(50) default 'AVSLAG';
+
+update bosatt_periode_avklaring
+    set avklaringtype = 'AVSLAG'
+    where avklaringtype is null;
+
+alter table bosatt_periode_avklaring
+    alter column avklaringtype set not null;

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.platform.version>8.3.0</confluent.platform.version>
         <mockito.version>5.23.0</mockito.version>
         <ung-deltakelse-opplyser.version>2.11.3</ung-deltakelse-opplyser.version>
-        <ung-brukerdialog-api.version>1.0.6</ung-brukerdialog-api.version>
+        <ung-brukerdialog-api.version>1.0.7</ung-brukerdialog-api.version>
         <handlebars.version>4.5.3</handlebars.version>
         <validation-model-jakarta.version>1.30.2</validation-model-jakarta.version>
         <openhtmltopdf.version>1.1.62</openhtmltopdf.version>

--- a/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/VurderFaktaOmBostedOppdaterer.java
+++ b/web/src/main/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/VurderFaktaOmBostedOppdaterer.java
@@ -22,6 +22,7 @@ import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.ung.sak.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.ung.sak.behandlingslager.bosatt.Avklaringtype;
 import no.nav.ung.sak.behandlingslager.bosatt.BostedAvklaringData;
 import no.nav.ung.sak.behandlingslager.bosatt.BostedsGrunnlagRepository;
 import no.nav.ung.sak.behandlingslager.bosatt.BostedsPeriodeAvklaring;
@@ -95,6 +96,7 @@ public class VurderFaktaOmBostedOppdaterer implements AksjonspunktOppdaterer<Vur
         for (BostedFaktaavklaringPeriodeDto avklaring : dto.getAvklaringer().stream().filter(a -> a.vurdering() != null).toList()) {
             var fom = avklaring.periode().getFom();
             var tom = avklaring.periode().getTom() != null ? avklaring.periode().getTom() : maxTomDato;
+            var avklaringtype = avklaring.periode().getTom() != null ? Avklaringtype.AVSLAG : Avklaringtype.OPPHØR;
 
             var vurdering = avklaring.vurdering();
             if (avklaring.skalSendeVarsel()) {
@@ -110,7 +112,8 @@ public class VurderFaktaOmBostedOppdaterer implements AksjonspunktOppdaterer<Vur
                 vurdering.fritekstTilVarsel(),
                 vurdering.begrunnelseIkkeVarsel(),
                 vurdertAv,
-                vurdertTidspunkt
+                vurdertTidspunkt,
+                avklaringtype
             ));
         }
 

--- a/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/VurderFaktaOmBostedOppdatererTest.java
+++ b/web/src/test/java/no/nav/ung/sak/web/app/tjenester/behandling/aktivitetspenger/VurderFaktaOmBostedOppdatererTest.java
@@ -16,10 +16,7 @@ import no.nav.ung.sak.behandlingslager.behandling.Behandling;
 import no.nav.ung.sak.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.ung.sak.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatBuilder;
-import no.nav.ung.sak.behandlingslager.bosatt.BostedsGrunnlag;
-import no.nav.ung.sak.behandlingslager.bosatt.BostedsGrunnlagRepository;
-import no.nav.ung.sak.behandlingslager.bosatt.BostedsPeriodeAvklaring;
-import no.nav.ung.sak.behandlingslager.bosatt.BostedsfaktaOgAvklaring;
+import no.nav.ung.sak.behandlingslager.bosatt.*;
 import no.nav.ung.sak.behandlingslager.etterlysning.Etterlysning;
 import no.nav.ung.sak.behandlingslager.etterlysning.EtterlysningRepository;
 import no.nav.ung.sak.behandlingslager.fagsak.Fagsak;
@@ -245,7 +242,8 @@ class VurderFaktaOmBostedOppdatererTest {
             (årsak == BostedsvilkårIkkeOppfyltÅrsak.ANNET) ? "Fritekstbegrunnelse" : null,
             "Begrunnelse ikke varsel",
             "A12345",
-            LocalDateTime.now()
+            LocalDateTime.now(),
+            Avklaringtype.OPPHØR
         );
         var fakta = new BostedsfaktaOgAvklaring(null, avklaring);
         return new LocalDateTimeline<>(List.of(new LocalDateSegment<>(FOM, TOM, fakta)));

--- a/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/steg/bosatt/VurderBostedVilkårStegTest.java
+++ b/ytelse-aktivitetspenger/src/test/java/no/nav/ung/ytelse/aktivitetspenger/del1/steg/bosatt/VurderBostedVilkårStegTest.java
@@ -22,6 +22,7 @@ import no.nav.ung.sak.behandlingslager.behandling.startdato.Startdatoer;
 import no.nav.ung.sak.behandlingslager.behandling.startdato.SøktStartdato;
 import no.nav.ung.sak.behandlingslager.behandling.sporing.BehandingprosessSporingRepository;
 import no.nav.ung.sak.behandlingslager.behandling.vilkår.VilkårResultatRepository;
+import no.nav.ung.sak.behandlingslager.bosatt.Avklaringtype;
 import no.nav.ung.sak.behandlingslager.bosatt.BostedsGrunnlagRepository;
 import no.nav.ung.sak.behandlingslager.bosatt.BostedsPeriodeAvklaring;
 import no.nav.ung.sak.behandlingslager.inngangsvilkår.AktivitetspengerInngangsvilkårResultatGrunnlag;
@@ -304,7 +305,8 @@ class VurderBostedVilkårStegTest {
             skalSendeVarsel && BostedsvilkårIkkeOppfyltÅrsak.ANNET.equals(ikkeOppfyltÅrsak) ? "Fritekst til varselet" : null,
             skalSendeVarsel ? null : "Fritekst for ikke varsling",
             "A12345",
-            LocalDateTime.now()
+            LocalDateTime.now(),
+            Avklaringtype.AVSLAG
         );
     }
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Visning av tidligere bostedsavklaringer og varsling må vite om avklaringen er opphør eller avslått periode. 
Opphør er sendt som en åpen periode, som i aksjonspunktet konverteres til en lukket periode med siste dato i vilkårsperioden som tom. Det er gjort for å gjøre det tydeligere hvilken periode opphøret gjaldt for. 
På grunn av denne konverteringen mister vi det opprinnelige valget, må vi også lagre ned avklaringtypen. 

### Løsning
Tar inn ny kontrakt fra ung-brukerdialog-api. Lagrer ned avklaringtype (opphør eller avslag) for varsling og visning i ettertid.

### Andre endringer
Avhengig av denne for at verdikjeden skal bli grønn: https://github.com/navikt/ung-brukerdialog-api/pull/257

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
